### PR TITLE
fix(security): replace raw SQL where parameter with parameterized filters

### DIFF
--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -67,9 +67,27 @@ class ReadTableTool extends AbstractRecordTool
                 ],
                 'description' => 'Filter by record UID. Pass a single integer for one record, or an array of integers to fetch several at once — useful when reading inline-relation hints like "metadata: [1, 5]". Use the pid filter to read all records of a page.',
             ],
-            'where' => [
-                'type' => 'string',
-                'description' => 'SQL WHERE condition for filtering (without the WHERE keyword)',
+            'filters' => [
+                'type' => 'array',
+                'description' => 'Filter conditions applied with AND. Each filter has field, operator, and optionally value.',
+                'items' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'field' => [
+                            'type' => 'string',
+                            'description' => 'Column name to filter on',
+                        ],
+                        'operator' => [
+                            'type' => 'string',
+                            'description' => 'Comparison operator',
+                            'enum' => self::ALLOWED_OPERATORS,
+                        ],
+                        'value' => [
+                            'description' => 'Value to compare against (not needed for isNull/isNotNull). Use array for in/notIn.',
+                        ],
+                    ],
+                    'required' => ['field', 'operator'],
+                ],
             ],
             'limit' => [
                 'type' => 'integer',
@@ -143,7 +161,10 @@ class ReadTableTool extends AbstractRecordTool
                 fn($n) => $n > 0
             ));
         }
-        $condition = $params['where'] ?? '';
+        $filters = $params['filters'] ?? [];
+        if (!is_array($filters)) {
+            throw new ValidationException(['The "filters" parameter must be an array of filter objects']);
+        }
         $limit = isset($params['limit']) ? (int)$params['limit'] : 20;
         $offset = isset($params['offset']) ? (int)$params['offset'] : 0;
         $language = $params['language'] ?? null;
@@ -180,7 +201,7 @@ class ReadTableTool extends AbstractRecordTool
             $table,
             $pid,
             $uids,
-            $condition,
+            $filters,
             $limit,
             $offset,
             $languageUid,
@@ -206,7 +227,7 @@ class ReadTableTool extends AbstractRecordTool
         string $table,
         ?int $pid,
         ?array $uids,
-        string $condition,
+        array $filters,
         int $limit,
         int $offset,
         ?int $languageUid = null,
@@ -254,25 +275,9 @@ class ReadTableTool extends AbstractRecordTool
             $this->applyUidFilter($queryBuilder, $table, $uids);
         }
 
-        // Apply custom condition if specified
-        if (!empty($condition)) {
-            // Basic SQL injection protection
-            $disallowedKeywords = ['DROP', 'DELETE', 'UPDATE', 'INSERT', 'TRUNCATE', 'ALTER', 'CREATE'];
-            $containsDisallowed = false;
-
-            foreach ($disallowedKeywords as $keyword) {
-                if (stripos($condition, $keyword) !== false) {
-                    $containsDisallowed = true;
-                    break;
-                }
-            }
-
-            if ($containsDisallowed) {
-                throw new \InvalidArgumentException('The condition contains disallowed SQL keywords');
-            }
-
-            // Add the condition directly
-            $queryBuilder->andWhere($condition);
+        // Apply structured filters
+        if (!empty($filters)) {
+            $this->applyFilters($queryBuilder, $filters, $table);
         }
 
         // Apply default sorting from TCA
@@ -319,8 +324,8 @@ class ReadTableTool extends AbstractRecordTool
             $this->applyUidFilter($countQueryBuilder, $table, $uids);
         }
 
-        if (!empty($condition)) {
-            $countQueryBuilder->andWhere($condition);
+        if (!empty($filters)) {
+            $this->applyFilters($countQueryBuilder, $filters, $table);
         }
 
         // Allow listeners to add restrictions (e.g. file mounts, tenant scopes)
@@ -678,6 +683,155 @@ class ReadTableTool extends AbstractRecordTool
         }
 
         return $normalized;
+    }
+
+    private const ALLOWED_OPERATORS = [
+        'eq', 'neq', 'lt', 'lte', 'gt', 'gte',
+        'like', 'notLike',
+        'in', 'notIn',
+        'isNull', 'isNotNull',
+    ];
+
+    /**
+     * Apply structured filters to a query builder using parameterized queries.
+     *
+     * @param QueryBuilder $queryBuilder
+     * @param array $filters Array of filter definitions with field, operator, value
+     * @param string $table Table name for field validation
+     * @throws ValidationException
+     */
+    protected function applyFilters(QueryBuilder $queryBuilder, array $filters, string $table): void
+    {
+        // Build set of valid field names for this table (TCA columns + essential fields)
+        $essentialFields = $this->tableAccessService->getEssentialFields($table);
+        $validFields = array_merge(array_keys($GLOBALS['TCA'][$table]['columns'] ?? []), $essentialFields);
+        $validFieldsLower = [];
+        foreach ($validFields as $fieldName) {
+            $validFieldsLower[strtolower($fieldName)] = $fieldName;
+        }
+
+        // Operators that require a value
+        $valueRequiredOperators = ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'like', 'notLike', 'in', 'notIn'];
+
+        foreach ($filters as $index => $filter) {
+            if (!is_array($filter)) {
+                throw new ValidationException(["Filter at index {$index} must be an object"]);
+            }
+
+            $field = $filter['field'] ?? null;
+            $operator = $filter['operator'] ?? null;
+            $value = $filter['value'] ?? null;
+
+            if (empty($field) || !is_string($field)) {
+                throw new ValidationException(["Filter at index {$index} requires a 'field' string"]);
+            }
+
+            if (empty($operator) || !is_string($operator)) {
+                throw new ValidationException(["Filter at index {$index} requires an 'operator' string"]);
+            }
+
+            if (!in_array($operator, self::ALLOWED_OPERATORS, true)) {
+                throw new ValidationException(["Filter at index {$index} has invalid operator '{$operator}'. Allowed: " . implode(', ', self::ALLOWED_OPERATORS)]);
+            }
+
+            // Validate that comparison operators have a value
+            if (in_array($operator, $valueRequiredOperators, true) && $value === null) {
+                throw new ValidationException(["Filter at index {$index}: operator '{$operator}' requires a 'value'"]);
+            }
+
+            // Scalar comparison operators must receive a scalar value. Binding a
+            // non-scalar (array/object) through createNamedParameter() would otherwise
+            // fail inside DBAL at query time instead of as a clean validation error.
+            if (in_array($operator, ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'like', 'notLike'], true)
+                && !is_scalar($value)
+            ) {
+                throw new ValidationException(["Filter at index {$index}: operator '{$operator}' requires a scalar value"]);
+            }
+
+            // Validate field exists in table (case-insensitive lookup)
+            $resolvedField = $validFieldsLower[strtolower($field)] ?? null;
+            if ($resolvedField === null) {
+                throw new ValidationException(["Filter at index {$index} references unknown field '{$field}' in table '{$table}'"]);
+            }
+
+            // Verify the field is accessible (not excluded by TSconfig, permissions, etc.)
+            // Essential fields (uid, pid, type, label, etc.) are always allowed for filtering
+            if (!in_array($resolvedField, $essentialFields, true)
+                && !$this->tableAccessService->canAccessField($table, $resolvedField)
+            ) {
+                throw new ValidationException(["Filter at index {$index} references inaccessible field '{$resolvedField}' in table '{$table}'"]);
+            }
+
+            // Determine the parameter type from the actual PHP type — no string coercion
+            $paramType = ParameterType::STRING;
+            if (is_int($value)) {
+                $paramType = ParameterType::INTEGER;
+            } elseif (is_bool($value)) {
+                $paramType = ParameterType::INTEGER;
+                $value = (int)$value;
+            }
+
+            // Build the expression
+            $expr = $queryBuilder->expr();
+            switch ($operator) {
+                case 'eq':
+                    $queryBuilder->andWhere($expr->eq($resolvedField, $queryBuilder->createNamedParameter($value, $paramType)));
+                    break;
+                case 'neq':
+                    $queryBuilder->andWhere($expr->neq($resolvedField, $queryBuilder->createNamedParameter($value, $paramType)));
+                    break;
+                case 'lt':
+                    $queryBuilder->andWhere($expr->lt($resolvedField, $queryBuilder->createNamedParameter($value, $paramType)));
+                    break;
+                case 'lte':
+                    $queryBuilder->andWhere($expr->lte($resolvedField, $queryBuilder->createNamedParameter($value, $paramType)));
+                    break;
+                case 'gt':
+                    $queryBuilder->andWhere($expr->gt($resolvedField, $queryBuilder->createNamedParameter($value, $paramType)));
+                    break;
+                case 'gte':
+                    $queryBuilder->andWhere($expr->gte($resolvedField, $queryBuilder->createNamedParameter($value, $paramType)));
+                    break;
+                case 'like':
+                    $queryBuilder->andWhere($expr->like($resolvedField, $queryBuilder->createNamedParameter($value)));
+                    break;
+                case 'notLike':
+                    $queryBuilder->andWhere($expr->notLike($resolvedField, $queryBuilder->createNamedParameter($value)));
+                    break;
+                case 'in':
+                case 'notIn':
+                    if (!is_array($value) || $value === []) {
+                        throw new ValidationException(["Filter at index {$index}: '{$operator}' operator requires a non-empty array value"]);
+                    }
+                    foreach ($value as $element) {
+                        if (!is_scalar($element)) {
+                            throw new ValidationException(["Filter at index {$index}: '{$operator}' array values must all be scalar"]);
+                        }
+                    }
+                    $arrayType = $this->isIntegerArray($value)
+                        ? \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY
+                        : \TYPO3\CMS\Core\Database\Connection::PARAM_STR_ARRAY;
+                    $exprMethod = $operator === 'in' ? 'in' : 'notIn';
+                    $queryBuilder->andWhere($expr->$exprMethod(
+                        $resolvedField,
+                        $queryBuilder->createNamedParameter($value, $arrayType)
+                    ));
+                    break;
+                case 'isNull':
+                    $queryBuilder->andWhere($expr->isNull($resolvedField));
+                    break;
+                case 'isNotNull':
+                    $queryBuilder->andWhere($expr->isNotNull($resolvedField));
+                    break;
+            }
+        }
+    }
+
+    private function isIntegerArray(array $values): bool
+    {
+        return !empty($values) && array_reduce($values, static function (bool $carry, $v): bool {
+            return $carry && is_int($v);
+        }, true);
     }
 
     /**

--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -67,9 +67,27 @@ class ReadTableTool extends AbstractRecordTool
                 ],
                 'description' => 'Filter by record UID. Pass a single integer for one record, or an array of integers to fetch several at once — useful when reading inline-relation hints like "metadata: [1, 5]". Use the pid filter to read all records of a page.',
             ],
-            'where' => [
-                'type' => 'string',
-                'description' => 'SQL WHERE condition for filtering (without the WHERE keyword)',
+            'filters' => [
+                'type' => 'array',
+                'description' => 'Filter conditions applied with AND. Each filter has field, operator, and optionally value.',
+                'items' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'field' => [
+                            'type' => 'string',
+                            'description' => 'Column name to filter on',
+                        ],
+                        'operator' => [
+                            'type' => 'string',
+                            'description' => 'Comparison operator',
+                            'enum' => self::ALLOWED_OPERATORS,
+                        ],
+                        'value' => [
+                            'description' => 'Value to compare against (not needed for isNull/isNotNull). Use array for in/notIn.',
+                        ],
+                    ],
+                    'required' => ['field', 'operator'],
+                ],
             ],
             'limit' => [
                 'type' => 'integer',
@@ -143,7 +161,7 @@ class ReadTableTool extends AbstractRecordTool
                 fn($n) => $n > 0
             ));
         }
-        $condition = $params['where'] ?? '';
+        $filters = $params['filters'] ?? [];
         $limit = isset($params['limit']) ? (int)$params['limit'] : 20;
         $offset = isset($params['offset']) ? (int)$params['offset'] : 0;
         $language = $params['language'] ?? null;
@@ -180,7 +198,7 @@ class ReadTableTool extends AbstractRecordTool
             $table,
             $pid,
             $uids,
-            $condition,
+            $filters,
             $limit,
             $offset,
             $languageUid,
@@ -206,7 +224,7 @@ class ReadTableTool extends AbstractRecordTool
         string $table,
         ?int $pid,
         ?array $uids,
-        string $condition,
+        array $filters,
         int $limit,
         int $offset,
         ?int $languageUid = null,
@@ -284,25 +302,9 @@ class ReadTableTool extends AbstractRecordTool
             }
         }
 
-        // Apply custom condition if specified
-        if (!empty($condition)) {
-            // Basic SQL injection protection
-            $disallowedKeywords = ['DROP', 'DELETE', 'UPDATE', 'INSERT', 'TRUNCATE', 'ALTER', 'CREATE'];
-            $containsDisallowed = false;
-
-            foreach ($disallowedKeywords as $keyword) {
-                if (stripos($condition, $keyword) !== false) {
-                    $containsDisallowed = true;
-                    break;
-                }
-            }
-
-            if ($containsDisallowed) {
-                throw new \InvalidArgumentException('The condition contains disallowed SQL keywords');
-            }
-
-            // Add the condition directly
-            $queryBuilder->andWhere($condition);
+        // Apply structured filters
+        if (!empty($filters)) {
+            $this->applyFilters($queryBuilder, $filters, $table);
         }
 
         // Apply default sorting from TCA
@@ -374,8 +376,8 @@ class ReadTableTool extends AbstractRecordTool
             }
         }
 
-        if (!empty($condition)) {
-            $countQueryBuilder->andWhere($condition);
+        if (!empty($filters)) {
+            $this->applyFilters($countQueryBuilder, $filters, $table);
         }
 
         // Allow listeners to add restrictions (e.g. file mounts, tenant scopes)
@@ -687,6 +689,141 @@ class ReadTableTool extends AbstractRecordTool
         }
 
         return $normalized;
+    }
+
+    private const ALLOWED_OPERATORS = [
+        'eq', 'neq', 'lt', 'lte', 'gt', 'gte',
+        'like', 'notLike',
+        'in', 'notIn',
+        'isNull', 'isNotNull',
+    ];
+
+    /**
+     * Apply structured filters to a query builder using parameterized queries.
+     *
+     * @param QueryBuilder $queryBuilder
+     * @param array $filters Array of filter definitions with field, operator, value
+     * @param string $table Table name for field validation
+     * @throws ValidationException
+     */
+    protected function applyFilters(QueryBuilder $queryBuilder, array $filters, string $table): void
+    {
+        // Build set of valid field names for this table (TCA columns + essential fields)
+        $essentialFields = $this->tableAccessService->getEssentialFields($table);
+        $validFields = array_merge(array_keys($GLOBALS['TCA'][$table]['columns'] ?? []), $essentialFields);
+        $validFieldsLower = [];
+        foreach ($validFields as $fieldName) {
+            $validFieldsLower[strtolower($fieldName)] = $fieldName;
+        }
+
+        // Operators that require a value
+        $valueRequiredOperators = ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'like', 'notLike', 'in', 'notIn'];
+
+        foreach ($filters as $index => $filter) {
+            if (!is_array($filter)) {
+                throw new ValidationException(["Filter at index {$index} must be an object"]);
+            }
+
+            $field = $filter['field'] ?? null;
+            $operator = $filter['operator'] ?? null;
+            $value = $filter['value'] ?? null;
+
+            if (empty($field) || !is_string($field)) {
+                throw new ValidationException(["Filter at index {$index} requires a 'field' string"]);
+            }
+
+            if (empty($operator) || !is_string($operator)) {
+                throw new ValidationException(["Filter at index {$index} requires an 'operator' string"]);
+            }
+
+            if (!in_array($operator, self::ALLOWED_OPERATORS, true)) {
+                throw new ValidationException(["Filter at index {$index} has invalid operator '{$operator}'. Allowed: " . implode(', ', self::ALLOWED_OPERATORS)]);
+            }
+
+            // Validate that comparison operators have a value
+            if (in_array($operator, $valueRequiredOperators, true) && $value === null) {
+                throw new ValidationException(["Filter at index {$index}: operator '{$operator}' requires a 'value'"]);
+            }
+
+            // Validate field exists in table (case-insensitive lookup)
+            $resolvedField = $validFieldsLower[strtolower($field)] ?? null;
+            if ($resolvedField === null) {
+                throw new ValidationException(["Filter at index {$index} references unknown field '{$field}' in table '{$table}'"]);
+            }
+
+            // Verify the field is accessible (not excluded by TSconfig, permissions, etc.)
+            // Essential fields (uid, pid, type, label, etc.) are always allowed for filtering
+            if (!in_array($resolvedField, $essentialFields, true)
+                && !$this->tableAccessService->canAccessField($table, $resolvedField)
+            ) {
+                throw new ValidationException(["Filter at index {$index} references inaccessible field '{$resolvedField}' in table '{$table}'"]);
+            }
+
+            // Determine the parameter type from the actual PHP type — no string coercion
+            $paramType = ParameterType::STRING;
+            if (is_int($value)) {
+                $paramType = ParameterType::INTEGER;
+            } elseif (is_bool($value)) {
+                $paramType = ParameterType::INTEGER;
+                $value = (int)$value;
+            }
+
+            // Build the expression
+            $expr = $queryBuilder->expr();
+            switch ($operator) {
+                case 'eq':
+                    $queryBuilder->andWhere($expr->eq($resolvedField, $queryBuilder->createNamedParameter($value, $paramType)));
+                    break;
+                case 'neq':
+                    $queryBuilder->andWhere($expr->neq($resolvedField, $queryBuilder->createNamedParameter($value, $paramType)));
+                    break;
+                case 'lt':
+                    $queryBuilder->andWhere($expr->lt($resolvedField, $queryBuilder->createNamedParameter($value, $paramType)));
+                    break;
+                case 'lte':
+                    $queryBuilder->andWhere($expr->lte($resolvedField, $queryBuilder->createNamedParameter($value, $paramType)));
+                    break;
+                case 'gt':
+                    $queryBuilder->andWhere($expr->gt($resolvedField, $queryBuilder->createNamedParameter($value, $paramType)));
+                    break;
+                case 'gte':
+                    $queryBuilder->andWhere($expr->gte($resolvedField, $queryBuilder->createNamedParameter($value, $paramType)));
+                    break;
+                case 'like':
+                    $queryBuilder->andWhere($expr->like($resolvedField, $queryBuilder->createNamedParameter($value)));
+                    break;
+                case 'notLike':
+                    $queryBuilder->andWhere($expr->notLike($resolvedField, $queryBuilder->createNamedParameter($value)));
+                    break;
+                case 'in':
+                case 'notIn':
+                    if (!is_array($value)) {
+                        throw new ValidationException(["Filter at index {$index}: '{$operator}' operator requires an array value"]);
+                    }
+                    $arrayType = $this->isIntegerArray($value)
+                        ? \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY
+                        : \TYPO3\CMS\Core\Database\Connection::PARAM_STR_ARRAY;
+                    $exprMethod = $operator === 'in' ? 'in' : 'notIn';
+                    $queryBuilder->andWhere($expr->$exprMethod(
+                        $resolvedField,
+                        $queryBuilder->createNamedParameter($value, $arrayType)
+                    ));
+                    break;
+                case 'isNull':
+                    $queryBuilder->andWhere($expr->isNull($resolvedField));
+                    break;
+                case 'isNotNull':
+                    $queryBuilder->andWhere($expr->isNotNull($resolvedField));
+                    break;
+            }
+        }
+    }
+
+    private function isIntegerArray(array $values): bool
+    {
+        return !empty($values) && array_reduce($values, static function (bool $carry, $v): bool {
+            return $carry && is_int($v);
+        }, true);
     }
 
     /**

--- a/Tests/Functional/MCP/Tool/EdgeCase/DatabaseErrorTest.php
+++ b/Tests/Functional/MCP/Tool/EdgeCase/DatabaseErrorTest.php
@@ -71,7 +71,9 @@ class DatabaseErrorTest extends AbstractFunctionalTest
         // Try a complex search that might be slow
         $result = $this->readTool->execute([
             'table' => 'pages',
-            'where' => "title LIKE '%Timeout%'"
+            'filters' => [
+                ['field' => 'title', 'operator' => 'like', 'value' => '%Timeout%'],
+            ],
         ]);
         
         // Should handle even complex queries

--- a/Tests/Functional/MCP/Tool/EdgeCase/ResourceConstraintTest.php
+++ b/Tests/Functional/MCP/Tool/EdgeCase/ResourceConstraintTest.php
@@ -67,7 +67,9 @@ class ResourceConstraintTest extends AbstractFunctionalTest
         // Test reading with no limit
         $result = $this->readTool->execute([
             'table' => 'tt_content',
-            'where' => 'pid = 1'
+            'filters' => [
+                ['field' => 'pid', 'operator' => 'eq', 'value' => 1],
+            ],
         ]);
         
         $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
@@ -92,7 +94,9 @@ class ResourceConstraintTest extends AbstractFunctionalTest
         // Try to read with huge IN clause
         $result = $this->readTool->execute([
             'table' => 'pages',
-            'where' => 'uid IN (' . implode(',', array_slice($uids, 0, 1000)) . ')' // Limit to 1000 to avoid SQL issues
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'in', 'value' => array_slice($uids, 0, 1000)],
+            ],
         ]);
         
         // Should handle this gracefully (maybe by batching)
@@ -129,7 +133,9 @@ class ResourceConstraintTest extends AbstractFunctionalTest
         // Try to read pages with complex conditions
         $result = $this->readTool->execute([
             'table' => 'pages',
-            'where' => "title LIKE '%Level%'"
+            'filters' => [
+                ['field' => 'title', 'operator' => 'like', 'value' => '%Level%'],
+            ],
         ]);
         
         // Should handle deep structures without stack overflow
@@ -271,68 +277,25 @@ class ResourceConstraintTest extends AbstractFunctionalTest
             }
         }
     }
-    
+
+
     /**
-     * Helper method to build WHERE clause from array structure
+     * Test handling of many structured filters
      */
-    protected function buildWhereClause(array $where): string
+    public function testManyFiltersHandling(): void
     {
-        if (isset($where['type']) && $where['type'] === 'AND') {
-            $conditions = [];
-            foreach ($where['conditions'] as $condition) {
-                if (isset($condition['type']) && $condition['type'] === 'OR') {
-                    $orConditions = [];
-                    foreach ($condition['conditions'] as $orCond) {
-                        $orConditions[] = sprintf(
-                            "%s %s '%s'",
-                            $orCond['field'],
-                            $orCond['operator'],
-                            $orCond['value']
-                        );
-                    }
-                    $conditions[] = '(' . implode(' OR ', $orConditions) . ')';
-                }
-            }
-            return implode(' AND ', $conditions);
-        }
-        return '1=1';
-    }
-    
-    /**
-     * Test handling of query complexity limits
-     */
-    public function testQueryComplexityLimits(): void
-    {
-        // Build a very complex where clause
-        $complexWhere = [
-            'type' => 'AND',
-            'conditions' => []
-        ];
-        
-        // Add many conditions
+        // Build a large set of filters
+        $filters = [];
         for ($i = 0; $i < 50; $i++) {
-            $complexWhere['conditions'][] = [
-                'type' => 'OR',
-                'conditions' => [
-                    ['field' => 'title', 'operator' => 'like', 'value' => "%test$i%"],
-                    ['field' => 'description', 'operator' => 'like', 'value' => "%test$i%"],
-                ]
-            ];
+            $filters[] = ['field' => 'title', 'operator' => 'notLike', 'value' => "%nonexistent$i%"];
         }
-        
-        // Build SQL where clause from the complex structure
-        $whereClause = $this->buildWhereClause($complexWhere);
-        
+
         $result = $this->readTool->execute([
             'table' => 'pages',
-            'where' => $whereClause
+            'filters' => $filters,
         ]);
-        
-        // Should handle complex queries or fail gracefully
-        if ($result->isError) {
-            $this->assertStringContainsString('complex', $result->content[0]->text);
-        } else {
-            $this->assertIsArray(json_decode($result->content[0]->text, true));
-        }
+
+        // Should handle many filters gracefully
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
     }
 }

--- a/Tests/Functional/MCP/Tool/ErrorHandlingTest.php
+++ b/Tests/Functional/MCP/Tool/ErrorHandlingTest.php
@@ -177,23 +177,23 @@ class ErrorHandlingTest extends AbstractFunctionalTest
     }
     
     /**
-     * Test that database exceptions are properly caught and converted
+     * Test that invalid filter fields are properly rejected
      */
-    public function testDatabaseExceptionHandling(): void
+    public function testInvalidFilterFieldHandling(): void
     {
         $tool = new ReadTableTool();
-        
-        // Create a condition that would cause a database error
-        // Using invalid SQL syntax in where clause
+
+        // Using a nonexistent field should produce a validation error
         $result = $tool->execute([
             'table' => 'pages',
-            'where' => 'invalid SQL syntax @@@ error'
+            'filters' => [
+                ['field' => 'nonexistent_column', 'operator' => 'eq', 'value' => 'test'],
+            ],
         ]);
-        
-        // Should handle the database error gracefully
+
+        // Should handle the error gracefully
         $this->assertTrue($result->isError, json_encode($result->jsonSerialize()));
-        // The error message should be user-friendly, not exposing SQL details
-        $this->assertStringNotContainsString('@@@ error', $result->content[0]->text);
+        $this->assertStringContainsString('unknown field', $result->content[0]->text);
     }
     
     /**

--- a/Tests/Functional/MCP/Tool/ReadTableFilterSecurityTest.php
+++ b/Tests/Functional/MCP/Tool/ReadTableFilterSecurityTest.php
@@ -1,0 +1,433 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use Hn\McpServer\MCP\Tool\Record\ReadTableTool;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use Hn\McpServer\Tests\Functional\Traits\McpAssertionsTrait;
+
+/**
+ * Tests for structured filter parameter replacing the raw WHERE condition.
+ *
+ * The raw "where" parameter accepted arbitrary SQL fragments with only a trivially-
+ * bypassable keyword blacklist. These tests verify the new "filters" parameter
+ * provides equivalent functionality through parameterized queries only.
+ */
+class ReadTableFilterSecurityTest extends AbstractFunctionalTest
+{
+    use McpAssertionsTrait;
+
+    private ReadTableTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tool = new ReadTableTool();
+    }
+
+    // ─── Schema tests ────────────────────────────────────────────────
+
+    public function testSchemaHasFiltersParameter(): void
+    {
+        $schema = $this->tool->getSchema();
+        $properties = $schema['inputSchema']['properties'];
+
+        $this->assertArrayHasKey('filters', $properties, 'Schema must expose a "filters" parameter');
+        $this->assertEquals('array', $properties['filters']['type']);
+        $this->assertArrayHasKey('items', $properties['filters']);
+    }
+
+    public function testSchemaDoesNotExposeWhereParameter(): void
+    {
+        $schema = $this->tool->getSchema();
+        $properties = $schema['inputSchema']['properties'];
+
+        $this->assertArrayNotHasKey('where', $properties, 'Raw "where" parameter must be removed from schema');
+    }
+
+    // ─── Basic filter functionality ──────────────────────────────────
+
+    public function testFilterByEquality(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'CType', 'operator' => 'eq', 'value' => 'textmedia'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $this->assertGreaterThan(0, count($data['records']));
+        foreach ($data['records'] as $record) {
+            $this->assertEquals('textmedia', $record['CType']);
+        }
+    }
+
+    public function testFilterByNotEqual(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'CType', 'operator' => 'neq', 'value' => 'textmedia'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        foreach ($data['records'] as $record) {
+            $this->assertNotEquals('textmedia', $record['CType']);
+        }
+    }
+
+    public function testFilterByLike(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'header', 'operator' => 'like', 'value' => '%Welcome%'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $this->assertGreaterThan(0, count($data['records']));
+        foreach ($data['records'] as $record) {
+            $this->assertStringContainsString('Welcome', $record['header']);
+        }
+    }
+
+    public function testFilterByGreaterThan(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'gt', 'value' => 100],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        foreach ($data['records'] as $record) {
+            $this->assertGreaterThan(100, $record['uid']);
+        }
+    }
+
+    public function testFilterByLessThan(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'lt', 'value' => 105],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        foreach ($data['records'] as $record) {
+            $this->assertLessThan(105, $record['uid']);
+        }
+    }
+
+    public function testFilterByIn(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'in', 'value' => [100, 101]],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $uids = array_column($data['records'], 'uid');
+        $this->assertCount(2, $uids);
+        $this->assertContains(100, $uids);
+        $this->assertContains(101, $uids);
+    }
+
+    public function testFilterByLessThanOrEqual(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'lte', 'value' => 100],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        foreach ($data['records'] as $record) {
+            $this->assertLessThanOrEqual(100, $record['uid']);
+        }
+    }
+
+    public function testFilterByGreaterThanOrEqual(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'gte', 'value' => 105],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        foreach ($data['records'] as $record) {
+            $this->assertGreaterThanOrEqual(105, $record['uid']);
+        }
+    }
+
+    public function testFilterByNotLike(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'header', 'operator' => 'notLike', 'value' => '%Welcome%'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        foreach ($data['records'] as $record) {
+            $this->assertStringNotContainsString('Welcome', $record['header'] ?? '');
+        }
+    }
+
+    public function testFilterByNotIn(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'notIn', 'value' => [100, 101]],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $uids = array_column($data['records'], 'uid');
+        $this->assertNotContains(100, $uids);
+        $this->assertNotContains(101, $uids);
+    }
+
+    public function testFilterByIsNull(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'header', 'operator' => 'isNull'],
+            ],
+        ]);
+
+        // Should succeed (even if zero results)
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+    }
+
+    public function testFilterByIsNotNull(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'header', 'operator' => 'isNotNull'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+        $this->assertGreaterThan(0, count($data['records']));
+    }
+
+    // ─── Multiple filters (AND combination) ──────────────────────────
+
+    public function testMultipleFiltersAreCombinedWithAnd(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'CType', 'operator' => 'eq', 'value' => 'textmedia'],
+                ['field' => 'pid', 'operator' => 'eq', 'value' => 1],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        foreach ($data['records'] as $record) {
+            $this->assertEquals('textmedia', $record['CType']);
+            $this->assertEquals(1, $record['pid']);
+        }
+    }
+
+    // ─── Validation: reject invalid filters ──────────────────────────
+
+    public function testRejectsInvalidOperator(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'UNION SELECT', 'value' => '1'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'Invalid operator must be rejected');
+    }
+
+    public function testRejectsFilterWithoutField(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['operator' => 'eq', 'value' => '1'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'Filter without field must be rejected');
+    }
+
+    public function testRejectsFilterWithoutOperator(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'value' => '1'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'Filter without operator must be rejected');
+    }
+
+    public function testRejectsFieldNotInTable(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'nonexistent_field', 'operator' => 'eq', 'value' => '1'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'Field not in table must be rejected');
+    }
+
+    public function testRejectsFieldWithSqlInjectionAttempt(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid; DROP TABLE pages', 'operator' => 'eq', 'value' => '1'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'SQL injection in field name must be rejected');
+    }
+
+    public function testRejectsComparisonOperatorWithoutValue(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'eq'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'Comparison operator without value must be rejected');
+    }
+
+    public function testNotInOperatorRequiresArrayValue(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'notIn', 'value' => 'not-an-array'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'notIn operator with non-array value must be rejected');
+    }
+
+    // ─── Security: raw WHERE must be rejected ────────────────────────
+
+    public function testRawWhereParameterIsRejectedOrIgnored(): void
+    {
+        // Even if someone passes "where", it must have no effect
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'where' => 'uid > 0 UNION SELECT username,password FROM be_users',
+        ]);
+
+        // Either: error (rejected) or success with normal results (ignored)
+        if (!$result->isError) {
+            $data = $this->extractJsonFromResult($result);
+            // If not an error, the WHERE must have been completely ignored
+            // — verify no be_users data leaked
+            foreach ($data['records'] as $record) {
+                $this->assertArrayNotHasKey('username', $record);
+                $this->assertArrayNotHasKey('password', $record);
+            }
+        }
+    }
+
+    // ─── Count query uses same filters ───────────────────────────────
+
+    public function testFiltersApplyToTotalCount(): void
+    {
+        // Get filtered result with a high limit to avoid pagination mismatch
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'limit' => 1000,
+            'filters' => [
+                ['field' => 'CType', 'operator' => 'eq', 'value' => 'textmedia'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        // Total count must match the number of actual textmedia records, not all records
+        $this->assertEquals(count($data['records']), $data['total']);
+    }
+
+    // ─── Backwards compatibility: filters + pid/uid coexist ──────────
+
+    public function testFiltersCombineWithPidParameter(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'pid' => 1,
+            'filters' => [
+                ['field' => 'CType', 'operator' => 'eq', 'value' => 'textmedia'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        foreach ($data['records'] as $record) {
+            $this->assertEquals('textmedia', $record['CType']);
+            $this->assertEquals(1, $record['pid']);
+        }
+    }
+
+    public function testInOperatorRequiresArrayValue(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'in', 'value' => 'not-an-array'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'in operator with non-array value must be rejected');
+    }
+}

--- a/Tests/Functional/MCP/Tool/ReadTableFilterSecurityTest.php
+++ b/Tests/Functional/MCP/Tool/ReadTableFilterSecurityTest.php
@@ -1,0 +1,505 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use Hn\McpServer\MCP\Tool\Record\ReadTableTool;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use Hn\McpServer\Tests\Functional\Traits\McpAssertionsTrait;
+
+/**
+ * Tests for structured filter parameter replacing the raw WHERE condition.
+ *
+ * The raw "where" parameter accepted arbitrary SQL fragments with only a trivially-
+ * bypassable keyword blacklist. These tests verify the new "filters" parameter
+ * provides equivalent functionality through parameterized queries only.
+ */
+class ReadTableFilterSecurityTest extends AbstractFunctionalTest
+{
+    use McpAssertionsTrait;
+
+    private ReadTableTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tool = new ReadTableTool();
+    }
+
+    // ─── Schema tests ────────────────────────────────────────────────
+
+    public function testSchemaHasFiltersParameter(): void
+    {
+        $schema = $this->tool->getSchema();
+        $properties = $schema['inputSchema']['properties'];
+
+        $this->assertArrayHasKey('filters', $properties, 'Schema must expose a "filters" parameter');
+        $this->assertEquals('array', $properties['filters']['type']);
+        $this->assertArrayHasKey('items', $properties['filters']);
+    }
+
+    public function testSchemaDoesNotExposeWhereParameter(): void
+    {
+        $schema = $this->tool->getSchema();
+        $properties = $schema['inputSchema']['properties'];
+
+        $this->assertArrayNotHasKey('where', $properties, 'Raw "where" parameter must be removed from schema');
+    }
+
+    // ─── Basic filter functionality ──────────────────────────────────
+
+    public function testFilterByEquality(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'CType', 'operator' => 'eq', 'value' => 'textmedia'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $this->assertGreaterThan(0, count($data['records']));
+        foreach ($data['records'] as $record) {
+            $this->assertEquals('textmedia', $record['CType']);
+        }
+    }
+
+    public function testFilterByNotEqual(): void
+    {
+        // All fixture rows share CType=textmedia, so filter on a field with
+        // varied values to exercise neq against a non-empty result set.
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'header', 'operator' => 'neq', 'value' => 'Welcome Header'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $this->assertGreaterThan(0, count($data['records']));
+        foreach ($data['records'] as $record) {
+            $this->assertNotEquals('Welcome Header', $record['header']);
+        }
+    }
+
+    public function testFilterByLike(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'header', 'operator' => 'like', 'value' => '%Welcome%'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $this->assertGreaterThan(0, count($data['records']));
+        foreach ($data['records'] as $record) {
+            // LIKE resolves against a case-insensitive collation, so compare case-insensitively.
+            $this->assertStringContainsStringIgnoringCase('Welcome', $record['header']);
+        }
+    }
+
+    public function testFilterByGreaterThan(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'gt', 'value' => 100],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $this->assertGreaterThan(0, count($data['records']));
+        foreach ($data['records'] as $record) {
+            $this->assertGreaterThan(100, $record['uid']);
+        }
+    }
+
+    public function testFilterByLessThan(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'lt', 'value' => 105],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $this->assertGreaterThan(0, count($data['records']));
+        foreach ($data['records'] as $record) {
+            $this->assertLessThan(105, $record['uid']);
+        }
+    }
+
+    public function testFilterByIn(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'in', 'value' => [100, 101]],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $uids = array_column($data['records'], 'uid');
+        $this->assertCount(2, $uids);
+        $this->assertContains(100, $uids);
+        $this->assertContains(101, $uids);
+    }
+
+    public function testFilterByLessThanOrEqual(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'lte', 'value' => 100],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $this->assertGreaterThan(0, count($data['records']));
+        foreach ($data['records'] as $record) {
+            $this->assertLessThanOrEqual(100, $record['uid']);
+        }
+    }
+
+    public function testFilterByGreaterThanOrEqual(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'gte', 'value' => 105],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $this->assertGreaterThan(0, count($data['records']));
+        foreach ($data['records'] as $record) {
+            $this->assertGreaterThanOrEqual(105, $record['uid']);
+        }
+    }
+
+    public function testFilterByNotLike(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'header', 'operator' => 'notLike', 'value' => '%Welcome%'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        foreach ($data['records'] as $record) {
+            $this->assertStringNotContainsStringIgnoringCase('Welcome', $record['header'] ?? '');
+        }
+    }
+
+    public function testFilterByNotIn(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'notIn', 'value' => [100, 101]],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $this->assertGreaterThan(0, count($data['records']));
+        $uids = array_column($data['records'], 'uid');
+        $this->assertNotContains(100, $uids);
+        $this->assertNotContains(101, $uids);
+    }
+
+    public function testFilterByIsNull(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'header', 'operator' => 'isNull'],
+            ],
+        ]);
+
+        // Should succeed (even if zero results)
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+    }
+
+    public function testFilterByIsNotNull(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'header', 'operator' => 'isNotNull'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+        $this->assertGreaterThan(0, count($data['records']));
+    }
+
+    // ─── Multiple filters (AND combination) ──────────────────────────
+
+    public function testMultipleFiltersAreCombinedWithAnd(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'CType', 'operator' => 'eq', 'value' => 'textmedia'],
+                ['field' => 'pid', 'operator' => 'eq', 'value' => 1],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $this->assertGreaterThan(0, count($data['records']));
+        foreach ($data['records'] as $record) {
+            $this->assertEquals('textmedia', $record['CType']);
+            $this->assertEquals(1, $record['pid']);
+        }
+    }
+
+    // ─── Validation: reject invalid filters ──────────────────────────
+
+    public function testRejectsInvalidOperator(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'UNION SELECT', 'value' => '1'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'Invalid operator must be rejected');
+    }
+
+    public function testRejectsFilterWithoutField(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['operator' => 'eq', 'value' => '1'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'Filter without field must be rejected');
+    }
+
+    public function testRejectsFilterWithoutOperator(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'value' => '1'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'Filter without operator must be rejected');
+    }
+
+    public function testRejectsFieldNotInTable(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'nonexistent_field', 'operator' => 'eq', 'value' => '1'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'Field not in table must be rejected');
+    }
+
+    public function testRejectsFieldWithSqlInjectionAttempt(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid; DROP TABLE pages', 'operator' => 'eq', 'value' => '1'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'SQL injection in field name must be rejected');
+    }
+
+    public function testRejectsComparisonOperatorWithoutValue(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'eq'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'Comparison operator without value must be rejected');
+    }
+
+    public function testNotInOperatorRequiresArrayValue(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'notIn', 'value' => 'not-an-array'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'notIn operator with non-array value must be rejected');
+    }
+
+    public function testInOperatorRequiresArrayValue(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'in', 'value' => 'not-an-array'],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'in operator with non-array value must be rejected');
+    }
+
+    public function testRejectsNonArrayFiltersParameter(): void
+    {
+        // A scalar "filters" value must produce a clean validation error,
+        // not a TypeError when forwarded to the typed array argument.
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => 'CType = textmedia',
+        ]);
+
+        $this->assertTrue($result->isError, 'Non-array filters parameter must be rejected');
+    }
+
+    public function testRejectsScalarOperatorWithArrayValue(): void
+    {
+        // Binding an array through a scalar operator would fail inside DBAL at
+        // query time; it must be rejected up front instead.
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'eq', 'value' => [100, 101]],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'Scalar operator with array value must be rejected');
+    }
+
+    public function testRejectsEmptyInArray(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'in', 'value' => []],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'in operator with empty array must be rejected');
+    }
+
+    public function testRejectsNestedInArray(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'filters' => [
+                ['field' => 'uid', 'operator' => 'in', 'value' => [[100, 101]]],
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'in operator with non-scalar array values must be rejected');
+    }
+
+    // ─── Security: raw WHERE must be rejected ────────────────────────
+
+    public function testRawWhereParameterIsRejectedOrIgnored(): void
+    {
+        // Baseline: the identical query without any raw "where".
+        $baseline = $this->tool->execute(['table' => 'tt_content', 'limit' => 1000]);
+        $this->assertFalse($baseline->isError, json_encode($baseline->jsonSerialize()));
+        $baselineData = $this->extractJsonFromResult($baseline);
+
+        // Even if someone passes "where", it must have no effect
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'limit' => 1000,
+            'where' => 'uid > 0 UNION SELECT username,password FROM be_users',
+        ]);
+
+        // Either: error (rejected) or success with the exact unfiltered baseline (ignored)
+        if (!$result->isError) {
+            $data = $this->extractJsonFromResult($result);
+
+            // The injected WHERE must neither narrow nor expand the result set —
+            // a regression that silently re-applies it would change these counts.
+            $this->assertSame($baselineData['total'], $data['total']);
+            $this->assertCount(count($baselineData['records']), $data['records']);
+
+            // ...and no be_users data may leak.
+            foreach ($data['records'] as $record) {
+                $this->assertArrayNotHasKey('username', $record);
+                $this->assertArrayNotHasKey('password', $record);
+            }
+        }
+    }
+
+    // ─── Count query uses same filters ───────────────────────────────
+
+    public function testFiltersApplyToTotalCount(): void
+    {
+        // Get filtered result with a high limit to avoid pagination mismatch
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'limit' => 1000,
+            'filters' => [
+                ['field' => 'CType', 'operator' => 'eq', 'value' => 'textmedia'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        // Total count must match the number of actual textmedia records, not all records
+        $this->assertEquals(count($data['records']), $data['total']);
+    }
+
+    // ─── Backwards compatibility: filters + pid/uid coexist ──────────
+
+    public function testFiltersCombineWithPidParameter(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'pid' => 1,
+            'filters' => [
+                ['field' => 'CType', 'operator' => 'eq', 'value' => 'textmedia'],
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $data = $this->extractJsonFromResult($result);
+
+        $this->assertGreaterThan(0, count($data['records']));
+        foreach ($data['records'] as $record) {
+            $this->assertEquals('textmedia', $record['CType']);
+            $this->assertEquals(1, $record['pid']);
+        }
+    }
+}

--- a/Tests/Functional/MCP/Tool/ReadTableToolTest.php
+++ b/Tests/Functional/MCP/Tool/ReadTableToolTest.php
@@ -207,42 +207,55 @@ class ReadTableToolTest extends AbstractFunctionalTest
     }
 
     /**
-     * Test reading with custom WHERE condition
+     * Test reading with structured filters
      */
-    public function testReadWithWhereCondition(): void
+    public function testReadWithFilters(): void
     {
         $tool = new ReadTableTool();
-        
+
         $result = $tool->execute([
             'table' => 'tt_content',
-            'where' => 'CType = "textmedia"',
+            'filters' => [
+                ['field' => 'CType', 'operator' => 'eq', 'value' => 'textmedia'],
+            ],
             'includeRelations' => false
         ]);
-        
-        $this->assertFalse($result->isError);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
         $data = json_decode($result->content[0]->text, true);
-        
+
         // All returned records should have CType = textmedia
+        $this->assertGreaterThan(0, count($data['records']));
         foreach ($data['records'] as $record) {
             $this->assertEquals('textmedia', $record['CType']);
         }
     }
 
     /**
-     * Test WHERE condition security (should block dangerous SQL)
+     * Test that raw WHERE parameter is no longer accepted
      */
-    public function testWhereConditionSecurity(): void
+    public function testRawWhereParameterIsIgnored(): void
     {
         $tool = new ReadTableTool();
-        
-        // Try to inject dangerous SQL
-        $result = $tool->execute([
-            'table' => 'pages',
-            'where' => 'uid = 1; DROP TABLE pages',
+
+        // Passing "where" should have no filtering effect (parameter removed)
+        $resultWithWhere = $tool->execute([
+            'table' => 'tt_content',
+            'where' => 'CType = "textmedia"',
         ]);
-        
-        $this->assertTrue($result->isError);
-        $this->assertStringContainsString('disallowed SQL keywords', $result->content[0]->text);
+
+        $resultWithout = $tool->execute([
+            'table' => 'tt_content',
+        ]);
+
+        $this->assertFalse($resultWithWhere->isError, json_encode($resultWithWhere->jsonSerialize()));
+        $this->assertFalse($resultWithout->isError, json_encode($resultWithout->jsonSerialize()));
+
+        $dataWith = json_decode($resultWithWhere->content[0]->text, true);
+        $dataWithout = json_decode($resultWithout->content[0]->text, true);
+
+        // Both should return the same records since "where" is ignored
+        $this->assertEquals($dataWith['total'], $dataWithout['total']);
     }
 
     /**
@@ -265,7 +278,7 @@ class ReadTableToolTest extends AbstractFunctionalTest
         $this->assertArrayHasKey('uid', $properties);
         $this->assertArrayHasKey('limit', $properties);
         $this->assertArrayHasKey('offset', $properties);
-        $this->assertArrayHasKey('where', $properties);
+        $this->assertArrayHasKey('filters', $properties);
     }
 
     /**

--- a/Tests/Functional/MCP/Tool/ReadTableToolTest.php
+++ b/Tests/Functional/MCP/Tool/ReadTableToolTest.php
@@ -207,21 +207,23 @@ class ReadTableToolTest extends AbstractFunctionalTest
     }
 
     /**
-     * Test reading with custom WHERE condition
+     * Test reading with structured filters
      */
-    public function testReadWithWhereCondition(): void
+    public function testReadWithFilters(): void
     {
         $tool = new ReadTableTool();
-        
+
         $result = $tool->execute([
             'table' => 'tt_content',
-            'where' => 'CType = "textmedia"',
+            'filters' => [
+                ['field' => 'CType', 'operator' => 'eq', 'value' => 'textmedia'],
+            ],
             'includeRelations' => false
         ]);
-        
-        $this->assertFalse($result->isError);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
         $data = json_decode($result->content[0]->text, true);
-        
+
         // All returned records should have CType = textmedia
         foreach ($data['records'] as $record) {
             $this->assertEquals('textmedia', $record['CType']);
@@ -229,20 +231,30 @@ class ReadTableToolTest extends AbstractFunctionalTest
     }
 
     /**
-     * Test WHERE condition security (should block dangerous SQL)
+     * Test that raw WHERE parameter is no longer accepted
      */
-    public function testWhereConditionSecurity(): void
+    public function testRawWhereParameterIsIgnored(): void
     {
         $tool = new ReadTableTool();
-        
-        // Try to inject dangerous SQL
-        $result = $tool->execute([
-            'table' => 'pages',
-            'where' => 'uid = 1; DROP TABLE pages',
+
+        // Passing "where" should have no filtering effect (parameter removed)
+        $resultWithWhere = $tool->execute([
+            'table' => 'tt_content',
+            'where' => 'CType = "textmedia"',
         ]);
-        
-        $this->assertTrue($result->isError);
-        $this->assertStringContainsString('disallowed SQL keywords', $result->content[0]->text);
+
+        $resultWithout = $tool->execute([
+            'table' => 'tt_content',
+        ]);
+
+        $this->assertFalse($resultWithWhere->isError, json_encode($resultWithWhere->jsonSerialize()));
+        $this->assertFalse($resultWithout->isError, json_encode($resultWithout->jsonSerialize()));
+
+        $dataWith = json_decode($resultWithWhere->content[0]->text, true);
+        $dataWithout = json_decode($resultWithout->content[0]->text, true);
+
+        // Both should return the same records since "where" is ignored
+        $this->assertEquals($dataWith['total'], $dataWithout['total']);
     }
 
     /**
@@ -265,7 +277,7 @@ class ReadTableToolTest extends AbstractFunctionalTest
         $this->assertArrayHasKey('uid', $properties);
         $this->assertArrayHasKey('limit', $properties);
         $this->assertArrayHasKey('offset', $properties);
-        $this->assertArrayHasKey('where', $properties);
+        $this->assertArrayHasKey('filters', $properties);
     }
 
     /**


### PR DESCRIPTION
## Summary

The ReadTable tool's `where` parameter accepted arbitrary SQL fragments with only a 7-keyword blacklist (DROP, DELETE, UPDATE, INSERT, TRUNCATE, ALTER, CREATE). This was trivially bypassable via UNION SELECT, subqueries, CASE/WHEN, and function calls — enabling data exfiltration from any table accessible to the backend user.

## Changes

- **Replace `where` with `filters`**: Structured array of `{field, operator, value}` objects using parameterized queries exclusively
- **Field validation**: Against TCA columns and essential fields, with access control enforcement via `canAccessField()`
- **Operator whitelist**: 12 safe comparison operators (eq, neq, lt, lte, gt, gte, like, notLike, in, notIn, isNull, isNotNull)
- **Parameterized values**: All values through `createNamedParameter()` with proper ParameterType
- **Value validation**: Comparison operators require a non-null value; in/notIn require arrays
- **Test runner**: Docker-based `Build/runTests.sh` matching CI environment (PHP 8.3, SQLite)

## Breaking change

`where` parameter replaced by `filters` — per project rules, MCP tool parameters don't need backwards compatibility. Old `where` parameter is silently ignored.

## Test plan

- [x] All 441 functional tests pass
- [x] 26 new security-focused tests covering all operators, validation, and injection rejection
- [x] Existing tests migrated from `where` to `filters`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured table read filtering via a `filters` array (`{field, operator, value}`), supporting equality/inequality, `like/notLike`, range comparisons, `in/notIn`, and null checks.
  * Multiple filters are combined with AND and applied consistently to both returned records and the total count.
* **Bug Fixes**
  * Legacy raw `where` input is no longer supported; invalid/unsafe filter definitions now return clear errors.
* **Tests**
  * Updated and expanded functional coverage for schema exposure, operator/value validation, malformed inputs, security edge cases, and large filter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->