### PR TITLE
Fix MM relation handling in workspace and translation contexts

### DIFF
--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -450,12 +450,12 @@ class WriteTableTool extends AbstractRecordTool
         // Convert data for storage
         $data = $this->convertDataForStorage($table, $data);
 
+        // Resolve the live UID to workspace UID (once, used throughout)
+        $workspaceUid = $this->resolveToWorkspaceUid($table, $uid);
+
         // For translation records, ensure l10n_state marks explicitly updated fields as "custom"
         // so DataHandler doesn't override them with allowLanguageSynchronization
-        $data = $this->ensureL10nStateForTranslation($table, $uid, $data);
-
-        // Resolve the live UID to workspace UID
-        $workspaceUid = $this->resolveToWorkspaceUid($table, $uid);
+        $data = $this->ensureL10nStateForTranslation($table, $workspaceUid, $data);
 
         // First, update the parent record without inline relations
         $dataMap = [$table => [$workspaceUid => $data]];
@@ -1361,9 +1361,8 @@ class WriteTableTool extends AbstractRecordTool
             return $data;
         }
 
-        // Resolve the workspace UID so we read the correct record
-        $workspaceUid = $this->resolveToWorkspaceUid($table, $uid);
-        $record = BackendUtility::getRecord($table, $workspaceUid, $translationParentField . ',l10n_state');
+        // $uid is already the workspace UID (resolved by the caller)
+        $record = BackendUtility::getRecord($table, $uid, $translationParentField . ',l10n_state');
         if (!$record || empty($record[$translationParentField])) {
             // Not a translation — nothing to do
             return $data;
@@ -1408,7 +1407,7 @@ class WriteTableTool extends AbstractRecordTool
             $connection->update(
                 $table,
                 ['l10n_state' => json_encode($l10nState)],
-                ['uid' => $workspaceUid]
+                ['uid' => $uid]
             );
         }
 

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -449,10 +449,14 @@ class WriteTableTool extends AbstractRecordTool
         
         // Convert data for storage
         $data = $this->convertDataForStorage($table, $data);
-        
+
+        // For translation records, ensure l10n_state marks explicitly updated fields as "custom"
+        // so DataHandler doesn't override them with allowLanguageSynchronization
+        $data = $this->ensureL10nStateForTranslation($table, $uid, $data);
+
         // Resolve the live UID to workspace UID
         $workspaceUid = $this->resolveToWorkspaceUid($table, $uid);
-        
+
         // First, update the parent record without inline relations
         $dataMap = [$table => [$workspaceUid => $data]];
         
@@ -1340,6 +1344,77 @@ class WriteTableTool extends AbstractRecordTool
         return $data;
     }
     
+    /**
+     * For translation records, set l10n_state to "custom" for fields that
+     * have allowLanguageSynchronization enabled and are being explicitly updated.
+     *
+     * Without this, DataHandler would sync these fields from the default language
+     * record and silently discard the values the MCP client sent.
+     *
+     * DataHandler reads l10n_state from the database record (not from incoming data),
+     * so this method writes directly to the database before the DataHandler call.
+     */
+    protected function ensureL10nStateForTranslation(string $table, int $uid, array $data): array
+    {
+        $translationParentField = $this->tableAccessService->getTranslationParentFieldName($table);
+        if (!$translationParentField) {
+            return $data;
+        }
+
+        // Resolve the workspace UID so we read the correct record
+        $workspaceUid = $this->resolveToWorkspaceUid($table, $uid);
+        $record = BackendUtility::getRecord($table, $workspaceUid, $translationParentField . ',l10n_state');
+        if (!$record || empty($record[$translationParentField])) {
+            // Not a translation — nothing to do
+            return $data;
+        }
+
+        $columns = $GLOBALS['TCA'][$table]['columns'] ?? [];
+        $syncFields = [];
+
+        foreach ($data as $fieldName => $_value) {
+            $behaviour = $columns[$fieldName]['config']['behaviour'] ?? [];
+            if (!empty($behaviour['allowLanguageSynchronization'])) {
+                $syncFields[] = $fieldName;
+            }
+        }
+
+        if (empty($syncFields)) {
+            return $data;
+        }
+
+        // Decode existing l10n_state (JSON field on the record)
+        $l10nState = [];
+        if (!empty($record['l10n_state'])) {
+            $decoded = json_decode($record['l10n_state'], true);
+            if (is_array($decoded)) {
+                $l10nState = $decoded;
+            }
+        }
+
+        $changed = false;
+        foreach ($syncFields as $fieldName) {
+            if (($l10nState[$fieldName] ?? '') !== 'custom') {
+                $l10nState[$fieldName] = 'custom';
+                $changed = true;
+            }
+        }
+
+        if ($changed) {
+            // Write l10n_state directly to the database because DataHandler reads it
+            // from the record, not from the incoming dataMap
+            $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getConnectionForTable($table);
+            $connection->update(
+                $table,
+                ['l10n_state' => json_encode($l10nState)],
+                ['uid' => $workspaceUid]
+            );
+        }
+
+        return $data;
+    }
+
     /**
      * Get the live UID for a workspace record
      * For workspace records, this returns the t3ver_oid (original/live UID)

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -450,12 +450,12 @@ class WriteTableTool extends AbstractRecordTool
         // Convert data for storage
         $data = $this->convertDataForStorage($table, $data);
 
+        // For translation records, add l10n_state overrides so DataHandler treats
+        // explicitly updated fields as "custom" (not synced from parent)
+        $data = $this->ensureL10nStateForTranslation($table, $uid, $data);
+
         // Resolve the live UID to workspace UID (once, used throughout)
         $workspaceUid = $this->resolveToWorkspaceUid($table, $uid);
-
-        // For translation records, ensure l10n_state marks explicitly updated fields as "custom"
-        // so DataHandler doesn't override them with allowLanguageSynchronization
-        $data = $this->ensureL10nStateForTranslation($table, $workspaceUid, $data);
 
         // First, update the parent record without inline relations
         $dataMap = [$table => [$workspaceUid => $data]];
@@ -1348,11 +1348,13 @@ class WriteTableTool extends AbstractRecordTool
      * For translation records, set l10n_state to "custom" for fields that
      * have allowLanguageSynchronization enabled and are being explicitly updated.
      *
-     * Without this, DataHandler would sync these fields from the default language
-     * record and silently discard the values the MCP client sent.
+     * Without this, DataHandler's DataMapProcessor would sync these fields from
+     * the default language record and silently discard the values the MCP client sent.
      *
-     * DataHandler reads l10n_state from the database record (not from incoming data),
-     * so this method writes directly to the database before the DataHandler call.
+     * This uses the same mechanism as TYPO3's FormEngine: passing l10n_state as an
+     * array in the dataMap. DataMapProcessor's DataMapItem::buildState() reads the
+     * persisted l10n_state JSON from the database first, then merges incoming array
+     * values on top (see DataMapItem::buildState step 4).
      */
     protected function ensureL10nStateForTranslation(string $table, int $uid, array $data): array
     {
@@ -1361,67 +1363,27 @@ class WriteTableTool extends AbstractRecordTool
             return $data;
         }
 
-        // $uid is already the workspace UID (resolved by the caller).
-        // Request l10n_state alongside the parent field; if the column doesn't exist
-        // (misconfigured extension), BackendUtility may throw — catch gracefully.
-        try {
-            $record = BackendUtility::getRecord($table, $uid, $translationParentField . ',l10n_state');
-        } catch (\Doctrine\DBAL\Exception $e) {
-            // l10n_state column might not exist; fall back to just the parent field
-            $record = BackendUtility::getRecord($table, $uid, $translationParentField);
-        }
+        // $uid is already the workspace UID (resolved by the caller)
+        $record = BackendUtility::getRecord($table, $uid, $translationParentField);
         if (!$record || empty($record[$translationParentField])) {
             // Not a translation — nothing to do
             return $data;
         }
 
         $columns = $GLOBALS['TCA'][$table]['columns'] ?? [];
-        $syncFields = [];
+        $l10nStateOverrides = [];
 
         foreach ($data as $fieldName => $_value) {
             $behaviour = $columns[$fieldName]['config']['behaviour'] ?? [];
             if (!empty($behaviour['allowLanguageSynchronization'])) {
-                $syncFields[] = $fieldName;
+                $l10nStateOverrides[$fieldName] = 'custom';
             }
         }
 
-        if (empty($syncFields)) {
-            return $data;
-        }
-
-        // Decode existing l10n_state (JSON field on the record)
-        $l10nState = [];
-        if (!empty($record['l10n_state'])) {
-            $decoded = json_decode($record['l10n_state'], true);
-            if (is_array($decoded)) {
-                $l10nState = $decoded;
-            }
-        }
-
-        $changed = false;
-        foreach ($syncFields as $fieldName) {
-            if (($l10nState[$fieldName] ?? '') !== 'custom') {
-                $l10nState[$fieldName] = 'custom';
-                $changed = true;
-            }
-        }
-
-        if ($changed) {
-            // Write l10n_state directly to the database because DataHandler reads it
-            // from the record, not from the incoming dataMap.
-            // The l10n_state column is auto-added by TYPO3 for translatable tables,
-            // but guard against misconfigured extensions with a try-catch.
-            try {
-                $connection = GeneralUtility::makeInstance(ConnectionPool::class)
-                    ->getConnectionForTable($table);
-                $connection->update(
-                    $table,
-                    ['l10n_state' => json_encode($l10nState)],
-                    ['uid' => $uid]
-                );
-            } catch (\Doctrine\DBAL\Exception $e) {
-                // l10n_state column might not exist; skip gracefully
-            }
+        if (!empty($l10nStateOverrides)) {
+            // Pass as array — DataMapProcessor merges this on top of the DB value,
+            // exactly like FormEngine's LocalizationStateSelector does.
+            $data['l10n_state'] = $l10nStateOverrides;
         }
 
         return $data;

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -1361,8 +1361,15 @@ class WriteTableTool extends AbstractRecordTool
             return $data;
         }
 
-        // $uid is already the workspace UID (resolved by the caller)
-        $record = BackendUtility::getRecord($table, $uid, $translationParentField . ',l10n_state');
+        // $uid is already the workspace UID (resolved by the caller).
+        // Request l10n_state alongside the parent field; if the column doesn't exist
+        // (misconfigured extension), BackendUtility may throw — catch gracefully.
+        try {
+            $record = BackendUtility::getRecord($table, $uid, $translationParentField . ',l10n_state');
+        } catch (\Doctrine\DBAL\Exception $e) {
+            // l10n_state column might not exist; fall back to just the parent field
+            $record = BackendUtility::getRecord($table, $uid, $translationParentField);
+        }
         if (!$record || empty($record[$translationParentField])) {
             // Not a translation — nothing to do
             return $data;
@@ -1401,14 +1408,20 @@ class WriteTableTool extends AbstractRecordTool
 
         if ($changed) {
             // Write l10n_state directly to the database because DataHandler reads it
-            // from the record, not from the incoming dataMap
-            $connection = GeneralUtility::makeInstance(ConnectionPool::class)
-                ->getConnectionForTable($table);
-            $connection->update(
-                $table,
-                ['l10n_state' => json_encode($l10nState)],
-                ['uid' => $uid]
-            );
+            // from the record, not from the incoming dataMap.
+            // The l10n_state column is auto-added by TYPO3 for translatable tables,
+            // but guard against misconfigured extensions with a try-catch.
+            try {
+                $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+                    ->getConnectionForTable($table);
+                $connection->update(
+                    $table,
+                    ['l10n_state' => json_encode($l10nState)],
+                    ['uid' => $uid]
+                );
+            } catch (\Doctrine\DBAL\Exception $e) {
+                // l10n_state column might not exist; skip gracefully
+            }
         }
 
         return $data;

--- a/Tests/Functional/MCP/Tool/MmRelationWorkspaceTest.php
+++ b/Tests/Functional/MCP/Tool/MmRelationWorkspaceTest.php
@@ -1,0 +1,383 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use Hn\McpServer\MCP\Tool\Record\ReadTableTool;
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use Hn\McpServer\Service\WorkspaceContextService;
+use Symfony\Component\Yaml\Yaml;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Test MM relation handling in workspace and translation contexts.
+ *
+ * These tests verify that MM relations work correctly when:
+ * - Existing live records are updated in workspace context
+ * - Records with MM relations are translated
+ * - Translations get independent MM relations (allowLanguageSynchronization override)
+ */
+class MmRelationWorkspaceTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+        'frontend',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'mcp_server',
+        'news',
+    ];
+
+    protected WriteTableTool $writeTool;
+    protected ReadTableTool $readTool;
+    protected WorkspaceContextService $workspaceService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createMultiLanguageSiteConfiguration();
+
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/sys_category.csv');
+
+        $this->setUpBackendUser(1);
+
+        // Required by DataHandler for localization operations
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('en');
+
+        $this->writeTool = new WriteTableTool();
+        $this->readTool = new ReadTableTool();
+        $this->workspaceService = GeneralUtility::makeInstance(WorkspaceContextService::class);
+    }
+
+    protected function createMultiLanguageSiteConfiguration(): void
+    {
+        $siteConfiguration = [
+            'rootPageId' => 1,
+            'base' => 'https://example.com/',
+            'websiteTitle' => 'Test Site',
+            'languages' => [
+                0 => [
+                    'title' => 'English',
+                    'enabled' => true,
+                    'languageId' => 0,
+                    'base' => '/',
+                    'locale' => 'en_US.UTF-8',
+                    'iso-639-1' => 'en',
+                    'hreflang' => 'en-us',
+                    'direction' => 'ltr',
+                    'flag' => 'us',
+                    'navigationTitle' => 'English',
+                ],
+                1 => [
+                    'title' => 'German',
+                    'enabled' => true,
+                    'languageId' => 1,
+                    'base' => '/de/',
+                    'locale' => 'de_DE.UTF-8',
+                    'iso-639-1' => 'de',
+                    'hreflang' => 'de-de',
+                    'direction' => 'ltr',
+                    'flag' => 'de',
+                    'navigationTitle' => 'Deutsch',
+                ],
+            ],
+            'routes' => [],
+            'errorHandling' => [],
+        ];
+
+        $configPath = $this->instancePath . '/typo3conf/sites/test-site';
+        GeneralUtility::mkdir_deep($configPath);
+
+        $yamlContent = Yaml::dump($siteConfiguration, 99, 2);
+        GeneralUtility::writeFile($configPath . '/config.yaml', $yamlContent, true);
+    }
+
+    /**
+     * Test updating opposite MM relations (categories) on an existing live record in workspace.
+     *
+     * 1. Create a record in live (no workspace)
+     * 2. Switch to workspace
+     * 3. Update the record's MM relations
+     * 4. Read back with includeRelations — should see workspace changes, not live data
+     */
+    public function testUpdateOppositeMmOnLiveRecordInWorkspace(): void
+    {
+        // Create in live
+        $GLOBALS['BE_USER']->workspace = 0;
+
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'title' => 'Live News',
+                'datetime' => time(),
+                'categories' => [1, 2],
+            ]
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $newsUid = json_decode($result->content[0]->text)->uid;
+
+        // Switch to workspace
+        $this->workspaceService->switchToOptimalWorkspace($GLOBALS['BE_USER']);
+        $this->assertGreaterThan(0, $GLOBALS['BE_USER']->workspace);
+
+        // Update categories in workspace
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'update',
+            'uid' => $newsUid,
+            'data' => ['categories' => [3, 4, 5]],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        // Read back — should see workspace categories
+        $result = $this->readTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'uid' => $newsUid,
+            'includeRelations' => true,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $news = json_decode($result->content[0]->text)->records[0];
+
+        $this->assertEquals($newsUid, $news->uid, 'Client should see live UID');
+        $this->assertCount(3, $news->categories, 'Should see 3 workspace categories, not 2 live');
+        $this->assertEquals([3, 4, 5], $news->categories);
+    }
+
+    /**
+     * Test updating standard MM relations (tags) on an existing live record in workspace.
+     */
+    public function testUpdateStandardMmOnLiveRecordInWorkspace(): void
+    {
+        $GLOBALS['BE_USER']->workspace = 0;
+
+        $tagUids = [];
+        foreach (['Tag A', 'Tag B', 'Tag C', 'Tag D'] as $title) {
+            $result = $this->writeTool->execute([
+                'table' => 'tx_news_domain_model_tag',
+                'action' => 'create',
+                'pid' => 1,
+                'data' => ['title' => $title],
+            ]);
+            $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+            $tagUids[] = json_decode($result->content[0]->text)->uid;
+        }
+
+        // Create news with tags A,B in live
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'title' => 'Live News with Tags',
+                'datetime' => time(),
+                'tags' => [$tagUids[0], $tagUids[1]],
+            ]
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $newsUid = json_decode($result->content[0]->text)->uid;
+
+        // Switch to workspace and change to tags C,D
+        $this->workspaceService->switchToOptimalWorkspace($GLOBALS['BE_USER']);
+
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'update',
+            'uid' => $newsUid,
+            'data' => ['tags' => [$tagUids[2], $tagUids[3]]],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        // Read back — should see workspace tags C,D
+        $result = $this->readTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'uid' => $newsUid,
+            'includeRelations' => true,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $news = json_decode($result->content[0]->text)->records[0];
+
+        $this->assertEquals($newsUid, $news->uid);
+        $this->assertCount(2, $news->tags);
+        $this->assertEquals([$tagUids[2], $tagUids[3]], $news->tags);
+    }
+
+    /**
+     * Test that translating a record copies its MM relations to the translation.
+     */
+    public function testTranslateRecordCopiesMmRelations(): void
+    {
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'title' => 'English News',
+                'datetime' => time(),
+                'categories' => [1, 2, 3],
+            ]
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $newsUid = json_decode($result->content[0]->text)->uid;
+
+        // Translate to German
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'translate',
+            'uid' => $newsUid,
+            'data' => ['sys_language_uid' => 'de'],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $translationUid = json_decode($result->content[0]->text)->translationUid;
+
+        // Translation should have the same categories as the source
+        $result = $this->readTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'uid' => $translationUid,
+            'includeRelations' => true,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $translation = json_decode($result->content[0]->text)->records[0];
+
+        $this->assertIsArray($translation->categories);
+        $this->assertCount(3, $translation->categories);
+        $this->assertEquals([1, 2, 3], $translation->categories);
+    }
+
+    /**
+     * Test that translations can override MM relations independently of the source.
+     *
+     * News extension uses allowLanguageSynchronization for categories and tags.
+     * The WriteTableTool must automatically set l10n_state to "custom" so
+     * DataHandler doesn't discard the explicit values sent by the MCP client.
+     */
+    public function testTranslationCanOverrideSyncedMmRelations(): void
+    {
+        // Create news with categories [1,2]
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'title' => 'English News',
+                'datetime' => time(),
+                'categories' => [1, 2],
+            ]
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $newsUid = json_decode($result->content[0]->text)->uid;
+
+        // Translate to German
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'translate',
+            'uid' => $newsUid,
+            'data' => ['sys_language_uid' => 'de'],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $translationUid = json_decode($result->content[0]->text)->translationUid;
+
+        // Update translation's categories to different values
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'update',
+            'uid' => $translationUid,
+            'data' => ['categories' => [3, 4, 5]],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        // Source should still have [1,2]
+        $result = $this->readTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'uid' => $newsUid,
+            'includeRelations' => true,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $source = json_decode($result->content[0]->text)->records[0];
+        $this->assertEquals([1, 2], $source->categories, 'Source should be unchanged');
+
+        // Translation should have [3,4,5]
+        $result = $this->readTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'uid' => $translationUid,
+            'includeRelations' => true,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $translation = json_decode($result->content[0]->text)->records[0];
+        $this->assertEquals([3, 4, 5], $translation->categories, 'Translation should have independent categories');
+    }
+
+    /**
+     * Test workspace + translation combined: translate a live record in workspace,
+     * then update the source's MM relations.
+     */
+    public function testWorkspaceTranslationMmRelations(): void
+    {
+        // Create in live
+        $GLOBALS['BE_USER']->workspace = 0;
+
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'title' => 'Live English News',
+                'datetime' => time(),
+                'categories' => [1, 2],
+            ]
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $newsUid = json_decode($result->content[0]->text)->uid;
+
+        // Switch to workspace
+        $this->workspaceService->switchToOptimalWorkspace($GLOBALS['BE_USER']);
+
+        // Translate in workspace
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'translate',
+            'uid' => $newsUid,
+            'data' => ['sys_language_uid' => 'de'],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $translationUid = json_decode($result->content[0]->text)->translationUid;
+
+        // Update source record's categories in workspace
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'update',
+            'uid' => $newsUid,
+            'data' => ['categories' => [3, 4, 5]],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        // Source should see workspace categories
+        $result = $this->readTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'uid' => $newsUid,
+            'includeRelations' => true,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $source = json_decode($result->content[0]->text)->records[0];
+        $this->assertEquals([3, 4, 5], $source->categories);
+
+        // Translation should have its own categories (copied at translation time)
+        $result = $this->readTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'uid' => $translationUid,
+            'includeRelations' => true,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $translation = json_decode($result->content[0]->text)->records[0];
+        $this->assertIsArray($translation->categories, 'Translation should have categories');
+    }
+}

--- a/Tests/Functional/MCP/Tool/MmRelationWorkspaceTest.php
+++ b/Tests/Functional/MCP/Tool/MmRelationWorkspaceTest.php
@@ -380,4 +380,166 @@ class MmRelationWorkspaceTest extends FunctionalTestCase
         $translation = json_decode($result->content[0]->text)->records[0];
         $this->assertIsArray($translation->categories, 'Translation should have categories');
     }
+
+    /**
+     * Test updating a live record with BOTH MM relations AND inline relations in workspace.
+     *
+     * Reproduces GitHub issue #19: "WriteTable fails on existing live records
+     * with MM/inline relations (update & translate)".
+     */
+    public function testUpdateLiveRecordWithMmAndInlineInWorkspace(): void
+    {
+        // Create in live with categories (opposite MM) and related_links (inline)
+        $GLOBALS['BE_USER']->workspace = 0;
+
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'title' => 'Live News with MM and Inline',
+                'datetime' => time(),
+                'categories' => [1, 2],
+                'related_links' => [
+                    ['uri' => 'https://example.com', 'title' => 'Example'],
+                ],
+            ]
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $newsUid = json_decode($result->content[0]->text)->uid;
+
+        // Switch to workspace
+        $this->workspaceService->switchToOptimalWorkspace($GLOBALS['BE_USER']);
+        $this->assertGreaterThan(0, $GLOBALS['BE_USER']->workspace);
+
+        // Update both MM and inline in workspace
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'update',
+            'uid' => $newsUid,
+            'data' => [
+                'title' => 'Updated News in Workspace',
+                'categories' => [3, 4, 5],
+                'related_links' => [
+                    ['uri' => 'https://workspace.example.com', 'title' => 'Workspace Link'],
+                ],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        // Read back — should see workspace data
+        $result = $this->readTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'uid' => $newsUid,
+            'includeRelations' => true,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $news = json_decode($result->content[0]->text)->records[0];
+
+        $this->assertEquals($newsUid, $news->uid, 'Client should see live UID');
+        $this->assertEquals('Updated News in Workspace', $news->title);
+        $this->assertCount(3, $news->categories, 'Should see 3 workspace categories');
+        $this->assertEquals([3, 4, 5], $news->categories);
+    }
+
+    /**
+     * Test translating a live record in workspace context.
+     *
+     * Part of GitHub issue #19: translating pre-existing live records
+     * should work in workspace context.
+     */
+    public function testTranslateLiveRecordInWorkspace(): void
+    {
+        // Create in live with categories
+        $GLOBALS['BE_USER']->workspace = 0;
+
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'title' => 'Live News to Translate',
+                'datetime' => time(),
+                'categories' => [1, 2, 3],
+            ]
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $newsUid = json_decode($result->content[0]->text)->uid;
+
+        // Switch to workspace
+        $this->workspaceService->switchToOptimalWorkspace($GLOBALS['BE_USER']);
+        $this->assertGreaterThan(0, $GLOBALS['BE_USER']->workspace);
+
+        // Translate in workspace
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'translate',
+            'uid' => $newsUid,
+            'data' => ['sys_language_uid' => 'de'],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $translationUid = json_decode($result->content[0]->text)->translationUid;
+        $this->assertNotEmpty($translationUid, 'Should get a translation UID');
+
+        // Translation should have categories copied from source
+        $result = $this->readTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'uid' => $translationUid,
+            'includeRelations' => true,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $translation = json_decode($result->content[0]->text)->records[0];
+
+        $this->assertIsArray($translation->categories, 'Translation should have categories');
+        $this->assertCount(3, $translation->categories, 'Translation should have same categories as source');
+        $this->assertEquals([1, 2, 3], $translation->categories);
+    }
+
+    /**
+     * Test updating MM-only on a live record in workspace (no other field changes).
+     *
+     * This verifies DataHandler auto-versioning works when the ONLY
+     * changes are to MM relation fields.
+     */
+    public function testUpdateOnlyMmFieldOnLiveRecordInWorkspace(): void
+    {
+        $GLOBALS['BE_USER']->workspace = 0;
+
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'title' => 'News with only MM update',
+                'datetime' => time(),
+                'categories' => [1],
+            ]
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $newsUid = json_decode($result->content[0]->text)->uid;
+
+        // Switch to workspace
+        $this->workspaceService->switchToOptimalWorkspace($GLOBALS['BE_USER']);
+
+        // Update ONLY categories (no other fields)
+        $result = $this->writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'update',
+            'uid' => $newsUid,
+            'data' => ['categories' => [2, 3, 4, 5]],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        // Read back
+        $result = $this->readTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'uid' => $newsUid,
+            'includeRelations' => true,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $news = json_decode($result->content[0]->text)->records[0];
+
+        $this->assertCount(4, $news->categories, 'Should see 4 workspace categories');
+        $this->assertEquals([2, 3, 4, 5], $news->categories);
+    }
 }


### PR DESCRIPTION
## Summary
Ensure MM relations (both standard and opposite) are correctly handled when updating existing live records in workspace context and when translating records with synchronized fields.

## Key Changes

- **Added comprehensive test suite** (`MmRelationWorkspaceTest.php`): 8 functional tests covering:
  - Updating opposite MM relations (categories) on live records in workspace
  - Updating standard MM relations (tags) on live records in workspace
  - Translating records with MM relations
  - Overriding synchronized MM relations in translations
  - Combined workspace + translation scenarios
  - Updating records with both MM and inline relations simultaneously
  - Translating live records within workspace context
  - Updating only MM fields without other field changes

- **Enhanced `WriteTableTool.updateRecord()`**: Added `ensureL10nStateForTranslation()` method to properly handle translation records with synchronized fields:
  - Detects when a record is a translation (has a translation parent)
  - Identifies fields with `allowLanguageSynchronization` enabled
  - Sets `l10n_state` to "custom" for explicitly updated fields
  - Prevents DataHandler from silently discarding client-provided values in favor of synced parent values
  - Uses the same mechanism as TYPO3's FormEngine (array-based l10n_state merging)

## Implementation Details

The fix addresses a core issue where DataHandler's DataMapProcessor would sync fields marked with `allowLanguageSynchronization` from the default language record, silently discarding values sent by the MCP client. By explicitly setting `l10n_state` to "custom" for updated fields, the processor treats them as intentionally overridden rather than synced.

The test fixtures use the `news` extension which has MM relations (categories, tags) and inline relations (related_links), providing realistic coverage of the issue scenarios.
