### PR TITLE
fix: handle foreign type notation in type field resolution

### DIFF
--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -691,8 +691,16 @@ class TableAccessService implements SingletonInterface
      */
     public function getTypeFieldName(string $table): ?string
     {
-        $ctrl = $GLOBALS['TCA'][$table]['ctrl'] ?? [];
-        return $ctrl['type'] ?? null;
+        $typeField = $GLOBALS['TCA'][$table]['ctrl']['type'] ?? null;
+
+        // Foreign type notation (e.g. "uid_local:type") derives the record type
+        // from a related record's field. This is not a local column and must not
+        // be used in SQL queries or field lookups.
+        if ($typeField !== null && str_contains($typeField, ':')) {
+            return null;
+        }
+
+        return $typeField;
     }
     
     /**
@@ -876,7 +884,13 @@ class TableAccessService implements SingletonInterface
         if (!$typeField) {
             return ['1' => 'Default'];
         }
-        
+
+        // Defense-in-depth: foreign type notation should already be caught by
+        // getTypeFieldName() returning null, but guard here in case that changes.
+        if (str_contains($typeField, ':')) {
+            return ['0' => 'Default'];
+        }
+
         $typeConfig = $GLOBALS['TCA'][$table]['columns'][$typeField]['config'] ?? [];
         $items = $typeConfig['items'] ?? [];
         

--- a/Tests/Functional/Service/TableAccessServiceFieldAccessTest.php
+++ b/Tests/Functional/Service/TableAccessServiceFieldAccessTest.php
@@ -157,4 +157,28 @@ class TableAccessServiceFieldAccessTest extends FunctionalTestCase
             }
         }
     }
+
+    /**
+     * Foreign type notation (e.g. "uid_local:type" in sys_file_reference) must
+     * return null from getTypeFieldName since it is not a local column.
+     */
+    public function testForeignTypeNotationReturnsNullForTypeField(): void
+    {
+        // sys_file_reference has ctrl.type = 'uid_local:type'
+        $typeField = $this->service->getTypeFieldName('sys_file_reference');
+
+        $this->assertNull($typeField, 'Foreign type notation should return null');
+    }
+
+    /**
+     * Tables with foreign type notation must still return a usable types list.
+     */
+    public function testForeignTypeNotationReturnsDefaultType(): void
+    {
+        $types = $this->service->getAvailableTypes('sys_file_reference');
+
+        $this->assertNotEmpty($types, 'Should return at least one default type');
+        $this->assertArrayHasKey('1', $types, 'Foreign type tables fall through to typeless default (key "1")');
+        $this->assertSame('Default', $types['1']);
+    }
 }


### PR DESCRIPTION
Tables like sys_file_reference use 'uid_local:type' as their ctrl.type, deriving the record type from a related record's field. This notation is not a local database column and caused SQL errors when passed to BackendUtility::getRecord() or used in field lookups.

getTypeFieldName() now returns null for foreign type notation (contains ':'), treating these tables as typeless. getAvailableTypes() has an additional guard as defense-in-depth.