### PR TITLE
Fix CORS headers and auth header test credentials handling

### DIFF
--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -322,12 +322,6 @@ class McpEndpoint
             $receivedAuthHeader = true;
         }
 
-        $response = GeneralUtility::makeInstance(Response::class)
-            ->withHeader('Content-Type', 'application/json; charset=utf-8')
-            ->withHeader('Access-Control-Allow-Origin', '*')
-            ->withHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
-            ->withStatus(200);
-
         $responseData = [
             'test' => 'auth',
             'headers_received' => $headers,
@@ -339,6 +333,11 @@ class McpEndpoint
         $body = GeneralUtility::makeInstance(Stream::class, 'php://temp', 'rw');
         $body->write(json_encode($responseData, JSON_PRETTY_PRINT));
 
-        return $response->withBody($body);
+        $response = GeneralUtility::makeInstance(Response::class)
+            ->withHeader('Content-Type', 'application/json; charset=utf-8')
+            ->withStatus(200)
+            ->withBody($body);
+
+        return $this->addCorsHeaders($response);
     }
 }

--- a/Resources/Public/JavaScript/mcp-module.js
+++ b/Resources/Public/JavaScript/mcp-module.js
@@ -822,6 +822,8 @@ function checkMcpEndpointAuth(element, endpoint) {
     element.classList.remove('success', 'warning', 'error');
     
     // Create a test request with a dummy Bearer token
+    // Use credentials: 'omit' to avoid sending HTTP basic auth credentials,
+    // which would be replaced by our Bearer header and cause logout issues
     fetch(endpoint + '?test=auth', {
         method: 'GET',
         headers: {
@@ -829,7 +831,7 @@ function checkMcpEndpointAuth(element, endpoint) {
             'Authorization': 'Bearer test-header-check-12345'
         },
         mode: 'cors',
-        credentials: 'same-origin'
+        credentials: 'omit'
     })
     .then(response => {
         // We expect this to fail with 401 since it's a fake token
@@ -854,8 +856,12 @@ function checkMcpEndpointAuth(element, endpoint) {
         }).catch(() => {
             // If JSON parsing fails, check the status code
             if (response.status === 401) {
-                // This is expected for a fake token, but we need to know if headers were passed
-                setEndpointStatus(element, 'warning', 'MCP endpoint is reachable but Authorization header status unknown');
+                // A 401 may indicate HTTP basic auth is blocking the request
+                setEndpointStatus(element, 'warning', 'MCP endpoint returned 401 - if behind HTTP basic auth, the Authorization header may be blocked');
+                const warningDiv = document.getElementById('auth-header-warning');
+                if (warningDiv) {
+                    warningDiv.style.display = 'block';
+                }
             } else {
                 setEndpointStatus(element, 'error', `MCP endpoint returned ${response.status} ${response.statusText}`);
             }


### PR DESCRIPTION
## Summary
This PR improves the MCP endpoint authentication header testing by fixing CORS header handling and adjusting fetch credentials to prevent HTTP basic auth interference.

## Key Changes

- **Frontend (mcp-module.js)**:
  - Changed fetch `credentials` from `'same-origin'` to `'omit'` to prevent HTTP basic auth credentials from interfering with Bearer token testing

## Implementation Details

The credentials change prevents scenarios where HTTP basic auth credentials are automatically sent by the browser, which would override the custom Authorization header and cause unexpected logout behavior. The backend changes consolidate CORS header handling into a dedicated method for better maintainability.
