### PR TITLE
Add workspace and localhost detection with improved warnings

### DIFF
--- a/Classes/Controller/McpServerModuleController.php
+++ b/Classes/Controller/McpServerModuleController.php
@@ -15,6 +15,7 @@ use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use Hn\McpServer\MCP\ToolRegistry;
 use Hn\McpServer\Service\OAuthService;
+use Hn\McpServer\Service\WorkspaceContextService;
 
 /**
  * Backend module controller for MCP Server configuration
@@ -25,7 +26,8 @@ class McpServerModuleController
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
         private readonly ToolRegistry $toolRegistry,
         private readonly PageRenderer $pageRenderer,
-        private readonly OAuthService $oauthService
+        private readonly OAuthService $oauthService,
+        private readonly WorkspaceContextService $workspaceContextService
     ) {}
 
     public function mainAction(ServerRequestInterface $request): ResponseInterface
@@ -66,6 +68,12 @@ class McpServerModuleController
         $n8nTokenInfo = $this->getClientTokenInfo($tokens, 'n8n token');
         $manusTokenInfo = $this->getClientTokenInfo($tokens, 'manus token');
 
+        // Check if any workspace exists
+        $hasWorkspace = $this->hasAnyWorkspace();
+
+        // Detect if the server is running on localhost
+        $isLocalhost = $this->isLocalhostUrl($baseUrl);
+
         // Prepare template variables
         $templateVariables = [
             'tokens' => $tokens,
@@ -78,6 +86,8 @@ class McpServerModuleController
             'n8nTokenInfo' => $n8nTokenInfo,
             'manusTokenInfo' => $manusTokenInfo,
             'siteName' => $this->getSiteName(),
+            'hasWorkspace' => $hasWorkspace,
+            'isLocalhost' => $isLocalhost,
         ];
         
         // Include JavaScript for copy functionality
@@ -290,6 +300,44 @@ class McpServerModuleController
             'expires' => $token['expires'] ?? null,
             'clientName' => $clientName,
         ];
+    }
+
+    /**
+     * Check if any TYPO3 workspace exists
+     */
+    private function hasAnyWorkspace(): bool
+    {
+        try {
+            $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
+            $queryBuilder = $connectionPool->getQueryBuilderForTable('sys_workspace');
+            $count = $queryBuilder
+                ->count('uid')
+                ->from('sys_workspace')
+                ->where(
+                    $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, \TYPO3\CMS\Core\Database\Connection::PARAM_INT))
+                )
+                ->executeQuery()
+                ->fetchOne();
+            return (int)$count > 0;
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Check if the base URL points to localhost
+     */
+    private function isLocalhostUrl(string $baseUrl): bool
+    {
+        $host = parse_url($baseUrl, PHP_URL_HOST);
+        if ($host === null) {
+            return false;
+        }
+        $host = strtolower($host);
+        return $host === 'localhost'
+            || $host === '127.0.0.1'
+            || $host === '::1'
+            || str_ends_with($host, '.localhost');
     }
 
     /**

--- a/Classes/Controller/McpServerModuleController.php
+++ b/Classes/Controller/McpServerModuleController.php
@@ -325,19 +325,38 @@ class McpServerModuleController
     }
 
     /**
-     * Check if the base URL points to localhost
+     * Check if the base URL resolves to a private/non-routable network address.
+     * Catches localhost, DDEV domains (*.ddev.site), Docker networks, etc.
      */
     private function isLocalhostUrl(string $baseUrl): bool
     {
         $host = parse_url($baseUrl, PHP_URL_HOST);
-        if ($host === null) {
+        if ($host === null || $host === '') {
             return false;
         }
         $host = strtolower($host);
-        return $host === 'localhost'
-            || $host === '127.0.0.1'
-            || $host === '::1'
-            || str_ends_with($host, '.localhost');
+
+        // Quick check for obvious literals
+        if ($host === 'localhost' || $host === '127.0.0.1' || $host === '::1' || str_ends_with($host, '.localhost')) {
+            return true;
+        }
+
+        // Resolve the hostname and check if all IPs are private/reserved
+        $ips = gethostbynamel($host);
+        if ($ips === false || $ips === []) {
+            // Cannot resolve → likely unreachable from outside too
+            return true;
+        }
+
+        foreach ($ips as $ip) {
+            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false) {
+                // At least one public IP → not localhost-only
+                return false;
+            }
+        }
+
+        // All resolved IPs are private/reserved (127.x, 10.x, 172.16-31.x, 192.168.x, etc.)
+        return true;
     }
 
     /**

--- a/Classes/Controller/McpServerModuleController.php
+++ b/Classes/Controller/McpServerModuleController.php
@@ -7,6 +7,7 @@ namespace Hn\McpServer\Controller;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -27,7 +28,8 @@ class McpServerModuleController
         private readonly ToolRegistry $toolRegistry,
         private readonly PageRenderer $pageRenderer,
         private readonly OAuthService $oauthService,
-        private readonly WorkspaceContextService $workspaceContextService
+        private readonly WorkspaceContextService $workspaceContextService,
+        private readonly UriBuilder $uriBuilder
     ) {}
 
     public function mainAction(ServerRequestInterface $request): ResponseInterface
@@ -74,6 +76,12 @@ class McpServerModuleController
         // Detect if the server is running on localhost
         $isLocalhost = $this->isLocalhostUrl($baseUrl);
 
+        // Generate URL to create a new workspace record (pid 0 = root level)
+        $createWorkspaceUrl = (string)$this->uriBuilder->buildUriFromRoute('record_edit', [
+            'edit' => ['sys_workspace' => [0 => 'new']],
+            'returnUrl' => (string)$request->getUri(),
+        ]);
+
         // Prepare template variables
         $templateVariables = [
             'tokens' => $tokens,
@@ -88,6 +96,7 @@ class McpServerModuleController
             'siteName' => $this->getSiteName(),
             'hasWorkspace' => $hasWorkspace,
             'isLocalhost' => $isLocalhost,
+            'createWorkspaceUrl' => $createWorkspaceUrl,
         ];
         
         // Include JavaScript for copy functionality

--- a/Classes/Controller/McpServerModuleController.php
+++ b/Classes/Controller/McpServerModuleController.php
@@ -336,6 +336,8 @@ class McpServerModuleController
     /**
      * Check if the base URL resolves to a private/non-routable network address.
      * Catches localhost, DDEV domains (*.ddev.site), Docker networks, etc.
+     * Checks both IPv4 (A) and IPv6 (AAAA) records to avoid false positives
+     * on IPv6-only hosts.
      */
     private function isLocalhostUrl(string $baseUrl): bool
     {
@@ -350,11 +352,11 @@ class McpServerModuleController
             return true;
         }
 
-        // Resolve the hostname and check if all IPs are private/reserved
-        $ips = gethostbynamel($host);
-        if ($ips === false || $ips === []) {
-            // Cannot resolve → likely unreachable from outside too
-            return true;
+        // Resolve both A and AAAA records
+        $ips = $this->resolveHostIps($host);
+        if ($ips === []) {
+            // Cannot resolve at all — don't assume private, could be a DNS issue
+            return false;
         }
 
         foreach ($ips as $ip) {
@@ -364,8 +366,36 @@ class McpServerModuleController
             }
         }
 
-        // All resolved IPs are private/reserved (127.x, 10.x, 172.16-31.x, 192.168.x, etc.)
+        // All resolved IPs are private/reserved
         return true;
+    }
+
+    /**
+     * Resolve a hostname to all its IPv4 and IPv6 addresses.
+     *
+     * @return string[]
+     */
+    private function resolveHostIps(string $host): array
+    {
+        $ips = [];
+
+        // IPv4 A records
+        $ipv4 = gethostbynamel($host);
+        if ($ipv4 !== false) {
+            $ips = $ipv4;
+        }
+
+        // IPv6 AAAA records
+        $records = @dns_get_record($host, DNS_AAAA);
+        if ($records !== false) {
+            foreach ($records as $record) {
+                if (isset($record['ipv6'])) {
+                    $ips[] = $record['ipv6'];
+                }
+            }
+        }
+
+        return $ips;
     }
 
     /**

--- a/Resources/Private/Templates/McpServerModule.html
+++ b/Resources/Private/Templates/McpServerModule.html
@@ -14,6 +14,18 @@
                     </p>
                 </div>
                 <div class="card-body pb-0">
+                    <!-- Workspace Hint -->
+                    <f:if condition="!{hasWorkspace}">
+                        <div class="alert alert-info mb-3">
+                            <h6><strong>Workspace recommended</strong></h6>
+                            <p class="mb-0">
+                                The MCP server uses TYPO3 Workspaces to stage all changes before publishing. A workspace will be created automatically on first use, but it is recommended to
+                                <a href="/typo3/module/web/WorkspacesWorkspaces" target="_blank">create one manually</a>
+                                so you can configure permissions and review workflow to your needs.
+                            </p>
+                        </div>
+                    </f:if>
+
                     <!-- Main Navigation Tabs -->
                     <ul class="nav nav-tabs" id="mcpSetupTabs" role="tablist">
                         <li class="nav-item" role="presentation">
@@ -41,6 +53,19 @@
                             <p class="text-muted mb-3">
                                 Connect MCP clients to this TYPO3 instance over the internet using OAuth authentication. This is the recommended method for most use cases.
                             </p>
+
+                            <!-- Localhost Warning -->
+                            <f:if condition="{isLocalhost}">
+                                <div class="alert alert-warning mb-3">
+                                    <h6><strong>Localhost detected</strong></h6>
+                                    <p class="mb-2">
+                                        This TYPO3 instance is running on <code>{baseUrl}</code>. Most remote MCP clients (Claude Desktop, n8n, manus) will not be able to connect because they cannot reach localhost on your machine.
+                                    </p>
+                                    <p class="mb-0">
+                                        <strong>What works on localhost:</strong> The <strong>MCP Inspector</strong> (runs locally in your browser) and the <strong>Local Setup (TYPO3 CLI)</strong> tab. The <strong>Local Setup (mcp-remote)</strong> may also work since mcp-remote runs on your machine.
+                                    </p>
+                                </div>
+                            </f:if>
 
                             <!-- Shared MCP Endpoint URL -->
                             <div class="mb-3">
@@ -134,6 +159,11 @@ RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]</code></pre>
                                 <!-- Claude Desktop Instructions -->
                                 <div class="tab-pane fade show active" id="claude-desktop" role="tabpanel" aria-labelledby="claude-desktop-pill">
                                     <h5>🚀 Claude Desktop Integration</h5>
+                                    <f:if condition="{isLocalhost}">
+                                        <div class="alert alert-danger mb-3">
+                                            <strong>Not available on localhost.</strong> Claude Desktop connects from Anthropic's servers and cannot reach <code>{baseUrl}</code>. Deploy TYPO3 to a publicly accessible URL or use the <strong>Local Setup (TYPO3 CLI)</strong> tab instead.
+                                        </div>
+                                    </f:if>
                                     <p>To connect Claude Desktop to this TYPO3 instance:</p>
                                     <ol>
                                         <li>In Claude Desktop, go to <strong>Settings → Integrations</strong></li>
@@ -147,6 +177,11 @@ RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]</code></pre>
                                 <!-- n8n Integration -->
                                 <div class="tab-pane fade" id="n8n" role="tabpanel" aria-labelledby="n8n-pill">
                                     <h5>🔄 n8n Integration</h5>
+                                    <f:if condition="{isLocalhost}">
+                                        <div class="alert alert-warning mb-3">
+                                            <strong>Localhost limitation.</strong> If your n8n instance runs on a remote server (e.g. n8n cloud), it will not be able to reach <code>{baseUrl}</code>. This only works if n8n runs on the same machine.
+                                        </div>
+                                    </f:if>
 
                                     <f:if condition="{n8nTokenInfo.hasToken}">
                                         <f:then>
@@ -197,6 +232,11 @@ RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]</code></pre>
                                 <!-- manus Integration -->
                                 <div class="tab-pane fade" id="manus" role="tabpanel" aria-labelledby="manus-pill">
                                     <h5>🤖 manus Integration</h5>
+                                    <f:if condition="{isLocalhost}">
+                                        <div class="alert alert-danger mb-3">
+                                            <strong>Not available on localhost.</strong> Manus connects from remote servers and cannot reach <code>{baseUrl}</code>. Deploy TYPO3 to a publicly accessible URL first.
+                                        </div>
+                                    </f:if>
 
                                     <f:if condition="{manusTokenInfo.hasToken}">
                                         <f:then>

--- a/Resources/Private/Templates/McpServerModule.html
+++ b/Resources/Private/Templates/McpServerModule.html
@@ -14,14 +14,25 @@
                     </p>
                 </div>
                 <div class="card-body pb-0">
-                    <!-- Workspace Hint -->
+                    <!-- Warnings -->
                     <f:if condition="!{hasWorkspace}">
-                        <div class="alert alert-info mb-3">
-                            <h6><strong>Workspace recommended</strong></h6>
+                        <div class="alert alert-warning mb-3">
+                            <h6><strong>No workspace configured</strong></h6>
                             <p class="mb-0">
-                                The MCP server uses TYPO3 Workspaces to stage all changes before publishing. A workspace will be created automatically on first use, but it is recommended to
+                                All changes made through MCP are staged in a TYPO3 Workspace before publishing. One will be created automatically, but you should
                                 <a href="/typo3/module/web/WorkspacesWorkspaces" target="_blank">create one manually</a>
-                                so you can configure permissions and review workflow to your needs.
+                                to control permissions and review workflow.
+                            </p>
+                        </div>
+                    </f:if>
+                    <f:if condition="{isLocalhost}">
+                        <div class="alert alert-warning mb-3">
+                            <h6><strong>Local/private network detected</strong></h6>
+                            <p class="mb-2">
+                                <code>{baseUrl}</code> resolves to a private network address. Most remote MCP clients (Claude Desktop, n8n cloud, manus) cannot reach this server from the internet.
+                            </p>
+                            <p class="mb-0">
+                                <strong>What works locally:</strong> The <strong>MCP Inspector</strong> (runs on your machine) and the <strong>Local Setup (TYPO3 CLI)</strong> tab. The <strong>Local Setup (mcp-remote)</strong> may also work since mcp-remote runs on your machine.
                             </p>
                         </div>
                     </f:if>
@@ -53,19 +64,6 @@
                             <p class="text-muted mb-3">
                                 Connect MCP clients to this TYPO3 instance over the internet using OAuth authentication. This is the recommended method for most use cases.
                             </p>
-
-                            <!-- Private Network Warning -->
-                            <f:if condition="{isLocalhost}">
-                                <div class="alert alert-warning mb-3">
-                                    <h6><strong>Local/private network detected</strong></h6>
-                                    <p class="mb-2">
-                                        <code>{baseUrl}</code> resolves to a private network address. Most remote MCP clients (Claude Desktop, n8n cloud, manus) will not be able to connect because they cannot reach this server from the internet.
-                                    </p>
-                                    <p class="mb-0">
-                                        <strong>What works locally:</strong> The <strong>MCP Inspector</strong> (runs on your machine) and the <strong>Local Setup (TYPO3 CLI)</strong> tab. The <strong>Local Setup (mcp-remote)</strong> may also work since mcp-remote runs on your machine.
-                                    </p>
-                                </div>
-                            </f:if>
 
                             <!-- Shared MCP Endpoint URL -->
                             <div class="mb-3">
@@ -159,11 +157,6 @@ RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]</code></pre>
                                 <!-- Claude Desktop Instructions -->
                                 <div class="tab-pane fade show active" id="claude-desktop" role="tabpanel" aria-labelledby="claude-desktop-pill">
                                     <h5>🚀 Claude Desktop Integration</h5>
-                                    <f:if condition="{isLocalhost}">
-                                        <div class="alert alert-danger mb-3">
-                                            <strong>Not reachable from the internet.</strong> Claude Desktop connects from Anthropic's servers and cannot reach <code>{baseUrl}</code>. Deploy TYPO3 to a publicly accessible URL or use the <strong>Local Setup (TYPO3 CLI)</strong> tab instead.
-                                        </div>
-                                    </f:if>
                                     <p>To connect Claude Desktop to this TYPO3 instance:</p>
                                     <ol>
                                         <li>In Claude Desktop, go to <strong>Settings → Integrations</strong></li>
@@ -177,11 +170,6 @@ RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]</code></pre>
                                 <!-- n8n Integration -->
                                 <div class="tab-pane fade" id="n8n" role="tabpanel" aria-labelledby="n8n-pill">
                                     <h5>🔄 n8n Integration</h5>
-                                    <f:if condition="{isLocalhost}">
-                                        <div class="alert alert-warning mb-3">
-                                            <strong>Private network limitation.</strong> If your n8n instance runs on a remote server (e.g. n8n cloud), it will not be able to reach <code>{baseUrl}</code>. This only works if n8n runs on the same machine or network.
-                                        </div>
-                                    </f:if>
 
                                     <f:if condition="{n8nTokenInfo.hasToken}">
                                         <f:then>
@@ -232,11 +220,6 @@ RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]</code></pre>
                                 <!-- manus Integration -->
                                 <div class="tab-pane fade" id="manus" role="tabpanel" aria-labelledby="manus-pill">
                                     <h5>🤖 manus Integration</h5>
-                                    <f:if condition="{isLocalhost}">
-                                        <div class="alert alert-danger mb-3">
-                                            <strong>Not reachable from the internet.</strong> Manus connects from remote servers and cannot reach <code>{baseUrl}</code>. Deploy TYPO3 to a publicly accessible URL first.
-                                        </div>
-                                    </f:if>
 
                                     <f:if condition="{manusTokenInfo.hasToken}">
                                         <f:then>

--- a/Resources/Private/Templates/McpServerModule.html
+++ b/Resources/Private/Templates/McpServerModule.html
@@ -54,15 +54,15 @@
                                 Connect MCP clients to this TYPO3 instance over the internet using OAuth authentication. This is the recommended method for most use cases.
                             </p>
 
-                            <!-- Localhost Warning -->
+                            <!-- Private Network Warning -->
                             <f:if condition="{isLocalhost}">
                                 <div class="alert alert-warning mb-3">
-                                    <h6><strong>Localhost detected</strong></h6>
+                                    <h6><strong>Local/private network detected</strong></h6>
                                     <p class="mb-2">
-                                        This TYPO3 instance is running on <code>{baseUrl}</code>. Most remote MCP clients (Claude Desktop, n8n, manus) will not be able to connect because they cannot reach localhost on your machine.
+                                        <code>{baseUrl}</code> resolves to a private network address. Most remote MCP clients (Claude Desktop, n8n cloud, manus) will not be able to connect because they cannot reach this server from the internet.
                                     </p>
                                     <p class="mb-0">
-                                        <strong>What works on localhost:</strong> The <strong>MCP Inspector</strong> (runs locally in your browser) and the <strong>Local Setup (TYPO3 CLI)</strong> tab. The <strong>Local Setup (mcp-remote)</strong> may also work since mcp-remote runs on your machine.
+                                        <strong>What works locally:</strong> The <strong>MCP Inspector</strong> (runs on your machine) and the <strong>Local Setup (TYPO3 CLI)</strong> tab. The <strong>Local Setup (mcp-remote)</strong> may also work since mcp-remote runs on your machine.
                                     </p>
                                 </div>
                             </f:if>
@@ -161,7 +161,7 @@ RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]</code></pre>
                                     <h5>🚀 Claude Desktop Integration</h5>
                                     <f:if condition="{isLocalhost}">
                                         <div class="alert alert-danger mb-3">
-                                            <strong>Not available on localhost.</strong> Claude Desktop connects from Anthropic's servers and cannot reach <code>{baseUrl}</code>. Deploy TYPO3 to a publicly accessible URL or use the <strong>Local Setup (TYPO3 CLI)</strong> tab instead.
+                                            <strong>Not reachable from the internet.</strong> Claude Desktop connects from Anthropic's servers and cannot reach <code>{baseUrl}</code>. Deploy TYPO3 to a publicly accessible URL or use the <strong>Local Setup (TYPO3 CLI)</strong> tab instead.
                                         </div>
                                     </f:if>
                                     <p>To connect Claude Desktop to this TYPO3 instance:</p>
@@ -179,7 +179,7 @@ RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]</code></pre>
                                     <h5>🔄 n8n Integration</h5>
                                     <f:if condition="{isLocalhost}">
                                         <div class="alert alert-warning mb-3">
-                                            <strong>Localhost limitation.</strong> If your n8n instance runs on a remote server (e.g. n8n cloud), it will not be able to reach <code>{baseUrl}</code>. This only works if n8n runs on the same machine.
+                                            <strong>Private network limitation.</strong> If your n8n instance runs on a remote server (e.g. n8n cloud), it will not be able to reach <code>{baseUrl}</code>. This only works if n8n runs on the same machine or network.
                                         </div>
                                     </f:if>
 
@@ -234,7 +234,7 @@ RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]</code></pre>
                                     <h5>🤖 manus Integration</h5>
                                     <f:if condition="{isLocalhost}">
                                         <div class="alert alert-danger mb-3">
-                                            <strong>Not available on localhost.</strong> Manus connects from remote servers and cannot reach <code>{baseUrl}</code>. Deploy TYPO3 to a publicly accessible URL first.
+                                            <strong>Not reachable from the internet.</strong> Manus connects from remote servers and cannot reach <code>{baseUrl}</code>. Deploy TYPO3 to a publicly accessible URL first.
                                         </div>
                                     </f:if>
 

--- a/Resources/Private/Templates/McpServerModule.html
+++ b/Resources/Private/Templates/McpServerModule.html
@@ -36,6 +36,22 @@
                             </p>
                         </div>
                     </f:if>
+                    <!-- Authorization Header Warning (shown/hidden by JS after endpoint check) -->
+                    <div class="alert alert-warning mb-3" id="auth-header-warning" style="display: none;">
+                        <h6><strong>Authorization header issue detected</strong></h6>
+                        <p class="mb-2">The MCP endpoint cannot receive Authorization headers. This prevents OAuth authentication from working.</p>
+                        <p class="mb-2"><strong>Common causes and solutions:</strong></p>
+                        <ul class="mb-0">
+                            <li>
+                                <strong>Apache:</strong> Add to your <code>.htaccess</code>:
+                                <pre class="mb-1 mt-1" style="background: #f5f5f5; padding: 8px; border-radius: 4px;"><code>RewriteEngine On
+RewriteCond %{HTTP:Authorization} ^(.*)
+RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]</code></pre>
+                            </li>
+                            <li><strong>HTTP Basic Auth:</strong> May conflict with OAuth headers. Consider IP-based restrictions instead.</li>
+                            <li><strong>Proxy/CDN:</strong> Some proxies strip Authorization headers. Check your infrastructure settings.</li>
+                        </ul>
+                    </div>
 
                     <!-- Main Navigation Tabs -->
                     <ul class="nav nav-tabs" id="mcpSetupTabs" role="tablist">
@@ -100,27 +116,6 @@
                                         </span>
                                     </small>
                                 </div>
-                            </div>
-
-                            <!-- Authorization Header Warning -->
-                            <div class="alert alert-warning mt-3 mb-3" id="auth-header-warning" style="display: none;">
-                                <h6><strong>⚠️ Authorization Header Issue Detected</strong></h6>
-                                <p class="mb-2">The MCP endpoint cannot receive Authorization headers. This is a common issue that prevents OAuth authentication from working properly.</p>
-                                <p class="mb-2"><strong>Common causes and solutions:</strong></p>
-                                <ul class="mb-0">
-                                    <li>
-                                        <strong>Apache configuration:</strong> Add this to your <code>.htaccess</code> file:
-                                        <pre class="mb-1 mt-1" style="background: #f5f5f5; padding: 8px; border-radius: 4px;"><code>RewriteEngine On
-RewriteCond %{HTTP:Authorization} ^(.*)
-RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]</code></pre>
-                                    </li>
-                                    <li>
-                                        <strong>Site-level authentication:</strong> If your site uses HTTP Basic Auth, it may conflict with OAuth headers. Consider using IP-based restrictions instead.
-                                    </li>
-                                    <li>
-                                        <strong>Proxy/CDN configuration:</strong> Some proxies or CDNs strip Authorization headers. Check your infrastructure settings.
-                                    </li>
-                                </ul>
                             </div>
 
                             <!-- Nested tabs for different clients -->

--- a/Resources/Private/Templates/McpServerModule.html
+++ b/Resources/Private/Templates/McpServerModule.html
@@ -20,7 +20,7 @@
                             <h6><strong>No workspace configured</strong></h6>
                             <p class="mb-0">
                                 All changes made through MCP are staged in a TYPO3 Workspace before publishing. One will be created automatically, but you should
-                                <a href="/typo3/module/web/WorkspacesWorkspaces" target="_blank">create one manually</a>
+                                <a href="{createWorkspaceUrl}">create one manually</a>
                                 to control permissions and review workflow.
                             </p>
                         </div>


### PR DESCRIPTION
## Summary
This PR enhances the MCP Server module controller with detection capabilities for TYPO3 workspaces and localhost environments, providing users with more contextual warnings about their setup configuration.

<img width="839" height="1084" alt="image" src="https://github.com/user-attachments/assets/50a0ae34-6310-4b12-a48b-b568c1f560e3" />
