### PR TITLE
Improve URL resolution to handle domains without protocol

### DIFF
--- a/Classes/MCP/Tool/GetPageTool.php
+++ b/Classes/MCP/Tool/GetPageTool.php
@@ -684,11 +684,17 @@ class GetPageTool extends AbstractRecordTool
     {
         $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
         
-        // Normalize URLs without a scheme: if the input looks like a domain (contains a dot
-        // but no scheme and no leading slash), prepend https:// so parse_url extracts the host.
+        // Normalize URLs without a scheme: if the input starts with a known site domain,
+        // prepend https:// so parse_url extracts the host correctly.
         // This handles cases like "www.example.com" or "www.example.com/about".
-        if (!str_contains($url, '://') && !str_starts_with($url, '/') && str_contains($url, '.')) {
-            $url = 'https://' . $url;
+        if (!str_contains($url, '://') && !str_starts_with($url, '/')) {
+            foreach ($siteFinder->getAllSites() as $site) {
+                $siteHost = $site->getBase()->getHost();
+                if (!empty($siteHost) && str_starts_with($url, $siteHost)) {
+                    $url = 'https://' . $url;
+                    break;
+                }
+            }
         }
 
         // Try to parse as full URL first

--- a/Classes/MCP/Tool/GetPageTool.php
+++ b/Classes/MCP/Tool/GetPageTool.php
@@ -684,10 +684,19 @@ class GetPageTool extends AbstractRecordTool
     {
         $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
         
+        // Normalize URLs without a scheme: if the input looks like a domain (contains a dot
+        // but no scheme and no leading slash), prepend https:// so parse_url extracts the host.
+        // This handles cases like "www.example.com" or "www.example.com/about".
+        if (!str_contains($url, '://') && !str_starts_with($url, '/') && str_contains($url, '.')) {
+            $url = 'https://' . $url;
+        }
+
         // Try to parse as full URL first
         $parsedUrl = parse_url($url);
-        $path = $parsedUrl['path'] ?? $url;
-        
+
+        // When a scheme+host URL has no path (e.g. "https://example.com"), treat it as home page
+        $path = $parsedUrl['path'] ?? '/';
+
         // Normalize: ensure leading slash, strip trailing slash (slugs in DB have no trailing slash)
         $path = '/' . trim($path, '/');
 

--- a/Tests/Functional/MCP/Tool/GetPageToolTest.php
+++ b/Tests/Functional/MCP/Tool/GetPageToolTest.php
@@ -644,6 +644,56 @@ class GetPageToolTest extends FunctionalTestCase
     }
 
     /**
+     * Test URL resolution with domain but no protocol (e.g. www.example.com)
+     */
+    public function testUrlResolutionWithDomainWithoutProtocol(): void
+    {
+        $siteInformationService = GeneralUtility::makeInstance(SiteInformationService::class);
+        $languageService = GeneralUtility::makeInstance(LanguageService::class);
+        $tool = new GetPageTool($siteInformationService, $languageService);
+
+        // Test with bare domain (no protocol) - should resolve to home page
+        $result = $tool->execute([
+            'url' => 'example.com'
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $content = $result->content[0]->text;
+        $this->assertStringContainsString('UID: 1', $content);
+        $this->assertStringContainsString('Title: Home', $content);
+
+        // Test with bare domain + path (no protocol)
+        $result = $tool->execute([
+            'url' => 'example.com/about'
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $content = $result->content[0]->text;
+        $this->assertStringContainsString('UID: 2', $content);
+        $this->assertStringContainsString('Title: About', $content);
+    }
+
+    /**
+     * Test URL resolution with full URL but no trailing slash (e.g. https://example.com)
+     */
+    public function testUrlResolutionWithFullUrlWithoutTrailingSlash(): void
+    {
+        $siteInformationService = GeneralUtility::makeInstance(SiteInformationService::class);
+        $languageService = GeneralUtility::makeInstance(LanguageService::class);
+        $tool = new GetPageTool($siteInformationService, $languageService);
+
+        // Test with full URL without trailing slash - should resolve to home page
+        $result = $tool->execute([
+            'url' => 'https://example.com'
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $content = $result->content[0]->text;
+        $this->assertStringContainsString('UID: 1', $content);
+        $this->assertStringContainsString('Title: Home', $content);
+    }
+
+    /**
      * Test URL resolution with language parameter
      */
     public function testUrlResolutionWithLanguage(): void


### PR DESCRIPTION
## Summary
Enhanced the `GetPageTool` URL resolution logic to properly handle URLs without a protocol scheme (e.g., `example.com` or `www.example.com`) and full URLs without trailing slashes (e.g., `https://example.com`).

## Key Changes
- **URL normalization**: Added logic to detect domain-like URLs (containing a dot, no scheme, no leading slash) and automatically prepend `https://` so `parse_url()` can correctly extract the host component
- **Path handling**: Changed the default path from the raw URL to `/` when `parse_url()` doesn't extract a path, ensuring URLs without paths resolve to the home page
- **Test coverage**: Added two new test cases:
  - `testUrlResolutionWithDomainWithoutProtocol()`: Validates bare domains and domains with paths resolve correctly
  - `testUrlResolutionWithFullUrlWithoutTrailingSlash()`: Validates full URLs without trailing slashes resolve to home page

## Implementation Details
The URL normalization check (`!str_contains($url, '://') && !str_starts_with($url, '/') && str_contains($url, '.')`) ensures we only prepend the scheme for domain-like inputs, avoiding false positives with relative paths or other URL formats. This maintains backward compatibility while extending support for common URL input patterns.