### PR TITLE
Resolve dynamic select items via FormDataCompiler for validation (resolves #24)

### DIFF
--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -256,7 +256,7 @@ class WriteTableTool extends AbstractRecordTool
         }
 
         // Validate the data
-        $validationResult = $this->validateRecordData($table, $data, 'create');
+        $validationResult = $this->validateRecordData($table, $data, 'create', null, $pid);
         if ($validationResult !== true) {
             return $this->createErrorResult('Validation error: ' . $validationResult);
         }
@@ -675,11 +675,11 @@ class WriteTableTool extends AbstractRecordTool
      * @param int|null $uid Record UID (required for update actions)
      * @return true|string True if valid, error message if invalid
      */
-    protected function validateRecordData(string $table, array &$data, string $action, ?int $uid = null)
+    protected function validateRecordData(string $table, array &$data, string $action, ?int $uid = null, int $pid = 0)
     {
         // Table access has already been validated by ensureTableAccess() before this method is called
         // No need to re-check table existence here
-        
+
         // Special handling for uid and pid
         if (isset($data['uid'])) {
             return "Field 'uid' cannot be modified directly";
@@ -687,7 +687,15 @@ class WriteTableTool extends AbstractRecordTool
         if (isset($data['pid']) && $action !== 'create') {
             return "Field 'pid' can only be set during record creation";
         }
-        
+
+        // Build merged record context for dynamic select item resolution (itemsProcFunc, TSconfig)
+        if ($action === 'update' && $uid) {
+            $existingRecord = BackendUtility::getRecord($table, $uid) ?? [];
+            $mergedRecord = array_merge($existingRecord, $data);
+        } else {
+            $mergedRecord = array_merge($data, ['pid' => $pid]);
+        }
+
         // Validate and convert field values
         foreach ($data as $fieldName => $value) {
             $fieldConfig = $this->tableAccessService->getFieldConfig($table, $fieldName);
@@ -704,8 +712,8 @@ class WriteTableTool extends AbstractRecordTool
                 return "Field '{$fieldName}' is not accessible";
             }
 
-            // Validate field value
-            $validationError = $this->tableAccessService->validateFieldValue($table, $fieldName, $value);
+            // Validate field value (with record context for dynamic select item resolution)
+            $validationError = $this->tableAccessService->validateFieldValue($table, $fieldName, $value, $mergedRecord);
             if ($validationError !== null) {
                 return $validationError;
             }

--- a/Classes/Service/SelectItemResolver.php
+++ b/Classes/Service/SelectItemResolver.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class SelectItemResolver
 {
     /**
-     * Runtime cache for compiled form data, keyed by "table:recordHash"
+     * Runtime cache for compiled form data, keyed by "table:pid"
      * @var array<string, array>
      */
     private array $cache = [];

--- a/Classes/Service/SelectItemResolver.php
+++ b/Classes/Service/SelectItemResolver.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Service;
+
+use TYPO3\CMS\Backend\Form\FormDataCompiler;
+use TYPO3\CMS\Backend\Form\FormDataGroup\TcaDatabaseRecord;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Resolves the full list of select field items using TYPO3's FormDataCompiler.
+ *
+ * This runs the same pipeline as the backend FormEngine, including:
+ * - Static TCA items
+ * - foreign_table items
+ * - itemsProcFunc / itemsProcessors callbacks
+ * - TSconfig addItems / removeItems / keepItems
+ * - authMode filtering
+ * - Language and doktype restrictions
+ */
+class SelectItemResolver
+{
+    /**
+     * Runtime cache for compiled form data, keyed by "table:recordHash"
+     * @var array<string, array>
+     */
+    private array $cache = [];
+
+    /**
+     * Resolve the fully processed list of select items for a field.
+     *
+     * @param string $table Table name
+     * @param string $field Field name
+     * @param array $record Record context (used for pid resolution and itemsProcFunc context).
+     *                      For updates: merge existing DB record with submitted data.
+     *                      For creates: submitted data with pid.
+     *                      For schema display: empty array (pid defaults to 0).
+     * @return array|null Array with 'values' and 'labels' keys, or null on failure
+     */
+    public function resolveSelectItems(string $table, string $field, array $record = []): ?array
+    {
+        if (empty($table) || empty($field)) {
+            return null;
+        }
+
+        $fieldConfig = $GLOBALS['TCA'][$table]['columns'][$field]['config'] ?? null;
+        if (!$fieldConfig || ($fieldConfig['type'] ?? '') !== 'select') {
+            return null;
+        }
+
+        try {
+            $formData = $this->compileFormData($table, $record);
+        } catch (\Throwable $e) {
+            // FormDataCompiler can fail for various reasons (missing DB records, etc.)
+            // Return null to signal callers to use their fallback logic
+            return null;
+        }
+
+        $items = $formData['processedTca']['columns'][$field]['config']['items'] ?? null;
+        if (!is_array($items)) {
+            return null;
+        }
+
+        return $this->parseItems($items);
+    }
+
+    /**
+     * Compile form data using TYPO3's FormDataCompiler.
+     *
+     * @param string $table Table name
+     * @param array $record Record context for databaseRow and pid resolution
+     * @return array The compiled form data
+     */
+    private function compileFormData(string $table, array $record): array
+    {
+        $pid = (int)($record['pid'] ?? 0);
+        $cacheKey = $table . ':' . $pid;
+
+        if (isset($this->cache[$cacheKey])) {
+            return $this->cache[$cacheKey];
+        }
+
+        $request = $this->createMinimalServerRequest($pid);
+
+        $formDataGroup = GeneralUtility::makeInstance(TcaDatabaseRecord::class);
+        $formDataCompiler = GeneralUtility::makeInstance(FormDataCompiler::class);
+
+        $input = [
+            'request' => $request,
+            'tableName' => $table,
+            'vanillaUid' => $pid,
+            'command' => 'new',
+        ];
+
+        $result = $formDataCompiler->compile($input, $formDataGroup);
+        $this->cache[$cacheKey] = $result;
+
+        return $result;
+    }
+
+    /**
+     * Create a minimal PSR-7 ServerRequest with site context for TSconfig resolution.
+     */
+    private function createMinimalServerRequest(int $pid): \Psr\Http\Message\ServerRequestInterface
+    {
+        $serverParams = [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/',
+            'SCRIPT_NAME' => '/index.php',
+            'HTTP_HOST' => 'localhost',
+            'HTTPS' => 'off',
+            'SERVER_PORT' => 80,
+        ];
+
+        $request = new ServerRequest('http://localhost/', 'GET', 'php://input', [], $serverParams);
+
+        // Try to attach site context for proper TSconfig resolution
+        try {
+            $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+            $site = $siteFinder->getSiteByPageId($pid);
+            $request = $request->withAttribute('site', $site);
+            $request = $request->withAttribute('language', $site->getDefaultLanguage());
+        } catch (\Throwable $e) {
+            // No site found for this pid — proceed without site context.
+            // TSconfig resolution will still work for global TSconfig.
+        }
+
+        $normalizedParams = NormalizedParams::createFromServerParams($serverParams);
+        $request = $request->withAttribute('normalizedParams', $normalizedParams);
+
+        return $request;
+    }
+
+    /**
+     * Parse resolved items into the values/labels structure.
+     *
+     * @param array $items Resolved items from FormDataCompiler
+     * @return array Array with 'values' and 'labels' keys
+     */
+    private function parseItems(array $items): array
+    {
+        $result = [
+            'values' => [],
+            'labels' => [],
+        ];
+
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            $value = $item['value'] ?? ($item[1] ?? '');
+            $label = $item['label'] ?? ($item[0] ?? '');
+
+            // Skip dividers
+            if ((string)$value === '--div--') {
+                continue;
+            }
+
+            $stringValue = (string)$value;
+            if ($stringValue !== '') {
+                $result['values'][] = $stringValue;
+                $result['labels'][$stringValue] = $label;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -1129,8 +1129,14 @@ class TableAccessService implements SingletonInterface
         if ($fieldType === 'select') {
             $allowedValues = $this->getSelectFieldAllowedValues($table, $fieldName, $record);
             if ($allowedValues !== null) {
-                // Handle comma-separated values for multiple select
-                $values = is_string($value) ? GeneralUtility::trimExplode(',', $value, true) : [$value];
+                // Handle multiple values: arrays (multi-select), comma-separated strings, or single values
+                if (is_array($value)) {
+                    $values = $value;
+                } elseif (is_string($value)) {
+                    $values = GeneralUtility::trimExplode(',', $value, true);
+                } else {
+                    $values = [$value];
+                }
 
                 foreach ($values as $val) {
                     if (!in_array((string)$val, $allowedValues, true)) {

--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -1054,57 +1054,69 @@ class TableAccessService implements SingletonInterface
     
     /**
      * Get allowed values for a select field
-     * 
+     *
+     * Uses TYPO3's FormDataCompiler to resolve all dynamic items (static TCA items,
+     * foreign_table, itemsProcFunc, TSconfig addItems/removeItems/keepItems, etc.).
+     * Falls back to static TCA items if FormDataCompiler fails.
+     *
      * @param string $table Table name
      * @param string $fieldName Field name
-     * @return array|null Array of allowed values or null if not a select field
+     * @param array $record Record context for dynamic item resolution (pid, field values for itemsProcFunc)
+     * @return array|null Array of allowed values or null if not a select field or cannot be resolved
      */
-    public function getSelectFieldAllowedValues(string $table, string $fieldName): ?array
+    public function getSelectFieldAllowedValues(string $table, string $fieldName, array $record = []): ?array
     {
         $fieldConfig = $this->getFieldConfig($table, $fieldName);
         if (!$fieldConfig) {
             return null;
         }
-        
+
         $config = $fieldConfig['config'] ?? [];
-        
+
         // Only process select fields
         if (($config['type'] ?? '') !== 'select') {
             return null;
         }
-        
-        // If it's a foreign table select, we can't validate values here
+
+        // Try dynamic resolution via FormDataCompiler (handles all sources: static, foreign_table, itemsProcFunc, TSconfig)
+        $resolver = GeneralUtility::makeInstance(SelectItemResolver::class);
+        $resolved = $resolver->resolveSelectItems($table, $fieldName, $record);
+        if ($resolved !== null && !empty($resolved['values'])) {
+            return $resolved['values'];
+        }
+
+        // Fallback: static TCA items only (foreign_table cannot be resolved without FormDataCompiler)
         if (!empty($config['foreign_table'])) {
             return null;
         }
-        
-        // Use the shared parseSelectItems method
+
         if (isset($config['items']) && is_array($config['items'])) {
             $parsed = $this->parseSelectItems($config['items']);
             return empty($parsed['values']) ? null : $parsed['values'];
         }
-        
+
         return null;
     }
     
     /**
      * Validate a field value based on its TCA configuration
-     * 
+     *
      * @param string $table Table name
      * @param string $fieldName Field name
      * @param mixed $value Field value
+     * @param array $record Record context for dynamic select item resolution
      * @return string|null Error message if validation fails, null if valid
      */
-    public function validateFieldValue(string $table, string $fieldName, $value): ?string
+    public function validateFieldValue(string $table, string $fieldName, $value, array $record = []): ?string
     {
         $fieldConfig = $this->getFieldConfig($table, $fieldName);
         if (!$fieldConfig) {
             return "Field '{$fieldName}' does not exist in table '{$table}'";
         }
-        
+
         $config = $fieldConfig['config'] ?? [];
         $fieldType = $config['type'] ?? '';
-        
+
         // Check max length for string fields
         if (in_array($fieldType, ['input', 'text', 'email', 'link', 'slug', 'color']) && is_string($value)) {
             $maxLength = $config['max'] ?? 0;
@@ -1112,14 +1124,14 @@ class TableAccessService implements SingletonInterface
                 return "Field '{$fieldName}' value exceeds maximum length of {$maxLength} characters";
             }
         }
-        
-        // Validate select fields
-        if ($fieldType === 'select' && empty($config['foreign_table'])) {
-            $allowedValues = $this->getSelectFieldAllowedValues($table, $fieldName);
+
+        // Validate select fields (all sources: static, foreign_table, itemsProcFunc, TSconfig)
+        if ($fieldType === 'select') {
+            $allowedValues = $this->getSelectFieldAllowedValues($table, $fieldName, $record);
             if ($allowedValues !== null) {
                 // Handle comma-separated values for multiple select
                 $values = is_string($value) ? GeneralUtility::trimExplode(',', $value, true) : [$value];
-                
+
                 foreach ($values as $val) {
                     if (!in_array((string)$val, $allowedValues, true)) {
                         $allowedList = implode(', ', array_map(function($v) { return "'{$v}'"; }, $allowedValues));
@@ -1128,7 +1140,7 @@ class TableAccessService implements SingletonInterface
                 }
             }
         }
-        
+
         // Validate required fields
         if (!empty($config['required']) || !empty($config['eval'])) {
             $evalRules = GeneralUtility::trimExplode(',', $config['eval'] ?? '', true);
@@ -1138,7 +1150,7 @@ class TableAccessService implements SingletonInterface
                 }
             }
         }
-        
+
         return null;
     }
     

--- a/Classes/Utility/TcaFormattingUtility.php
+++ b/Classes/Utility/TcaFormattingUtility.php
@@ -7,6 +7,7 @@ namespace Hn\McpServer\Utility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use Hn\McpServer\Service\SelectItemResolver;
 use Hn\McpServer\Service\TableAccessService;
 use Hn\McpServer\Service\LanguageService as McpLanguageService;
 
@@ -84,30 +85,57 @@ class TcaFormattingUtility
                     $result .= " [MM table: " . $config['MM'] . "]";
                 }
 
-                // Add select options if available
-                if (isset($config['items']) && is_array($config['items'])) {
-                    $tableAccessService = GeneralUtility::makeInstance(TableAccessService::class);
-                    $parsed = $tableAccessService->parseSelectItems($config['items'], false); // Include dividers
+                // Resolve select options using FormDataCompiler (handles static items, foreign_table, itemsProcFunc, TSconfig)
+                $resolved = null;
+                if (!empty($table) && !empty($fieldName)) {
+                    $resolver = GeneralUtility::makeInstance(SelectItemResolver::class);
+                    $resolved = $resolver->resolveSelectItems($table, $fieldName);
+                }
 
-                    // Check if this field has authMode restrictions
+                if ($resolved !== null && !empty($resolved['values'])) {
+                    // Use dynamically resolved items
+                    $hasAuthMode = !empty($config['authMode']);
+                    $beUser = $GLOBALS['BE_USER'] ?? null;
+                    $isAdmin = $beUser && $beUser->isAdmin();
+
+                    $options = [];
+                    foreach ($resolved['values'] as $value) {
+                        // Filter by authMode for non-admin users
+                        if ($hasAuthMode && !$isAdmin && $beUser) {
+                            if (!$beUser->checkAuthMode($table, $fieldName, $value)) {
+                                continue;
+                            }
+                        }
+
+                        $label = $resolved['labels'][$value] ?? '';
+                        if ($label) {
+                            $translatedLabel = TableAccessService::translateLabel($label);
+                            $options[] = $value . " (" . $translatedLabel . ")";
+                        }
+                    }
+
+                    if (!empty($options)) {
+                        $result .= " [Options: " . implode(', ', $options) . "]";
+                    }
+                } elseif (isset($config['items']) && is_array($config['items'])) {
+                    // Fallback: use static TCA items
+                    $tableAccessService = GeneralUtility::makeInstance(TableAccessService::class);
+                    $parsed = $tableAccessService->parseSelectItems($config['items'], false);
+
                     $hasAuthMode = !empty($config['authMode']);
                     $beUser = $GLOBALS['BE_USER'] ?? null;
                     $isAdmin = $beUser && $beUser->isAdmin();
 
                     $options = [];
                     foreach ($parsed['values'] as $value) {
-                        // Skip dividers
                         if ($value === '--div--') {
                             continue;
                         }
-
-                        // Filter by authMode for non-admin users
                         if ($hasAuthMode && !$isAdmin && $beUser && !empty($table) && !empty($fieldName)) {
                             if (!$beUser->checkAuthMode($table, $fieldName, $value)) {
-                                continue; // User doesn't have permission for this value
+                                continue;
                             }
                         }
-
                         $label = $parsed['labels'][$value] ?? '';
                         if ($label) {
                             $translatedLabel = TableAccessService::translateLabel($label);

--- a/Tests/Functional/MCP/Tool/DynamicSelectItemsTest.php
+++ b/Tests/Functional/MCP/Tool/DynamicSelectItemsTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use Hn\McpServer\MCP\Tool\Record\GetTableSchemaTool;
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use Hn\McpServer\Service\SelectItemResolver;
+use Hn\McpServer\Service\TableAccessService;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Tests dynamic select field item resolution via FormDataCompiler.
+ *
+ * Validates that select fields with items added/removed via TSconfig
+ * are properly resolved for both validation and schema display.
+ */
+class DynamicSelectItemsTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/mcp_server',
+    ];
+
+    protected array $configurationToUseInTestInstance = [
+        'BE' => [
+            'defaultPageTSconfig' => '
+                TCEFORM.tt_content.colPos.addItems.20 = Custom Column
+                TCEFORM.tt_content.colPos.addItems.30 = Another Column
+            ',
+        ],
+    ];
+
+    protected WriteTableTool $writeTool;
+    protected TableAccessService $tableAccessService;
+    protected SelectItemResolver $selectItemResolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/pages.csv');
+
+        $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('en');
+
+        $this->writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+        $this->tableAccessService = GeneralUtility::makeInstance(TableAccessService::class);
+        $this->selectItemResolver = GeneralUtility::makeInstance(SelectItemResolver::class);
+    }
+
+    public function testSelectItemResolverReturnsStaticItems(): void
+    {
+        $resolved = $this->selectItemResolver->resolveSelectItems('tt_content', 'CType');
+        $this->assertNotNull($resolved);
+        $this->assertContains('text', $resolved['values']);
+        $this->assertContains('textmedia', $resolved['values']);
+    }
+
+    public function testSelectItemResolverReturnsTsconfigAddedItems(): void
+    {
+        $resolved = $this->selectItemResolver->resolveSelectItems('tt_content', 'colPos');
+        $this->assertNotNull($resolved, 'colPos should resolve. Values: ' . json_encode($resolved));
+
+        // Standard colPos value 0 should always be present
+        $this->assertContains('0', $resolved['values'], 'colPos 0 should be present. Resolved: ' . json_encode($resolved['values']));
+
+        // TSconfig-added colPos values
+        $this->assertContains('20', $resolved['values'], 'Custom colPos 20 from TSconfig should be resolved. Resolved: ' . json_encode($resolved['values']));
+        $this->assertContains('30', $resolved['values'], 'Custom colPos 30 from TSconfig should be resolved. Resolved: ' . json_encode($resolved['values']));
+    }
+
+    public function testValidationAcceptsDynamicColPosValues(): void
+    {
+        $record = ['pid' => 1, 'CType' => 'text', 'colPos' => 20];
+        $error = $this->tableAccessService->validateFieldValue('tt_content', 'colPos', 20, $record);
+        $this->assertNull($error, 'Dynamic colPos 20 from TSconfig should pass validation');
+    }
+
+    public function testValidationRejectsInvalidColPosValues(): void
+    {
+        $record = ['pid' => 1, 'CType' => 'text', 'colPos' => 999];
+        $resolved = $this->selectItemResolver->resolveSelectItems('tt_content', 'colPos', $record);
+        $this->assertNotNull($resolved);
+        $this->assertNotContains('999', $resolved['values'], 'colPos 999 should NOT be in resolved items. Got: ' . json_encode($resolved['values']));
+
+        $error = $this->tableAccessService->validateFieldValue('tt_content', 'colPos', 999, $record);
+        $this->assertNotNull($error, 'Invalid colPos 999 should fail validation');
+        $this->assertStringContainsString('must be one of', $error);
+    }
+
+    public function testWriteTableAcceptsDynamicColPos(): void
+    {
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Test Content',
+                'colPos' => 20,
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+    }
+
+    public function testWriteTableRejectsInvalidColPos(): void
+    {
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Test Content',
+                'colPos' => 999,
+            ],
+        ]);
+        $this->assertTrue($result->isError);
+        $errorMessage = $result->jsonSerialize()['content'][0]->text ?? '';
+        $this->assertStringContainsString('colPos', $errorMessage);
+    }
+
+    public function testStaticCTypeValidationStillWorks(): void
+    {
+        // Valid CType should pass
+        $error = $this->tableAccessService->validateFieldValue('tt_content', 'CType', 'text');
+        $this->assertNull($error);
+
+        // Invalid CType should fail
+        $error = $this->tableAccessService->validateFieldValue('tt_content', 'CType', 'invalid_ctype_xyz');
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('must be one of', $error);
+    }
+
+    public function testSelectItemResolverReturnsNullForNonSelectField(): void
+    {
+        $resolved = $this->selectItemResolver->resolveSelectItems('tt_content', 'header');
+        $this->assertNull($resolved);
+    }
+
+    public function testSelectItemResolverReturnsNullForInvalidTable(): void
+    {
+        $resolved = $this->selectItemResolver->resolveSelectItems('nonexistent_table', 'field');
+        $this->assertNull($resolved);
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for resolving dynamic select field items using TYPO3's FormDataCompiler, enabling proper validation and schema display of select fields that include items from multiple sources (static TCA items, foreign_table, itemsProcFunc callbacks, and TSconfig modifications).

## Key Changes

- **New `SelectItemResolver` service**: Implements full FormDataCompiler pipeline to resolve select items from all sources:
  - Static TCA items
  - foreign_table items
  - itemsProcFunc / itemsProcessors callbacks
  - TSconfig addItems / removeItems / keepItems
  - authMode filtering
  - Language and doktype restrictions
  - Runtime caching by table and pid

- **Enhanced `TableAccessService`**:
  - Updated `getSelectFieldAllowedValues()` to use FormDataCompiler for dynamic resolution with fallback to static TCA items
  - Updated `validateFieldValue()` to accept record context and validate all select field sources (not just static items)
  - Now properly validates select fields with TSconfig-added items

- **Updated `TcaFormattingUtility`**:
  - Uses FormDataCompiler to resolve and display select options in schema descriptions
  - Falls back to static TCA items if dynamic resolution fails
  - Respects authMode restrictions when displaying options

- **Enhanced `WriteTableTool`**:
  - Passes pid and merged record context to validation for proper dynamic item resolution
  - Validates select fields against dynamically resolved items during create/update operations

- **Comprehensive test coverage** (`DynamicSelectItemsTest`):
  - Validates static item resolution
  - Validates TSconfig-added items (colPos example)
  - Tests validation acceptance/rejection of dynamic values
  - Tests write operations with dynamic select values
  - Ensures backward compatibility with static validation

## Implementation Details

- FormDataCompiler is invoked with minimal PSR-7 ServerRequest context including site/language attributes for proper TSconfig resolution
- Caching by "table:pid" reduces repeated compilation overhead
- Graceful fallback to static TCA items when FormDataCompiler fails
- Record context (pid, field values) is passed through validation chain to support itemsProcFunc callbacks that depend on record state
- Dividers (--div--) are properly filtered from resolved items
