### PR TITLE
Optimize page tree fetching with batch queries and subpage limits

### DIFF
--- a/Classes/MCP/Tool/GetPageTreeTool.php
+++ b/Classes/MCP/Tool/GetPageTreeTool.php
@@ -23,6 +23,8 @@ use Hn\McpServer\MCP\Tool\Record\AbstractRecordTool;
  */
 class GetPageTreeTool extends AbstractRecordTool
 {
+    private const SUBPAGE_LIMIT = 10;
+
     protected SiteInformationService $siteInformationService;
     protected LanguageService $languageService;
 
@@ -82,7 +84,7 @@ class GetPageTreeTool extends AbstractRecordTool
      */
     protected function doExecute(array $params): CallToolResult
     {
-        
+
         $startPage = (int)($params['startPage'] ?? 0);
         $depth = (int)($params['depth'] ?? 3);
         $languageUid = null;
@@ -97,13 +99,13 @@ class GetPageTreeTool extends AbstractRecordTool
 
         // Get page tree with the specified parameters
         $pageTree = $this->getPageTree($startPage, $depth, $languageUid);
-        
+
         // Collect all page UIDs from the tree
         $pageUids = $this->collectPageUids($pageTree);
-        
+
         // Get record counts for all pages
         $recordCounts = $this->getRecordCounts($pageUids);
-        
+
         // Get plugin hints for all pages
         $pluginHints = [];
         foreach ($pageUids as $uid) {
@@ -112,56 +114,251 @@ class GetPageTreeTool extends AbstractRecordTool
                 $pluginHints[$uid] = $hint;
             }
         }
-        
+
         // Convert the page tree to a text-based tree with indentation
         $textTree = $this->renderTextTree($pageTree, 0, $languageUid, $recordCounts, $pluginHints);
-        
+
         return new CallToolResult([new TextContent($textTree)]);
     }
 
     /**
-     * Get the page tree
+     * Get the page tree using batch queries per layer.
+     *
+     * Fetches one layer at a time with a single query per layer instead of
+     * one query per parent page. The first layer (direct children of startPage)
+     * is always fetched completely. Subsequent layers are limited to SUBPAGE_LIMIT
+     * children per parent to prevent large folders from overwhelming the output.
      */
     protected function getPageTree(int $startPage, int $depth, ?int $languageUid = null): array
     {
-        // Get database connection for pages table
+        $pageRepository = $this->createPageRepository($languageUid);
+
+        // Collect layer data top-down, one batch query per layer
+        $layerData = [];
+        $currentParentUids = [$startPage];
+
+        for ($d = 0; $d < $depth; $d++) {
+            if (empty($currentParentUids)) {
+                break;
+            }
+
+            // First layer (d=0) is unlimited, subsequent layers are limited per parent
+            $limit = ($d === 0) ? null : self::SUBPAGE_LIMIT;
+            $layerData[$d] = $this->fetchChildrenBatch($currentParentUids, $languageUid, $pageRepository, $limit);
+
+            // Collect UIDs of fetched pages for the next layer
+            $currentParentUids = [];
+            foreach ($layerData[$d] as $info) {
+                foreach ($info['pages'] as $page) {
+                    $currentParentUids[] = $page['uid'];
+                }
+            }
+        }
+
+        // Batch count subpages for leaf nodes (pages at the deepest fetched level)
+        $subpageCounts = !empty($currentParentUids)
+            ? $this->batchCountSubpages($currentParentUids)
+            : [];
+
+        // Assemble the nested tree from collected layer data
+        return $this->buildTreeFromLayers($layerData, $subpageCounts, $startPage, $depth);
+    }
+
+    /**
+     * Fetch children for multiple parent UIDs in a single query.
+     *
+     * @param array $parentUids Parent page UIDs to fetch children for
+     * @param int|null $languageUid Language UID for overlays
+     * @param PageRepository $pageRepository PageRepository with language context
+     * @param int|null $perParentLimit Max children per parent (null = unlimited)
+     * @return array Keyed by parent UID: [parentUid => ['pages' => [...], 'total' => int]]
+     */
+    protected function fetchChildrenBatch(
+        array $parentUids,
+        ?int $languageUid,
+        PageRepository $pageRepository,
+        ?int $perParentLimit = null
+    ): array {
+        if (empty($parentUids)) {
+            return [];
+        }
+
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable('pages');
 
-        // Only apply the DeletedRestriction to filter out deleted pages
         $queryBuilder->getRestrictions()
             ->removeAll()
             ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
 
-        // Build the query
         $query = $queryBuilder->select('*')
-            ->from('pages');
+            ->from('pages')
+            ->where(
+                $queryBuilder->expr()->in(
+                    'pid',
+                    $queryBuilder->createNamedParameter($parentUids, ArrayParameterType::INTEGER)
+                ),
+                $queryBuilder->expr()->eq(
+                    'sys_language_uid',
+                    $queryBuilder->createNamedParameter(0, ParameterType::INTEGER)
+                )
+            )
+            ->orderBy('pid')
+            ->addOrderBy('sorting');
 
-        // Filter by pid (parent ID) for the starting page
-        if ($startPage === 0) {
-            // Root level pages have pid=0
-            $query->where(
-                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter(0, ParameterType::INTEGER)),
-                $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(0, ParameterType::INTEGER))
-            );
-        } else {
-            // Get subpages of the specified page
-            $query->where(
-                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($startPage, ParameterType::INTEGER)),
-                $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(0, ParameterType::INTEGER))
-            );
+        $allPages = $query->executeQuery()->fetchAllAssociative();
+
+        // Initialize result structure for all requested parents
+        $grouped = [];
+        foreach ($parentUids as $uid) {
+            $grouped[$uid] = ['pages' => [], 'total' => 0];
         }
 
-        // Order by sorting
-        $query->orderBy('sorting');
+        // Group pages by parent and apply per-parent limit
+        foreach ($allPages as $page) {
+            $pid = (int)$page['pid'];
+            if (!isset($grouped[$pid])) {
+                $grouped[$pid] = ['pages' => [], 'total' => 0];
+            }
 
-        // Execute the query
-        $pages = $query->executeQuery()->fetchAllAssociative();
+            $grouped[$pid]['total']++;
 
-        // Set up context for language and visibility
+            // Skip pages beyond the per-parent limit (but keep counting total)
+            if ($perParentLimit !== null && count($grouped[$pid]['pages']) >= $perParentLimit) {
+                continue;
+            }
+
+            $pageData = [
+                'uid' => (int)$page['uid'],
+                'pid' => $pid,
+                'title' => $page['title'],
+                'nav_title' => $page['nav_title'],
+                'hidden' => (bool)$page['hidden'],
+                'doktype' => (int)$page['doktype'],
+                'subpageCount' => 0,
+                'url' => $this->siteInformationService->generatePageUrl((int)$page['uid']),
+            ];
+
+            // Apply language overlay
+            if ($languageUid !== null && $languageUid > 0) {
+                $overlaidPage = $pageRepository->getPageOverlay($page, $languageUid);
+
+                if ($overlaidPage !== $page) {
+                    $pageData['title'] = $overlaidPage['title'] ?: $pageData['title'];
+                    $pageData['nav_title'] = $overlaidPage['nav_title'] ?: $pageData['nav_title'];
+                    $pageData['hidden'] = (bool)$overlaidPage['hidden'];
+                    $pageData['_translated'] = true;
+                } else {
+                    $pageData['_translated'] = false;
+                }
+            }
+
+            $grouped[$pid]['pages'][] = $pageData;
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * Count subpages for multiple parent UIDs in a single query.
+     *
+     * @param array $parentUids Parent page UIDs to count children for
+     * @return array Keyed by parent UID: [parentUid => count]
+     */
+    protected function batchCountSubpages(array $parentUids): array
+    {
+        if (empty($parentUids)) {
+            return [];
+        }
+
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('pages');
+
+        $queryBuilder->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+
+        $counts = $queryBuilder
+            ->select('pid')
+            ->addSelectLiteral('COUNT(*) AS count')
+            ->from('pages')
+            ->where(
+                $queryBuilder->expr()->in(
+                    'pid',
+                    $queryBuilder->createNamedParameter($parentUids, ArrayParameterType::INTEGER)
+                ),
+                $queryBuilder->expr()->eq(
+                    'sys_language_uid',
+                    $queryBuilder->createNamedParameter(0, ParameterType::INTEGER)
+                )
+            )
+            ->groupBy('pid')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $result = [];
+        foreach ($counts as $row) {
+            $result[(int)$row['pid']] = (int)$row['count'];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Build the nested tree structure from pre-fetched layer data.
+     *
+     * @param array $layerData Layer data indexed by depth, then by parent UID
+     * @param array $subpageCounts Subpage counts for leaf nodes
+     * @param int $parentUid The parent UID to build children for
+     * @param int $maxDepth Total depth requested
+     * @param int $currentLayer Current layer index (0-based)
+     * @return array Nested tree structure
+     */
+    protected function buildTreeFromLayers(
+        array $layerData,
+        array $subpageCounts,
+        int $parentUid,
+        int $maxDepth,
+        int $currentLayer = 0
+    ): array {
+        if (!isset($layerData[$currentLayer][$parentUid])) {
+            return [];
+        }
+
+        $layerInfo = $layerData[$currentLayer][$parentUid];
+        $result = [];
+
+        foreach ($layerInfo['pages'] as $page) {
+            if ($currentLayer + 1 < $maxDepth) {
+                // Not at max depth: attach children recursively
+                $page['subpages'] = $this->buildTreeFromLayers(
+                    $layerData,
+                    $subpageCounts,
+                    $page['uid'],
+                    $maxDepth,
+                    $currentLayer + 1
+                );
+                // Use total from the next layer's data for this parent
+                $page['subpageCount'] = isset($layerData[$currentLayer + 1][$page['uid']])
+                    ? $layerData[$currentLayer + 1][$page['uid']]['total']
+                    : 0;
+            } else {
+                // At max depth: use batch-counted subpage counts
+                $page['subpageCount'] = $subpageCounts[$page['uid']] ?? 0;
+            }
+
+            $result[] = $page;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Create a PageRepository with the appropriate language context.
+     */
+    protected function createPageRepository(?int $languageUid): PageRepository
+    {
         $context = GeneralUtility::makeInstance(Context::class);
 
-        // Set up language aspect if needed
         if ($languageUid !== null && $languageUid > 0) {
             $languageAspect = new LanguageAspect(
                 $languageUid,
@@ -172,76 +369,8 @@ class GetPageTreeTool extends AbstractRecordTool
             $context->setAspect('language', $languageAspect);
         }
 
-        // Create PageRepository with context
-        $pageRepository = GeneralUtility::makeInstance(PageRepository::class, $context);
-
-        // Process the result
-        $pageTree = [];
-        foreach ($pages as $page) {
-            $pageData = [
-                'uid' => (int)$page['uid'],
-                'pid' => (int)$page['pid'],
-                'title' => $page['title'],
-                'nav_title' => $page['nav_title'],
-                'hidden' => (bool)$page['hidden'],
-                'doktype' => (int)$page['doktype'],
-                'subpageCount' => 0,
-                'url' => $this->siteInformationService->generatePageUrl((int)$page['uid']),
-            ];
-
-            // Get language overlay if language specified
-            if ($languageUid !== null && $languageUid > 0) {
-                $overlaidPage = $pageRepository->getPageOverlay($page, $languageUid);
-
-                if ($overlaidPage !== $page) {
-                    // Apply overlay data
-                    $pageData['title'] = $overlaidPage['title'] ?: $pageData['title'];
-                    $pageData['nav_title'] = $overlaidPage['nav_title'] ?: $pageData['nav_title'];
-                    $pageData['hidden'] = (bool)$overlaidPage['hidden'];
-                    $pageData['_translated'] = true;
-                } else {
-                    $pageData['_translated'] = false;
-                }
-            }
-
-            // Check if there are subpages if depth > 1
-            if ($depth > 1) {
-                $subpages = $this->getPageTree((int)$page['uid'], $depth - 1, $languageUid);
-                $pageData['subpages'] = $subpages;
-                $pageData['subpageCount'] = count($subpages);
-            } else {
-                // We're at max depth, count the number of subpages
-                $pageData['subpageCount'] = $this->countSubpages((int)$page['uid']);
-            }
-
-            $pageTree[] = $pageData;
-        }
-
-        return $pageTree;
+        return GeneralUtility::makeInstance(PageRepository::class, $context);
     }
-    
-    /**
-     * Count the number of subpages for a page
-     */
-    protected function countSubpages(int $pageId): int
-    {
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('pages');
-
-        $queryBuilder->getRestrictions()
-            ->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-
-        $query = $queryBuilder->count('uid')
-            ->from('pages')
-            ->where(
-                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pageId, ParameterType::INTEGER)),
-                $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(0, ParameterType::INTEGER))
-            );
-
-        return (int)$query->executeQuery()->fetchOne();
-    }
-    
 
     /**
      * Collect all page UIDs from the tree structure
@@ -249,18 +378,18 @@ class GetPageTreeTool extends AbstractRecordTool
     protected function collectPageUids(array $pageTree): array
     {
         $uids = [];
-        
+
         foreach ($pageTree as $page) {
             $uids[] = $page['uid'];
-            
+
             if (!empty($page['subpages'])) {
                 $uids = array_merge($uids, $this->collectPageUids($page['subpages']));
             }
         }
-        
+
         return $uids;
     }
-    
+
     /**
      * Get record counts for given page UIDs
      */
@@ -269,26 +398,26 @@ class GetPageTreeTool extends AbstractRecordTool
         if (empty($pageUids)) {
             return [];
         }
-        
+
         $recordCounts = [];
-        
+
         // Get accessible tables (exclude read-only system tables)
         $accessibleTables = $this->tableAccessService->getAccessibleTables(false);
-        
+
         foreach ($accessibleTables as $table => $accessInfo) {
             // Skip pages table itself
             if ($table === 'pages') {
                 continue;
             }
-            
+
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
                 ->getQueryBuilderForTable($table);
-            
+
             // Only apply DeletedRestriction
             $queryBuilder->getRestrictions()
                 ->removeAll()
                 ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-            
+
             // Count records grouped by pid
             $counts = $queryBuilder
                 ->select('pid')
@@ -296,9 +425,9 @@ class GetPageTreeTool extends AbstractRecordTool
                 ->from($table)
                 ->where(
                     $queryBuilder->expr()->in(
-                        'pid', 
+                        'pid',
                         $queryBuilder->createNamedParameter(
-                            $pageUids, 
+                            $pageUids,
                             ArrayParameterType::INTEGER
                         )
                     )
@@ -306,20 +435,20 @@ class GetPageTreeTool extends AbstractRecordTool
                 ->groupBy('pid')
                 ->executeQuery()
                 ->fetchAllAssociative();
-            
+
             // Store counts
             foreach ($counts as $row) {
                 $pid = (int)$row['pid'];
                 $count = (int)$row['count'];
-                
+
                 if (!isset($recordCounts[$pid])) {
                     $recordCounts[$pid] = [];
                 }
-                
+
                 $recordCounts[$pid][$table] = $count;
             }
         }
-        
+
         return $recordCounts;
     }
 
@@ -329,15 +458,15 @@ class GetPageTreeTool extends AbstractRecordTool
     protected function getPluginStorageHints(int $pageId): string
     {
         $hints = '';
-        
+
         // Query for plugins on this page
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable('tt_content');
-        
+
         $queryBuilder->getRestrictions()
             ->removeAll()
             ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-        
+
         $plugins = $queryBuilder
             ->select('*')
             ->from('tt_content')
@@ -347,7 +476,7 @@ class GetPageTreeTool extends AbstractRecordTool
             )
             ->executeQuery()
             ->fetchAllAssociative();
-        
+
         foreach ($plugins as $plugin) {
             // Check for news plugin with startingpoint configuration
             if (isset($plugin['list_type']) && $plugin['list_type'] === 'news_pi1' && !empty($plugin['pi_flexform'])) {
@@ -358,10 +487,7 @@ class GetPageTreeTool extends AbstractRecordTool
                 }
             }
         }
-        
-        // Debug: Remove debug for now
-        // The issue seems to be with the condition or regex
-        
+
         return $hints;
     }
 
@@ -389,15 +515,15 @@ class GetPageTreeTool extends AbstractRecordTool
     {
         $result = '';
         $indent = str_repeat('  ', $level);
-        
+
         foreach ($pageTree as $page) {
             $title = $page['nav_title'] ?: $page['title'];
             $hiddenMark = $page['hidden'] ? ' [HIDDEN]' : '';
             $doktypeLabel = $this->getDoktypeLabel($page['doktype']);
-            
+
             // Start building the line: [uid] Title [Type]
             $result .= $indent . '- [' . $page['uid'] . '] ' . $title . ' [' . $doktypeLabel . ']' . $hiddenMark;
-            
+
             // Add translation status if language specified
             if ($languageUid !== null && $languageUid > 0) {
                 if (isset($page['_translated'])) {
@@ -416,24 +542,32 @@ class GetPageTreeTool extends AbstractRecordTool
             if (!empty($page['url'])) {
                 $result .= ' - ' . $page['url'];
             }
-            
-            // If the page has subpages but we've reached max depth, show the count
+
+            // If the page has no expanded subpages but has children, show the count
             if (empty($page['subpages']) && $page['subpageCount'] > 0) {
                 $result .= ' (' . $page['subpageCount'] . ' subpages)';
             }
-            
+
             // Add plugin hints if available
             if (!empty($pluginHints[$page['uid']])) {
                 $result .= $pluginHints[$page['uid']];
             }
-            
+
             $result .= PHP_EOL;
-            
+
             if (!empty($page['subpages'])) {
                 $result .= $this->renderTextTree($page['subpages'], $level + 1, $languageUid, $recordCounts, $pluginHints);
+
+                // Show truncation notice if not all children were fetched
+                $shownCount = count($page['subpages']);
+                $totalCount = $page['subpageCount'];
+                if ($totalCount > $shownCount) {
+                    $childIndent = str_repeat('  ', $level + 1);
+                    $result .= $childIndent . '- (showing ' . $shownCount . ' of ' . $totalCount . ' subpages, use GetPageTree with startPage: ' . $page['uid'] . ' to see all)' . PHP_EOL;
+                }
             }
         }
-        
+
         return $result;
     }
 


### PR DESCRIPTION
## Summary
Refactored the `GetPageTreeTool` to use batch queries for fetching page hierarchies instead of recursive per-page queries. This significantly improves performance for large page trees while introducing intelligent truncation of deeply nested children to prevent overwhelming output.

## Key Changes

- **Batch Query Architecture**: Replaced recursive `getPageTree()` calls with a layer-by-layer batch fetching approach that executes one query per depth level instead of one per parent page
- **Subpage Limiting**: Introduced `SUBPAGE_LIMIT` constant (10) to cap children per parent at depths > 1, while keeping the first layer unlimited to ensure all top-level pages are always visible
- **New Helper Methods**:
  - `fetchChildrenBatch()`: Fetches children for multiple parent UIDs in a single query with optional per-parent limits
  - `batchCountSubpages()`: Counts subpages for multiple parents in one query instead of individual queries
  - `buildTreeFromLayers()`: Reconstructs the nested tree structure from pre-fetched layer data
  - `createPageRepository()`: Extracted language context setup for reusability
- **Truncation Feedback**: Added user-friendly truncation notices showing "showing X of Y subpages" with actionable hints to fetch remaining children via `startPage` parameter
- **Code Cleanup**: Fixed trailing whitespace and improved code organization

## Implementation Details

- The refactored `getPageTree()` now collects all pages at each depth level in a single batch query, then recursively builds the nested structure from this pre-fetched data
- Language overlays are still applied per-page to maintain translation support
- Subpage counts are tracked separately (total vs. shown) to enable truncation notices
- First-layer children are never truncated, ensuring users always see all direct children of their starting page
- All existing functionality (language support, record counting, plugin hints, doktype labels) is preserved

https://claude.ai/code/session_01Q6Qsc98sVfSf3tBY2LwQqR