### PR TITLE
Stabilize TYPO3 tests and add CI automation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  functional-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: sqlite3, pdo_sqlite
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run functional test suite
+        run: composer test

--- a/Build/setup-typo3.sh
+++ b/Build/setup-typo3.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script bootstraps a minimal TYPO3 installation for running tests.
+# It uses an SQLite database stored under var/sqlite.db and creates
+# a basic site configuration pointing to http://localhost.
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT_DIR/vendor/bin/typo3"
+DB_PATH="$ROOT_DIR/var/sqlite.db"
+
+$BIN setup \
+  --driver=sqlite \
+  --dbname="$DB_PATH" \
+  --admin-username=admin \
+  --admin-user-password=Admin123! \
+  --admin-email=admin@example.com \
+  --project-name="TYPO3 MCP Server" \
+  --create-site=http://localhost \
+  --server-type=other \
+  --no-interaction \
+  --force
+
+if [ ! -f "$ROOT_DIR/public/index.php" ]; then
+  cat > "$ROOT_DIR/public/index.php" <<'PHP'
+<?php
+call_user_func(static function () {
+    $classLoader = require __DIR__ . '/../vendor/autoload.php';
+    \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::run(1);
+    \TYPO3\CMS\Core\Core\Bootstrap::init($classLoader, true)->get(\TYPO3\CMS\Core\Http\Application::class)->run();
+});
+PHP
+fi

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,15 @@
         }
     },
     "scripts": {
+        "setup": [
+            "bash Build/setup-typo3.sh"
+        ],
+        "post-install-cmd": [
+            "@setup"
+        ],
+        "post-update-cmd": [
+            "@setup"
+        ],
         "test": [
             "@test:functional"
         ],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,11 +15,13 @@
          beStrictAboutOutputDuringTests="false"
          beStrictAboutTestsThatDoNotTestAnything="false"
          beStrictAboutChangesToGlobalState="false"
+         failOnWarning="false"
          executionOrder="default"
 >
     <testsuites>
         <testsuite name="Functional Tests">
             <directory suffix="Test.php">Tests/Functional/</directory>
+            <exclude>Tests/Functional/AbstractFunctionalTest.php</exclude>
         </testsuite>
     </testsuites>
     <php>


### PR DESCRIPTION
## Summary
- skip the abstract functional test base class and allow expected TYPO3 DataHandler warnings without failing the suite
- add a GitHub Actions workflow that installs dependencies and relies on Composer's TYPO3 setup hook before running the functional test suite on push and PRs

## Testing
- `composer validate --no-check-all --strict`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68c7665ddf30832f9e3facb247a1360b