### PR TITLE
Fix URL resolution to handle trailing slashes correctly

### DIFF
--- a/Classes/MCP/Tool/GetPageTool.php
+++ b/Classes/MCP/Tool/GetPageTool.php
@@ -668,7 +668,13 @@ class GetPageTool extends AbstractRecordTool
         if (!str_starts_with($path, '/')) {
             $path = '/' . $path;
         }
-        
+
+        // Strip trailing slash for non-root paths (slugs in DB don't have trailing slashes)
+        // This handles the common case of URLs like /about/ vs slug /about
+        if ($path !== '/' && str_ends_with($path, '/')) {
+            $path = rtrim($path, '/');
+        }
+
         // Special handling for home page
         if ($path === '/') {
             // Try to find the root page from any site

--- a/Classes/MCP/Tool/GetPageTool.php
+++ b/Classes/MCP/Tool/GetPageTool.php
@@ -664,16 +664,8 @@ class GetPageTool extends AbstractRecordTool
         $parsedUrl = parse_url($url);
         $path = $parsedUrl['path'] ?? $url;
         
-        // Normalize the path - ensure it starts with /
-        if (!str_starts_with($path, '/')) {
-            $path = '/' . $path;
-        }
-
-        // Strip trailing slash for non-root paths (slugs in DB don't have trailing slashes)
-        // This handles the common case of URLs like /about/ vs slug /about
-        if ($path !== '/' && str_ends_with($path, '/')) {
-            $path = rtrim($path, '/');
-        }
+        // Normalize: ensure leading slash, strip trailing slash (slugs in DB have no trailing slash)
+        $path = '/' . trim($path, '/');
 
         // Special handling for home page
         if ($path === '/') {

--- a/Tests/Functional/MCP/Tool/GetPageToolTest.php
+++ b/Tests/Functional/MCP/Tool/GetPageToolTest.php
@@ -512,6 +512,46 @@ class GetPageToolTest extends FunctionalTestCase
     }
 
     /**
+     * Test URL resolution with trailing slash
+     */
+    public function testUrlResolutionWithTrailingSlash(): void
+    {
+        $siteInformationService = GeneralUtility::makeInstance(SiteInformationService::class);
+        $languageService = GeneralUtility::makeInstance(LanguageService::class);
+        $tool = new GetPageTool($siteInformationService, $languageService);
+
+        // Test with trailing slash on path
+        $result = $tool->execute([
+            'url' => '/about/'
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $content = $result->content[0]->text;
+        $this->assertStringContainsString('UID: 2', $content);
+        $this->assertStringContainsString('Title: About', $content);
+    }
+
+    /**
+     * Test URL resolution with trailing slash on full URL
+     */
+    public function testUrlResolutionWithTrailingSlashFullUrl(): void
+    {
+        $siteInformationService = GeneralUtility::makeInstance(SiteInformationService::class);
+        $languageService = GeneralUtility::makeInstance(LanguageService::class);
+        $tool = new GetPageTool($siteInformationService, $languageService);
+
+        // Test with trailing slash on full URL
+        $result = $tool->execute([
+            'url' => 'https://example.com/about/team/'
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $content = $result->content[0]->text;
+        $this->assertStringContainsString('UID: 4', $content);
+        $this->assertStringContainsString('Title: Team', $content);
+    }
+
+    /**
      * Test URL resolution without leading slash
      */
     public function testUrlResolutionWithoutLeadingSlash(): void


### PR DESCRIPTION
## Summary
This PR fixes URL resolution in the GetPageTool to properly handle trailing slashes in both relative paths and full URLs. The tool now normalizes URLs by stripping trailing slashes before matching against page slugs stored in the database.

## Key Changes
- **URL normalization logic**: Updated `resolveUrlToPageUid()` method to strip trailing slashes from paths while ensuring a leading slash is present. This ensures URLs like `/about/` and `https://example.com/about/team/` correctly resolve to their corresponding pages.
- **Test coverage**: Added two new functional tests:
  - `testUrlResolutionWithTrailingSlash()`: Verifies that relative paths with trailing slashes resolve correctly
  - `testUrlResolutionWithTrailingSlashFullUrl()`: Verifies that full URLs with trailing slashes on nested paths resolve correctly

## Implementation Details
The fix simplifies the path normalization by using `trim($path, '/')` to remove both leading and trailing slashes, then prepending a single leading slash. This approach handles edge cases where URLs may have trailing slashes while maintaining compatibility with page slugs stored in the database (which don't include trailing slashes).

fixes #15
