### PR TITLE
fix: correct misleading schema descriptions in GetTableSchema and Lis…

### DIFF
--- a/Classes/MCP/Tool/Record/GetTableSchemaTool.php
+++ b/Classes/MCP/Tool/Record/GetTableSchemaTool.php
@@ -37,7 +37,9 @@ class GetTableSchemaTool extends AbstractRecordTool
                     ],
                     'type' => [
                         'type' => 'string',
-                        'description' => 'Optional specific type to include (e.g., "text" for tt_content). If not provided, will show the first available type and a summary of all types.',
+                        'description' => 'Specific record type to show fields for (e.g., "textmedia" for tt_content). Each type has different fields. ' .
+                            'If omitted, shows fields for the first available type and lists all available types. ' .
+                            'Call again with a different type to see its fields. Types may be filtered by backend TSconfig (some types hidden from the list).',
                     ],
                 ],
                 'required' => ['table'],

--- a/Classes/MCP/Tool/Record/ListTablesTool.php
+++ b/Classes/MCP/Tool/Record/ListTablesTool.php
@@ -111,9 +111,9 @@ class ListTablesTool extends AbstractRecordTool
     {
         $result = "ACCESSIBLE TABLES IN TYPO3 (via MCP)\n";
         $result .= "=====================================\n\n";
-        
-        $result .= "All tables listed are workspace-capable and accessible by the current user.\n";
-        $result .= "Tables marked as [READ-ONLY] can be read but not modified.\n\n";
+
+        $result .= "Tables accessible by the current user. Most are workspace-capable (changes require publishing).\n";
+        $result .= "Tables marked as [READ-ONLY] can be read but not modified via WriteTable.\n\n";
         
         foreach ($groupedTables as $extension => $extensionInfo) {
             $extensionLabel = $extensionInfo['extensionLabel'];

--- a/Tests/Functional/MCP/Tool/ListTablesToolTest.php
+++ b/Tests/Functional/MCP/Tool/ListTablesToolTest.php
@@ -52,7 +52,7 @@ class ListTablesToolTest extends FunctionalTestCase
         // Verify listing contains expected sections
         $this->assertStringContainsString('ACCESSIBLE TABLES IN TYPO3 (via MCP)', $content);
         $this->assertStringContainsString('=====================================', $content);
-        $this->assertStringContainsString('workspace-capable and accessible', $content);
+        $this->assertStringContainsString('accessible by the current user', $content);
         
         // Verify core tables are present
         $this->assertStringContainsString('pages', $content);
@@ -142,8 +142,8 @@ class ListTablesToolTest extends FunctionalTestCase
         
         $content = $result->content[0]->text;
         
-        // Verify workspace information - the tool states "workspace-capable and accessible"
-        $this->assertStringContainsString('workspace-capable and accessible', $content);
+        // Verify workspace information - the tool states "accessible by the current user"
+        $this->assertStringContainsString('accessible by the current user', $content);
         
         // All listed tables should be workspace-capable since that's the filtering criteria
         $this->assertStringContainsString('pages (Page)', $content);
@@ -258,7 +258,7 @@ class ListTablesToolTest extends FunctionalTestCase
         
         // ⚠️ ISSUE: No summary statistics provided by the tool
         // This would be useful for LLM context. For now, verify basic functionality.
-        $this->assertStringContainsString('workspace-capable and accessible', $content);
+        $this->assertStringContainsString('accessible by the current user', $content);
         // Note: [READ-ONLY] is mentioned in the description but not shown in actual data
         
         // Verify we have core tables


### PR DESCRIPTION
…tTables

GetTableSchemaTool:
- Fix type parameter description: clarify it shows one type at a time, not a summary. Document TSconfig-based type filtering.

ListTablesTool:
- Fix false "all workspace-capable" claim — some tables are read-only
- Update test assertions to match corrected output text