### PR TITLE
Strip trailing slashes from slug fields in WriteTableTool (resolves #6)

### DIFF
--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -1103,15 +1103,14 @@ class WriteTableTool extends AbstractRecordTool
                 continue;
             }
 
-            // Strip trailing slashes from slug fields.
-            // TYPO3's SlugNormalizer intentionally preserves trailing slashes if present in the input,
-            // but trailing slashes in page slugs cause 404 errors in TYPO3's routing.
-            // The TYPO3 backend avoids this through its auto-generation flow (which never produces
-            // trailing slashes), but the MCP tool receives slugs directly from LLM input,
-            // so we must sanitize here.
+            // Normalize slug fields: trim all slashes, then prepend exactly one.
+            // TYPO3's SlugNormalizer preserves trailing slashes if present in the input,
+            // but the frontend routing always strips them. LLMs commonly produce slugs
+            // with trailing slashes or missing leading slashes, so we normalize here.
+            // The root page slug "/" is handled correctly: trim('/', '/') = '' → '/' + '' = '/'.
             $fieldConfig = $this->tableAccessService->getFieldConfig($table, $fieldName);
             if ($fieldConfig && ($fieldConfig['config']['type'] ?? '') === 'slug' && is_string($value)) {
-                $data[$fieldName] = rtrim($value, '/');
+                $data[$fieldName] = '/' . trim($value, '/');
             }
 
             // Handle FlexForm fields


### PR DESCRIPTION
## Summary
This PR fixes an issue where trailing slashes in slug fields were causing 404 errors in TYPO3's routing. The WriteTableTool now automatically strips trailing slashes from slug fields during both create and update operations.

## Key Changes
- **WriteTableTool.php**: Added logic in `convertDataForStorage()` to strip trailing slashes from slug field values before storage
  - Checks if a field is configured as a slug type
  - Uses `rtrim()` to remove trailing slashes from string values
  - Includes detailed comments explaining why this sanitization is necessary
  
- **WriteTableToolTest.php**: Added comprehensive test coverage
  - `testCreatePageStripsTrailingSlash()`: Verifies trailing slashes are removed when creating pages
  - `testUpdatePageStripsTrailingSlash()`: Verifies trailing slashes are removed when updating pages in workspaces

## To be Discussed

I'm still a bit puzzled why this is necessary. TYPO3 explicitly allows a trailing slash in the URL normalization process.
https://github.com/TYPO3/typo3/blob/v13.4.25/typo3/sysext/core/Classes/Slug/SlugNormalizer.php#L71

The route matcher always looks for the closest match for the URL.
https://github.com/TYPO3/typo3/blob/v13.4.25/typo3/sysext/core/Classes/Routing/PageSlugCandidateProvider.php#L73

I can create ans safe urls with a tailing slash in TYPO3 13:
<img width="379" height="318" alt="image" src="https://github.com/user-attachments/assets/d4866bd1-35bf-4183-afe4-35212944c85d" />

And interestingly, that tailing slash is stripped by typolink but still resolves just fine in my test.

It could be an inconsistency in TYPO3 but since the typolink implementation appears to strip the tailing slash, it might be more consistent to just not allow it. Some implementations might not strip it and could cause duplicate url issues.

I got 2 reports of tailing slashes causing an issue, one of which is #6 

I still want to do some testing with it.

I could also imagine reporting this as an issue with the SlugNormalizer in the core but i'm not 100% sure i fully understood it yet.
