### PR TITLE
feat: add FAL read tools and file reference support

### DIFF
--- a/Classes/Database/Query/Restriction/WorkspaceDeletePlaceholderRestriction.php
+++ b/Classes/Database/Query/Restriction/WorkspaceDeletePlaceholderRestriction.php
@@ -59,17 +59,21 @@ class WorkspaceDeletePlaceholderRestriction implements QueryRestrictionInterface
                 $subQueryBuilder = $connectionPool->getQueryBuilderForTable($tableName);
                 $subQueryBuilder->getRestrictions()->removeAll();
                 
+                // Note: literal() is intentional here — createNamedParameter() registers params
+                // on the subquery builder, but the SQL is embedded in the outer query via getSQL(),
+                // so the outer query cannot resolve them. literal() is the correct approach for
+                // subqueries in QueryRestrictions where we lack access to the outer QueryBuilder.
                 $subQuery = $subQueryBuilder
                     ->select('t3ver_oid')
                     ->from($tableName)
                     ->where(
-                        $subQueryBuilder->expr()->eq('t3ver_state', 
+                        $subQueryBuilder->expr()->eq('t3ver_state',
                             $subQueryBuilder->expr()->literal((string)VersionState::DELETE_PLACEHOLDER->value)
                         ),
-                        $subQueryBuilder->expr()->eq('t3ver_wsid', 
+                        $subQueryBuilder->expr()->eq('t3ver_wsid',
                             $subQueryBuilder->expr()->literal((string)$this->workspaceId)
                         ),
-                        $subQueryBuilder->expr()->gt('t3ver_oid', 
+                        $subQueryBuilder->expr()->gt('t3ver_oid',
                             $subQueryBuilder->expr()->literal('0')
                         )
                     );

--- a/Classes/Event/AfterRecordWriteEvent.php
+++ b/Classes/Event/AfterRecordWriteEvent.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Event;
+
+/**
+ * PSR-14 event dispatched after WriteTableTool successfully creates or updates a record.
+ *
+ * This event is read-only — the operation has already completed. Use it for:
+ * - Audit logging of AI-initiated writes
+ * - Triggering side effects (cache clearing, webhook notifications)
+ * - Analytics and tracking of MCP operations
+ *
+ * Not dispatched on errors or vetoed operations.
+ */
+final class AfterRecordWriteEvent
+{
+    /**
+     * @param string $table The target table
+     * @param string $action The action that was performed: 'create', 'update', or 'delete'
+     * @param int $uid The record UID (live UID for workspace transparency)
+     * @param array $data The record data that was written (empty for delete)
+     * @param int|null $pid Page ID (only for create)
+     */
+    public function __construct(
+        private readonly string $table,
+        private readonly string $action,
+        private readonly int $uid,
+        private readonly array $data,
+        private readonly ?int $pid,
+    ) {}
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getAction(): string
+    {
+        return $this->action;
+    }
+
+    public function getUid(): int
+    {
+        return $this->uid;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function getPid(): ?int
+    {
+        return $this->pid;
+    }
+}

--- a/Classes/Event/BeforeRecordWriteEvent.php
+++ b/Classes/Event/BeforeRecordWriteEvent.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Event;
+
+/**
+ * PSR-14 event dispatched before WriteTableTool processes a write or move operation.
+ *
+ * Dispatched after parameter validation and ISO code conversion, but before
+ * validateRecordData() and DataHandler execution. This allows listeners to:
+ * - Modify data before validation and storage (auto-populate fields, normalize values)
+ * - Veto the operation with a reason (custom access control, policy enforcement)
+ * - Distinguish AI-originated writes from human-originated writes
+ */
+final class BeforeRecordWriteEvent
+{
+    private bool $vetoed = false;
+    private ?string $vetoReason = null;
+
+    /**
+     * @param string $table The target table
+     * @param string $action The action: 'create', 'update', 'delete', 'translate', or 'move'
+     * @param array $data The record data (mutable)
+     * @param int|null $uid Record UID (null for create)
+     * @param int|null $pid Page ID (null for update/delete)
+     */
+    public function __construct(
+        private readonly string $table,
+        private readonly string $action,
+        private array $data,
+        private readonly ?int $uid,
+        private readonly ?int $pid,
+    ) {}
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getAction(): string
+    {
+        return $this->action;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function setData(array $data): void
+    {
+        $this->data = $data;
+    }
+
+    public function getUid(): ?int
+    {
+        return $this->uid;
+    }
+
+    public function getPid(): ?int
+    {
+        return $this->pid;
+    }
+
+    public function veto(string $reason): void
+    {
+        $this->vetoed = true;
+        $this->vetoReason = $reason;
+    }
+
+    public function isVetoed(): bool
+    {
+        return $this->vetoed;
+    }
+
+    public function getVetoReason(): ?string
+    {
+        return $this->vetoReason;
+    }
+}

--- a/Classes/Event/ModifyAvailableFieldsEvent.php
+++ b/Classes/Event/ModifyAvailableFieldsEvent.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Event;
+
+/**
+ * PSR-14 event dispatched after TableAccessService discovers available fields for a table.
+ *
+ * Listeners can add, remove, or modify fields to control what the MCP tools expose.
+ * This event propagates through all tools (ReadTable, WriteTable, GetTableSchema, SearchTool)
+ * since they all use TableAccessService::getAvailableFields() as single source of truth.
+ */
+final class ModifyAvailableFieldsEvent
+{
+    /**
+     * @param string $table The table name
+     * @param string $type The record type (e.g. CType value, empty for default)
+     * @param array<string, array> $fields Field name => TCA config array
+     */
+    public function __construct(
+        private readonly string $table,
+        private readonly string $type,
+        private array $fields,
+    ) {}
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return array<string, array>
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @param array<string, array> $fields
+     */
+    public function setFields(array $fields): void
+    {
+        $this->fields = $fields;
+    }
+
+    public function removeField(string $fieldName): void
+    {
+        unset($this->fields[$fieldName]);
+    }
+
+    public function addField(string $fieldName, array $configuration): void
+    {
+        $this->fields[$fieldName] = $configuration;
+    }
+
+    public function hasField(string $fieldName): bool
+    {
+        return isset($this->fields[$fieldName]);
+    }
+}

--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -12,6 +12,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\FileProcessingAspect;
 use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Context\WorkspaceAspect;
 use TYPO3\CMS\Core\Http\Response;
@@ -268,6 +269,10 @@ class McpEndpoint
             $context = GeneralUtility::makeInstance(Context::class);
             $context->setAspect('backend.user', new UserAspect($beUser));
             $context->setAspect('workspace', new WorkspaceAspect($workspaceId));
+
+            // Disable deferred image processing — DeferredBackendImageProcessor requires a full
+            // backend session with CSRF tokens, which MCP endpoints don't have (Bearer token only).
+            $context->setAspect('fileProcessing', new FileProcessingAspect(false));
 
             // Log workspace selection for debugging
             error_log("MCP: User {$userId} switched to workspace {$workspaceId}");

--- a/Classes/MCP/Tool/File/BrowseFolderTool.php
+++ b/Classes/MCP/Tool/File/BrowseFolderTool.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\MCP\Tool\File;
+
+use Hn\McpServer\MCP\Tool\Record\AbstractRecordTool;
+use Mcp\Types\CallToolResult;
+use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderAccessPermissionsException;
+use TYPO3\CMS\Core\Resource\Folder;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Tool for browsing folder contents (subfolders and files) in a TYPO3 file storage
+ */
+class BrowseFolderTool extends AbstractRecordTool
+{
+    /**
+     * Get the tool schema
+     */
+    public function getSchema(): array
+    {
+        return [
+            'description' => 'Browse folder contents in a TYPO3 file storage. Lists subfolders and files with metadata (size, type, modification date). ' .
+                'Use combined identifier format like "1:/user_upload/" where 1 is the storage UID. ' .
+                'Note: File listing is limited to 100 files per folder. Use SearchFile for larger folders or filtered results.',
+            'inputSchema' => [
+                'type' => 'object',
+                'properties' => [
+                    'folder' => [
+                        'type' => 'string',
+                        'description' => 'Combined identifier of the folder to browse (e.g. "1:/user_upload/"). Use "/" or omit storage prefix for root of default storage.',
+                    ],
+                    'recursive' => [
+                        'type' => 'boolean',
+                        'description' => 'Show nested subfolders recursively (default: false)',
+                    ],
+                ],
+                'required' => ['folder'],
+            ],
+            'annotations' => [
+                'readOnlyHint' => true,
+                'idempotentHint' => true,
+            ],
+        ];
+    }
+
+    /**
+     * Execute the tool logic
+     */
+    protected function doExecute(array $params): CallToolResult
+    {
+        $folderIdentifier = (string)($params['folder'] ?? '/');
+        $recursive = (bool)($params['recursive'] ?? false);
+
+        $folder = $this->resolveFolder($folderIdentifier);
+
+        $lines = [];
+        $lines[] = sprintf('📁 Storage: %s (UID: %d)', $folder->getStorage()->getName(), $folder->getStorage()->getUid());
+        $lines[] = sprintf('📂 %s', $folder->getIdentifier());
+        $lines[] = '';
+
+        $this->renderFolderContents($folder, $lines, $recursive, 0);
+
+        return $this->createSuccessResult(implode("\n", $lines));
+    }
+
+    /**
+     * Resolve a folder identifier to a Folder object
+     */
+    private function resolveFolder(string $identifier): Folder
+    {
+        if (str_contains($identifier, ':')) {
+            $resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
+            return $resourceFactory->getFolderObjectFromCombinedIdentifier($identifier);
+        }
+
+        $storageRepository = GeneralUtility::makeInstance(StorageRepository::class);
+        $defaultStorage = $storageRepository->getDefaultStorage();
+
+        if ($defaultStorage === null) {
+            throw new \RuntimeException('No default storage found. Please specify a storage UID (e.g. "1:/").');
+        }
+
+        if ($identifier === '' || $identifier === '/') {
+            return $defaultStorage->getRootLevelFolder(true);
+        }
+
+        return $defaultStorage->getFolder($identifier);
+    }
+
+    /**
+     * Render folder contents into output lines
+     */
+    private function renderFolderContents(Folder $folder, array &$lines, bool $recursive, int $depth): void
+    {
+        $indent = str_repeat('  ', $depth);
+
+        try {
+            $subfolders = $folder->getSubfolders();
+        } catch (InsufficientFolderAccessPermissionsException) {
+            $lines[] = $indent . '⚠️ Access denied to this folder';
+            return;
+        }
+
+        foreach ($subfolders as $subfolder) {
+            $fileCount = count($subfolder->getFiles());
+            $combinedIdentifier = sprintf('%d:%s', $folder->getStorage()->getUid(), $subfolder->getIdentifier());
+            $lines[] = sprintf('%s📂 %s (%d files) [%s]', $indent, $subfolder->getName(), $fileCount, $combinedIdentifier);
+
+            if ($recursive) {
+                $this->renderFolderContents($subfolder, $lines, true, $depth + 1);
+            }
+        }
+
+        $files = $folder->getFiles(0, 100);
+        foreach ($files as $file) {
+            $lines[] = sprintf(
+                '%s📄 %s (%s, %s) [uid:%d]',
+                $indent,
+                $file->getName(),
+                $this->formatFileSize($file->getSize()),
+                $file->getMimeType(),
+                $file->getUid()
+            );
+        }
+
+        if (count($subfolders) === 0 && count($files) === 0) {
+            $lines[] = $indent . '(empty folder)';
+        }
+    }
+
+    /**
+     * Format file size to human-readable string
+     */
+    private function formatFileSize(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return $bytes . ' B';
+        }
+        if ($bytes < 1024 * 1024) {
+            return round($bytes / 1024, 1) . ' KB';
+        }
+        return round($bytes / (1024 * 1024), 1) . ' MB';
+    }
+}

--- a/Classes/MCP/Tool/File/ListStoragesTool.php
+++ b/Classes/MCP/Tool/File/ListStoragesTool.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\MCP\Tool\File;
+
+use Hn\McpServer\MCP\Tool\Record\AbstractRecordTool;
+use Mcp\Types\CallToolResult;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Tool for listing available file storages in TYPO3
+ */
+class ListStoragesTool extends AbstractRecordTool
+{
+    /**
+     * Get the tool schema
+     */
+    public function getSchema(): array
+    {
+        return [
+            'description' => 'List all available file storages in TYPO3 that can be browsed. Returns storage UIDs, names, and capabilities (public, writable, default).',
+            'inputSchema' => [
+                'type' => 'object',
+                'properties' => [
+                    'includeOffline' => [
+                        'type' => 'boolean',
+                        'description' => 'Include offline storages in the listing (default: false)',
+                    ],
+                ],
+                'required' => [],
+            ],
+            'annotations' => [
+                'readOnlyHint' => true,
+                'idempotentHint' => true,
+            ],
+        ];
+    }
+
+    /**
+     * Execute the tool logic
+     */
+    protected function doExecute(array $params): CallToolResult
+    {
+        $includeOffline = (bool)($params['includeOffline'] ?? false);
+
+        $storageRepository = GeneralUtility::makeInstance(StorageRepository::class);
+        $storages = $storageRepository->findAll();
+
+        $lines = [];
+        $lines[] = 'FILE STORAGES';
+        $lines[] = '=============';
+        $lines[] = '';
+
+        $count = 0;
+        foreach ($storages as $storage) {
+            if (!$storage->isBrowsable()) {
+                continue;
+            }
+            if (!$includeOffline && !$storage->isOnline()) {
+                continue;
+            }
+
+            $count++;
+            $flags = [];
+            if ($storage->isPublic()) {
+                $flags[] = 'public';
+            }
+            if ($storage->isWritable()) {
+                $flags[] = 'writable';
+            }
+            if ($storage->isDefault()) {
+                $flags[] = 'default';
+            }
+            if (!$storage->isOnline()) {
+                $flags[] = 'OFFLINE';
+            }
+
+            $rootFolder = $storage->getRootLevelFolder(true);
+
+            $lines[] = sprintf(
+                'Storage %d: %s [%s]',
+                $storage->getUid(),
+                $storage->getName(),
+                implode(', ', $flags)
+            );
+            $lines[] = sprintf(
+                '  Root: %d:%s',
+                $storage->getUid(),
+                $rootFolder->getIdentifier()
+            );
+            $lines[] = '';
+        }
+
+        if ($count === 0) {
+            $lines[] = 'No browsable storages found.';
+        } else {
+            $lines[] = sprintf('Total: %d storage(s)', $count);
+        }
+
+        return $this->createSuccessResult(implode("\n", $lines));
+    }
+}

--- a/Classes/MCP/Tool/File/SearchFileTool.php
+++ b/Classes/MCP/Tool/File/SearchFileTool.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\MCP\Tool\File;
+
+use Hn\McpServer\MCP\Tool\Record\AbstractRecordTool;
+use Mcp\Types\CallToolResult;
+use Mcp\Types\ImageContent;
+use Mcp\Types\TextContent;
+use Doctrine\DBAL\ParameterType;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Tool for searching files in TYPO3 FAL with optional thumbnail preview
+ */
+class SearchFileTool extends AbstractRecordTool
+{
+    private const DEFAULT_LIMIT = 10;
+    private const MAX_LIMIT = 30;
+    private const THUMBNAIL_WIDTH = 150;
+    private const THUMBNAIL_HEIGHT = 150;
+
+    public function getSchema(): array
+    {
+        return [
+            'description' => 'Search for existing files in TYPO3 FAL by name, extension, folder, or MIME type. '
+                . 'At least one search criterion is required (name, extension, folder, mimeType, or storage). '
+                . 'Returns file metadata and optionally Base64-encoded JPEG thumbnails (150x150px) as inline images. '
+                . 'SVG files are excluded from thumbnail generation. '
+                . 'For larger previews or to save a preview to disk, use PreviewFile which provides a downloadable URL.',
+            'inputSchema' => [
+                'type' => 'object',
+                'properties' => [
+                    'name' => [
+                        'type' => 'string',
+                        'description' => 'Search by filename (partial match, case-insensitive). Example: "logo" finds "logo.png", "company-logo.svg"',
+                    ],
+                    'extension' => [
+                        'type' => 'string',
+                        'description' => 'Filter by file extension(s), comma-separated. Example: "png,jpg,svg"',
+                    ],
+                    'folder' => [
+                        'type' => 'string',
+                        'description' => 'Filter by folder path (partial match). Example: "/user_upload/logos/"',
+                    ],
+                    'mimeType' => [
+                        'type' => 'string',
+                        'description' => 'Filter by MIME type (partial match). Example: "image/" for all images, "application/pdf" for PDFs',
+                    ],
+                    'storage' => [
+                        'type' => 'integer',
+                        'description' => 'Filter by storage UID (default: search all storages)',
+                    ],
+                    'limit' => [
+                        'type' => 'integer',
+                        'description' => 'Maximum number of results (default: 10, max: 30)',
+                    ],
+                    'thumbnails' => [
+                        'type' => 'boolean',
+                        'description' => 'Include thumbnail previews as inline images for image files (default: true). Thumbnails are 150x150px JPEG.',
+                    ],
+                ],
+                'required' => [],
+            ],
+            'annotations' => [
+                'readOnlyHint' => true,
+                'idempotentHint' => true,
+            ],
+        ];
+    }
+
+    protected function doExecute(array $params): CallToolResult
+    {
+        $name = (string)($params['name'] ?? '');
+        $extension = (string)($params['extension'] ?? '');
+        $folder = (string)($params['folder'] ?? '');
+        $mimeType = (string)($params['mimeType'] ?? '');
+        $storageUid = isset($params['storage']) ? (int)$params['storage'] : null;
+        $limit = min((int)($params['limit'] ?? self::DEFAULT_LIMIT), self::MAX_LIMIT);
+        $includeThumbnails = (bool)($params['thumbnails'] ?? true);
+
+        if ($name === '' && $extension === '' && $folder === '' && $mimeType === '' && $storageUid === null) {
+            return $this->createErrorResult('At least one search criterion is required (name, extension, folder, mimeType, or storage).');
+        }
+
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('sys_file');
+
+        $queryBuilder->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+
+        $queryBuilder
+            ->select('uid', 'name', 'identifier', 'storage', 'extension', 'mime_type', 'size', 'sha1', 'creation_date', 'modification_date')
+            ->from('sys_file')
+            ->setMaxResults($limit);
+
+        if ($name !== '') {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->like(
+                    'name',
+                    $queryBuilder->createNamedParameter('%' . $queryBuilder->escapeLikeWildcards($name) . '%')
+                )
+            );
+        }
+
+        if ($extension !== '') {
+            $extensions = array_map('trim', explode(',', $extension));
+            $extensionConstraints = [];
+            foreach ($extensions as $ext) {
+                $extensionConstraints[] = $queryBuilder->expr()->eq(
+                    'extension',
+                    $queryBuilder->createNamedParameter(ltrim($ext, '.'))
+                );
+            }
+            $queryBuilder->andWhere($queryBuilder->expr()->or(...$extensionConstraints));
+        }
+
+        if ($folder !== '') {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->like(
+                    'identifier',
+                    $queryBuilder->createNamedParameter('%' . $queryBuilder->escapeLikeWildcards($folder) . '%')
+                )
+            );
+        }
+
+        if ($mimeType !== '') {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->like(
+                    'mime_type',
+                    $queryBuilder->createNamedParameter('%' . $queryBuilder->escapeLikeWildcards($mimeType) . '%')
+                )
+            );
+        }
+
+        if ($storageUid !== null) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->eq('storage', $queryBuilder->createNamedParameter($storageUid, ParameterType::INTEGER))
+            );
+        }
+
+        $queryBuilder->orderBy('modification_date', 'DESC');
+
+        $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+
+        if (empty($rows)) {
+            return $this->createSuccessResult('No files found matching the search criteria.');
+        }
+
+        $content = [];
+        $content[] = new TextContent(sprintf('%d file(s) found:', count($rows)));
+
+        $resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
+
+        foreach ($rows as $row) {
+            $line = sprintf(
+                "uid:%d | %s | %s | %s | %d:%s",
+                $row['uid'],
+                $row['name'],
+                $this->formatFileSize((int)$row['size']),
+                $row['mime_type'],
+                $row['storage'],
+                $row['identifier']
+            );
+            $content[] = new TextContent($line);
+
+            if ($includeThumbnails && $this->isImageMimeType($row['mime_type'])) {
+                $thumbnailContent = $this->generateThumbnail($resourceFactory, (int)$row['uid']);
+                if ($thumbnailContent !== null) {
+                    $content[] = $thumbnailContent;
+                }
+            }
+        }
+
+        return new CallToolResult($content);
+    }
+
+    private function generateThumbnail(ResourceFactory $resourceFactory, int $fileUid): ?ImageContent
+    {
+        try {
+            $file = $resourceFactory->getFileObject($fileUid);
+
+            $processedFile = $file->process(
+                ProcessedFile::CONTEXT_IMAGEPREVIEW,
+                [
+                    'width' => self::THUMBNAIL_WIDTH,
+                    'height' => self::THUMBNAIL_HEIGHT,
+                ]
+            );
+
+            $localPath = $processedFile->getForLocalProcessing(false);
+            if ($localPath === '' || !file_exists($localPath)) {
+                return null;
+            }
+
+            $imageData = file_get_contents($localPath);
+            if ($imageData === false) {
+                return null;
+            }
+
+            return new ImageContent(
+                base64_encode($imageData),
+                $processedFile->getMimeType()
+            );
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function isImageMimeType(string $mimeType): bool
+    {
+        return str_starts_with($mimeType, 'image/') && $mimeType !== 'image/svg+xml';
+    }
+
+    private function formatFileSize(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return $bytes . ' B';
+        }
+        if ($bytes < 1024 * 1024) {
+            return round($bytes / 1024, 1) . ' KB';
+        }
+        return round($bytes / (1024 * 1024), 1) . ' MB';
+    }
+}

--- a/Classes/MCP/Tool/GetPageTool.php
+++ b/Classes/MCP/Tool/GetPageTool.php
@@ -480,6 +480,23 @@ class GetPageTool extends AbstractRecordTool
     }
     
     /**
+     * Get workspace name for display
+     */
+    protected function getWorkspaceInfo(int $workspaceId): string
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('sys_workspace');
+        $queryBuilder->getRestrictions()->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $row = $queryBuilder->select('title')
+            ->from('sys_workspace')
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($workspaceId, \Doctrine\DBAL\ParameterType::INTEGER)))
+            ->executeQuery()
+            ->fetchAssociative();
+        return $row ? (string)$row['title'] : 'Workspace #' . $workspaceId;
+    }
+
+    /**
      * Format page information as readable text
      */
     protected function formatPageInfo(array $pageData, array $recordsInfo, ?string $pageUrl = null, int $languageId = 0, array $translations = []): string

--- a/Classes/MCP/Tool/Record/GetTableSchemaTool.php
+++ b/Classes/MCP/Tool/Record/GetTableSchemaTool.php
@@ -37,7 +37,9 @@ class GetTableSchemaTool extends AbstractRecordTool
                     ],
                     'type' => [
                         'type' => 'string',
-                        'description' => 'Optional specific type to include (e.g., "text" for tt_content). If not provided, will show the first available type and a summary of all types.',
+                        'description' => 'Specific record type to show fields for (e.g., "textmedia" for tt_content). Each type has different fields. ' .
+                            'If omitted, shows fields for the first available type and lists all available types. ' .
+                            'Call again with a different type to see its fields. Types may be filtered by backend TSconfig (some types hidden from the list).',
                     ],
                 ],
                 'required' => ['table'],

--- a/Classes/MCP/Tool/Record/ListTablesTool.php
+++ b/Classes/MCP/Tool/Record/ListTablesTool.php
@@ -111,9 +111,9 @@ class ListTablesTool extends AbstractRecordTool
     {
         $result = "ACCESSIBLE TABLES IN TYPO3 (via MCP)\n";
         $result .= "=====================================\n\n";
-        
-        $result .= "All tables listed are workspace-capable and accessible by the current user.\n";
-        $result .= "Tables marked as [READ-ONLY] can be read but not modified.\n\n";
+
+        $result .= "Tables accessible by the current user. Most are workspace-capable (changes require publishing).\n";
+        $result .= "Tables marked as [READ-ONLY] can be read but not modified via WriteTable.\n\n";
         
         foreach ($groupedTables as $extension => $extensionInfo) {
             $extensionLabel = $extensionInfo['extensionLabel'];

--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -92,7 +92,14 @@ class ReadTableTool extends AbstractRecordTool
         }
 
         return [
-            'description' => 'Read records from TYPO3 tables with filtering, pagination, and relation embedding. By default, returns records from ALL languages mixed together (matching TYPO3\'s list module behavior). Use the language parameter to filter to a specific language. For page content, use pid filter instead of individual record lookups.',
+            'description' => 'Read records from TYPO3 tables with filtering, pagination, and relation embedding. ' .
+                'Returns records from ALL languages mixed together by default (like TYPO3\'s list module). Use the language parameter to filter. ' .
+                'Hidden records are always included (like the TYPO3 backend); only deleted records are excluded. ' .
+                'INLINE RELATIONS: Embedded inline fields (hideTable/passthrough) return full child record data arrays. Independent inline fields return only UIDs. ' .
+                'MM RELATIONS: Basic support — does not resolve foreign_table_where conditions or complex TYPO3 relation scenarios. ' .
+                'WORKSPACE: Returns live UIDs for workspace-overlaid records (transparent for subsequent WriteTable calls). ' .
+                'OUTPUT: {table, tableLabel, records[], total, limit, offset, hasMore}. Max limit: 1000. ' .
+                'For page content, use pid filter instead of individual record lookups.',
             'inputSchema' => [
                 'type' => 'object',
                 'properties' => $properties,
@@ -663,7 +670,7 @@ class ReadTableTool extends AbstractRecordTool
 
             match ($fieldType) {
                 'select', 'category' => $this->includeSelectRelations($result['records'], $fieldName, $fieldConfig, $table),
-                'inline' => $this->includeInlineRelations($result['records'], $fieldName, $fieldConfig, $recordUids),
+                'inline', 'file' => $this->includeInlineRelations($result['records'], $fieldName, $fieldConfig, $recordUids),
                 default => null,
             };
         }
@@ -805,7 +812,7 @@ class ReadTableTool extends AbstractRecordTool
 
         // Check if foreign table is hidden (dependent records that should be embedded)
         $foreignTableTCA = $GLOBALS['TCA'][$foreignTable] ?? [];
-        $isHiddenTable = ($foreignTableTCA['ctrl']['hideTable'] ?? false) === true;
+        $isHiddenTable = !empty($foreignTableTCA['ctrl']['hideTable']);
 
         // Get all related records
         $foreignSortBy = $fieldConfig['config']['foreign_sortby'] ?? '';

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Hn\McpServer\MCP\Tool\Record;
 
 use Doctrine\DBAL\ParameterType;
+use Hn\McpServer\Event\AfterRecordWriteEvent;
+use Hn\McpServer\Event\BeforeRecordWriteEvent;
 use Hn\McpServer\Exception\DatabaseException;
 use Hn\McpServer\Exception\ValidationException;
 use Hn\McpServer\Service\LanguageService;
 use Mcp\Types\CallToolResult;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -40,19 +43,23 @@ class WriteTableTool extends AbstractRecordTool
         sort($tableNames); // Sort alphabetically for better readability
         
         return [
-            'description' => 'Create, update, translate, or delete records in workspace-capable TYPO3 tables. All changes are made in workspace context and require publishing to become live. Language fields (sys_language_uid) can be provided as ISO codes (e.g., "de", "fr") instead of numeric IDs. ' .
-                'Before creating or updating content, always use GetPage to understand the page structure, existing content, and writing style. ' .
-                'Check existing content elements with ReadTable to ensure new content fits the page\'s tone and doesn\'t duplicate existing elements. ' .
-                'For content creation, verify the appropriate colPos by examining existing content layout. ' .
-                'Note: If you encounter plugins (CType=list) that reference non-workspace capable tables, ' .
-                'look for record storage folders (doktype=254) where the actual records are stored.',
+            'description' => 'Create, update, translate, move, or delete records in workspace-capable TYPO3 tables. All changes are made in workspace context and require publishing to become live. ' .
+                'Language fields (sys_language_uid) accept ISO codes ("de", "fr") instead of numeric IDs. Date/time fields accept ISO 8601 strings and are auto-converted to timestamps. Slug fields are auto-normalized (leading slash ensured). ' .
+                'REQUIRED PARAMETERS PER ACTION: ' .
+                'create: table, pid, data. update: table, uid, data. delete: table, uid. move: table, uid, position (and optionally pid for cross-page). translate: table, uid, data (with sys_language_uid). ' .
+                'INLINE RELATIONS (CRITICAL): On update, passing an inline field REPLACES ALL existing children — omitted children are deleted (embedded) or unlinked (independent). ' .
+                'To keep existing children, include their UIDs: [2546, 2547, {"CType": "textmedia", "header": "New"}]. To update an existing child: {"uid": 2546, "header": "Updated"}. Order in the array defines sorting. ' .
+                'Nested inline relations are supported: child record data may itself contain inline arrays. ' .
+                'FLEXFORM FIELDS: Pass as JSON objects (auto-converted to XML). Use "settings.fieldName" keys for plugin settings. ' .
+                'ORDERING: When creating multiple elements on a page, chain positions: create first with "bottom", then "after:{uid}" for each next. ' .
+                'Before creating content, use GetPage + ReadTable to understand page structure and existing content.',
             'inputSchema' => [
                 'type' => 'object',
                 'properties' => [
                     'action' => [
                         'type' => 'string',
-                        'description' => 'Action to perform: "create", "update", "translate", or "delete"',
-                        'enum' => ['create', 'update', 'translate', 'delete'],
+                        'description' => 'Action to perform: "create", "update", "move", "translate", or "delete"',
+                        'enum' => ['create', 'update', 'move', 'translate', 'delete'],
                     ],
                     'table' => [
                         'type' => 'string',
@@ -61,7 +68,7 @@ class WriteTableTool extends AbstractRecordTool
                     ],
                     'pid' => [
                         'type' => 'integer',
-                        'description' => 'Page ID for new records (required for "create" action)',
+                        'description' => 'Page ID — required for "create" action, optional for "move" action (target page for cross-page moves)',
                     ],
                     'uid' => [
                         'type' => 'integer',
@@ -69,23 +76,29 @@ class WriteTableTool extends AbstractRecordTool
                     ],
                     'data' => [
                         'type' => 'object',
-                        'description' => 'Record data with field names as keys and their values (required for "create", "update", and "translate" actions). ' .
-                            'Uses the same field syntax as ReadTable output. Language fields (sys_language_uid) accept ISO codes like "de", "fr" instead of numeric IDs. ' .
-                            'Inline relations can be specified as arrays - UIDs for independent tables, record data for embedded tables. ' .
-                            'For text fields in update actions, instead of providing the full text, you can provide an array of search-and-replace operations: ' .
-                            '[{"search": "old text", "replace": "new text"}]. Each operation can optionally include "replaceAll": true. ' .
-                            'Operations are applied sequentially. Each search string must match exactly once unless replaceAll is true.',
+                        'description' => 'Record data as field-value pairs. ' .
+                            'INLINE RELATIONS: For embedded tables, pass record data arrays to create new children or {"uid": N} to reference existing ones (optionally with fields to update). ' .
+                            'For independent tables, pass UIDs to link. On update, the array REPLACES all children — include existing UIDs to keep them. ' .
+                            'FILE FIELDS (image, media, assets): Array of sys_file UIDs [3, 4] or objects [{"uid_local": 3, "title": "...", "alternative": "...", "description": "Caption"}]. ' .
+                            'SEARCH-AND-REPLACE (update only): For text/input/email/link/slug fields, pass [{"search": "old", "replace": "new"}] instead of full text. ' .
+                            'Add "replaceAll": true per operation if search may match multiple times. Only these field types support search-and-replace. ' .
+                            'FLEXFORM: Pass as JSON object with "settings.fieldName" keys — auto-converted to XML.',
                         'additionalProperties' => true,
                         'examples' => [
                             ['title' => 'News Title', 'bodytext' => 'News <b>content</b>', 'datetime' => '2024-01-01 10:00:00'],
                             ['header' => 'Content Element Header', 'bodytext' => 'Content <b>text</b>', 'CType' => 'text'],
                             ['sys_language_uid' => 'de', 'title' => 'German translation'],
                             ['header' => [['search' => 'Welcom', 'replace' => 'Welcome'], ['search' => 'Compnay', 'replace' => 'Company']]],
+                            ['header' => 'With images', 'CType' => 'textmedia', 'assets' => [3, 4]],
+                            ['image' => [['uid_local' => 5, 'title' => 'Photo', 'alternative' => 'Alt text']]],
                         ]
                     ],
                     'position' => [
                         'type' => 'string',
-                        'description' => 'Position for new records: "top", "bottom", "after:UID", or "before:UID"',
+                        'description' => 'Position for "create" and "move" actions: "bottom" (default, append after last), "top" (prepend before first), '
+                            . '"after:UID" (insert after specific element), "before:UID" (insert before specific element). '
+                            . 'For "move", position is required unless moving to bottom of same page. '
+                            . 'To create elements in order, chain "after:UID" with the UID from the previous response.',
                         'default' => 'bottom',
                     ],
                 ],
@@ -190,6 +203,17 @@ class WriteTableTool extends AbstractRecordTool
                 }
                 break;
                 
+            case 'move':
+                if ($uid === null) {
+                    throw new ValidationException(['Record UID is required for move action']);
+                }
+                if ($pid === null && $position === 'bottom') {
+                    // Same-page bottom move is a no-op, but allowed
+                } elseif (!preg_match('/^(after|before):\d+$/', $position) && $position !== 'top' && $position !== 'bottom') {
+                    throw new ValidationException(['Position is required for move action. Use "after:UID", "before:UID", "top", or "bottom". For cross-page moves, also provide pid.']);
+                }
+                break;
+
             case 'translate':
                 if ($uid === null) {
                     throw new ValidationException(['Record UID is required for translate action']);
@@ -205,9 +229,19 @@ class WriteTableTool extends AbstractRecordTool
                 break;
 
             default:
-                throw new ValidationException(['Invalid action: ' . $action . '. Valid actions are: create, update, translate, delete']);
+                throw new ValidationException(['Invalid action: ' . $action . '. Valid actions are: create, update, move, translate, delete']);
         }
         
+        // Dispatch BeforeRecordWriteEvent — allows listeners to modify data or veto
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $beforeEvent = new BeforeRecordWriteEvent($table, $action, $data, $uid, $pid);
+        $eventDispatcher->dispatch($beforeEvent);
+
+        if ($beforeEvent->isVetoed()) {
+            return $this->createErrorResult('Operation vetoed: ' . ($beforeEvent->getVetoReason() ?? 'No reason given'));
+        }
+        $data = $beforeEvent->getData();
+
         // Execute the action
         switch ($action) {
             case 'create':
@@ -221,6 +255,9 @@ class WriteTableTool extends AbstractRecordTool
                 }
                 return $this->updateRecord($table, $uid, $data);
                 
+            case 'move':
+                return $this->moveRecord($table, $uid, $position, $pid);
+
             case 'delete':
                 return $this->deleteRecord($table, $uid);
 
@@ -261,188 +298,70 @@ class WriteTableTool extends AbstractRecordTool
             return $this->createErrorResult('Validation error: ' . $validationResult);
         }
         
-        // Extract inline relations before converting data
+        // Extract inline relations and build unified dataMap
         $inlineRelations = $this->extractInlineRelations($table, $data);
-        
+
         // Convert data for storage
         $data = $this->convertDataForStorage($table, $data);
-        
+
         // Prepare the data array
         $newRecordData = $data;
+        $newRecordData['pid'] = $pid;
 
-        // Use DataHandler's native pid-based positioning:
-        // - Positive pid → record is placed at the TOP of that page (DataHandler default)
-        // - Negative pid (-uid) → record is placed AFTER the record with that uid
-        if ($position === 'bottom') {
-            $sortingField = $this->tableAccessService->getSortingFieldName($table);
-            if ($sortingField !== null && !isset($data[$sortingField])) {
-                // Find the last record on this page to insert after it
-                $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-                    ->getQueryBuilderForTable($table);
-                $queryBuilder->getRestrictions()->removeAll()
-                    ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-
-                $lastRecord = $queryBuilder
-                    ->select('uid')
-                    ->from($table)
-                    ->where(
-                        $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pid, ParameterType::INTEGER))
-                    )
-                    ->orderBy($sortingField, 'DESC')
-                    ->addOrderBy('uid', 'DESC')
-                    ->setMaxResults(1)
-                    ->executeQuery()
-                    ->fetchAssociative();
-
-                if ($lastRecord) {
-                    // Negative pid tells DataHandler to insert after this record
-                    $newRecordData['pid'] = -(int)$lastRecord['uid'];
-                } else {
-                    // No records exist yet — positive pid inserts as first record
-                    $newRecordData['pid'] = $pid;
-                }
-            } else {
-                $newRecordData['pid'] = $pid;
-            }
-        } elseif (strpos($position, 'after:') === 0) {
-            $referenceUid = (int)substr($position, strlen('after:'));
-            // Resolve live UID to workspace UID if needed, since DataHandler works with real UIDs
-            $wsUid = $this->resolveToWorkspaceUid($table, $referenceUid);
-            $newRecordData['pid'] = -$wsUid;
-        } else {
-            // 'top', 'before:UID', or default — use positive pid (DataHandler inserts at top)
-            $newRecordData['pid'] = $pid;
-        }
+        // Sorting is handled after record creation via DataHandler move commands.
+        // This ensures correct sorting in all cases (live, workspace, colPos).
 
         // Create a unique ID for this new record
-        $newId = 'NEW' . uniqid();
-        
-        // Initialize DataHandler
-        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
-        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
-        
-        // First, create the parent record without inline relations
+        $newId = 'NEW' . bin2hex(random_bytes(8));
+
+        // Build unified dataMap: parent + all inline children in one structure.
+        // DataHandler resolves NEW keys, sets foreign_field, and handles workspace
+        // versioning atomically in a single process_datamap() call.
         $dataMap = [];
         $dataMap[$table][$newId] = $newRecordData;
-        
-        // Process the parent record first
+
+        // Add inline children to the same dataMap and set CSV references on parent
+        if (!empty($inlineRelations)) {
+            $this->buildInlineDataMap($dataMap, $table, $newId, $pid, $inlineRelations);
+        }
+
+        // Process everything in a single DataHandler call
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
         $dataHandler->start($dataMap, []);
         $dataHandler->process_datamap();
-        
-        // Check for errors in parent creation
+
+        // Check for errors
         if (!empty($dataHandler->errorLog)) {
             return $this->createErrorResult('Error creating record: ' . $this->formatDataHandlerErrors($dataHandler->errorLog));
         }
-        
+
         // Get the UID of the newly created parent record
         $parentUid = $dataHandler->substNEWwithIDs[$newId] ?? null;
-        
+
         if (!$parentUid) {
             return $this->createErrorResult('Error creating record: No UID returned');
         }
-        
-        // Get the live UID for inline relations if we're in a workspace
-        $liveParentUid = $this->getLiveUid($table, $parentUid);
-        
-        // Now process inline relations with the resolved parent UID
-        if (!empty($inlineRelations)) {
-            $childDataMap = [];
-            $this->processInlineRelations($childDataMap, $table, $parentUid, $pid, $inlineRelations);
-            
-            
-            if (!empty($childDataMap)) {
-                // Create a new DataHandler instance for child records
-                $childDataHandler = GeneralUtility::makeInstance(DataHandler::class);
-                $childDataHandler->BE_USER = $GLOBALS['BE_USER'];
-                $childDataHandler->start($childDataMap, []);
-                $childDataHandler->process_datamap();
-                
-                
-                // Check for errors in child creation
-                if (!empty($childDataHandler->errorLog)) {
-                    // Parent was created but children failed
-                    return $this->createErrorResult(
-                        'Parent record created but error creating child records: ' . 
-                        implode(', ', $childDataHandler->errorLog)
-                    );
-                }
-                
-                // Update foreign fields for embedded relations
-                foreach ($inlineRelations as $fieldName => $relationData) {
-                    $config = $relationData['config'];
-                    $foreignTable = $config['foreign_table'] ?? '';
-                    $foreignField = $config['foreign_field'] ?? '';
-                    
-                    if (empty($foreignTable) || empty($foreignField)) {
-                        continue;
-                    }
-                    
-                    // Check if this is an embedded table
-                    $foreignTableTCA = $GLOBALS['TCA'][$foreignTable] ?? [];
-                    $isHiddenTable = ($foreignTableTCA['ctrl']['hideTable'] ?? false) === true;
-                    
-                    if ($isHiddenTable) {
-                        // Collect the UIDs of created child records
-                        $childUids = [];
-                        foreach ($childDataHandler->substNEWwithIDs as $newId => $realId) {
-                            if (strpos($newId, 'NEW') === 0 && isset($childDataMap[$foreignTable][$newId])) {
-                                $childUids[] = $realId;
-                            }
-                        }
-                        
-                        if (!empty($childUids)) {
-                            // Update foreign field directly in database
-                            // RelationHandler's writeForeignField is for MM relations, not direct foreign fields
-                            $connection = GeneralUtility::makeInstance(ConnectionPool::class)
-                                ->getConnectionForTable($foreignTable);
-                            
-                            foreach ($childUids as $childUid) {
-                                $connection->update(
-                                    $foreignTable,
-                                    [$foreignField => $liveParentUid],
-                                    ['uid' => $childUid]
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        
-        
-        // Handle before positioning via move command (after is already handled via negative pid)
-        if (strpos($position, 'before:') === 0) {
-            $referenceUid = (int)substr($position, strlen('before:'));
 
-            // Set up the command map for moving the record
-            $cmdMap = [];
-            $cmdMap[$table][$parentUid]['move'] = [
-                'action' => 'before',
-                'target' => $referenceUid,
-            ];
-
-            // Initialize a new DataHandler for the move operation
-            $moveDataHandler = GeneralUtility::makeInstance(DataHandler::class);
-            $moveDataHandler->BE_USER = $GLOBALS['BE_USER'];
-            $moveDataHandler->start([], $cmdMap);
-            $moveDataHandler->process_cmdmap();
-
-            // Check for errors in the move operation
-            if (!empty($moveDataHandler->errorLog)) {
-                // The record was created but positioning failed
-                $liveUid = $this->getLiveUid($table, $parentUid);
-                return $this->createJsonResult([
-                    'action' => 'create',
-                    'table' => $table,
-                    'uid' => $liveUid,
-                    'warning' => 'Record created but positioning failed: ' . implode(', ', $moveDataHandler->errorLog)
-                ]);
-            }
+        // Handle positioning via DataHandler move command
+        $positionError = $this->applyPosition($table, $parentUid, $pid, $position);
+        if ($positionError !== null) {
+            $liveUid = $this->getLiveUid($table, $parentUid);
+            return $this->createJsonResult([
+                'action' => 'create',
+                'table' => $table,
+                'uid' => $liveUid,
+                'warning' => 'Record created but positioning failed: ' . $positionError,
+            ]);
         }
         
         // Get the live UID for workspace transparency
         $liveUid = $this->getLiveUid($table, $parentUid);
-        
+
+        // Dispatch AfterRecordWriteEvent
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $eventDispatcher->dispatch(new AfterRecordWriteEvent($table, 'create', $liveUid, $data, $pid));
+
         // Return the result with live UID
         return $this->createJsonResult([
             'action' => 'create',
@@ -462,9 +381,9 @@ class WriteTableTool extends AbstractRecordTool
             return $this->createErrorResult('Validation error: ' . $validationResult);
         }
         
-        // Extract inline relations before converting data
+        // Extract inline relations and build unified dataMap
         $inlineRelations = $this->extractInlineRelations($table, $data);
-        
+
         // Convert data for storage
         $data = $this->convertDataForStorage($table, $data);
 
@@ -475,84 +394,41 @@ class WriteTableTool extends AbstractRecordTool
         // Resolve the live UID to workspace UID (once, used throughout)
         $workspaceUid = $this->resolveToWorkspaceUid($table, $uid);
 
-        // First, update the parent record without inline relations
+        // Build unified dataMap: parent update + all inline children
         $dataMap = [$table => [$workspaceUid => $data]];
-        
-        // Update the record using DataHandler
-        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
-        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
-        $dataHandler->start($dataMap, []);
-        $dataHandler->process_datamap();
-        
-        // Check for errors in parent update
-        if (!empty($dataHandler->errorLog)) {
-            return $this->createErrorResult('Error updating record: ' . implode(', ', $dataHandler->errorLog));
-        }
-        
-        // Now process inline relations with the resolved parent UID
+        $cmdMap = [];
+
         if (!empty($inlineRelations)) {
             // Get record's pid for creating new inline records
             $record = BackendUtility::getRecord($table, $workspaceUid, 'pid');
             $pid = $record['pid'] ?? 0;
-            
-            $childDataMap = [];
-            $this->processInlineRelations($childDataMap, $table, $workspaceUid, $pid, $inlineRelations, $uid);
-            
-            if (!empty($childDataMap)) {
-                // Create a new DataHandler instance for child records
-                $childDataHandler = GeneralUtility::makeInstance(DataHandler::class);
-                $childDataHandler->BE_USER = $GLOBALS['BE_USER'];
-                $childDataHandler->start($childDataMap, []);
-                $childDataHandler->process_datamap();
-                
-                // Check for errors in child processing
-                if (!empty($childDataHandler->errorLog)) {
-                    return $this->createErrorResult('Error processing inline relations: ' . implode(', ', $childDataHandler->errorLog));
-                }
-                
-                // Update foreign fields for embedded relations
-                foreach ($inlineRelations as $fieldName => $relationData) {
-                    $config = $relationData['config'];
-                    $foreignTable = $config['foreign_table'] ?? '';
-                    $foreignField = $config['foreign_field'] ?? '';
-                    
-                    if (empty($foreignTable) || empty($foreignField)) {
-                        continue;
-                    }
-                    
-                    // Check if this is an embedded table
-                    $foreignTableTCA = $GLOBALS['TCA'][$foreignTable] ?? [];
-                    $isHiddenTable = ($foreignTableTCA['ctrl']['hideTable'] ?? false) === true;
-                    
-                    if ($isHiddenTable) {
-                        // Collect the UIDs of created child records
-                        $childUids = [];
-                        foreach ($childDataHandler->substNEWwithIDs as $newId => $realId) {
-                            if (strpos($newId, 'NEW') === 0 && isset($childDataMap[$foreignTable][$newId])) {
-                                $childUids[] = $realId;
-                            }
-                        }
-                        
-                        if (!empty($childUids)) {
-                            // Update foreign field directly in database
-                            // RelationHandler's writeForeignField is for MM relations, not direct foreign fields
-                            $connection = GeneralUtility::makeInstance(ConnectionPool::class)
-                                ->getConnectionForTable($foreignTable);
-                            
-                            // In update context, $uid is already the live UID
-                            foreach ($childUids as $childUid) {
-                                $connection->update(
-                                    $foreignTable,
-                                    [$foreignField => $uid],
-                                    ['uid' => $childUid]
-                                );
-                            }
-                        }
-                    }
-                }
-            }
+
+            $this->buildInlineDataMap($dataMap, $table, $workspaceUid, $pid, $inlineRelations);
+
+            // Sync inline relations: remove children that are no longer in the new list.
+            // DataHandler's raw dataMap processing does not automatically delete absent
+            // children (that's FormEngine's job), so we handle it explicitly via cmdMap.
+            $this->syncInlineRelations($dataMap, $cmdMap, $table, $uid, $inlineRelations);
+        }
+
+        // Process everything in a single DataHandler call (dataMap + cmdMap)
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+        $dataHandler->start($dataMap, $cmdMap);
+        $dataHandler->process_datamap();
+        if (!empty($cmdMap)) {
+            $dataHandler->process_cmdmap();
+        }
+
+        // Check for errors
+        if (!empty($dataHandler->errorLog)) {
+            return $this->createErrorResult('Error updating record: ' . implode(', ', $dataHandler->errorLog));
         }
         
+        // Dispatch AfterRecordWriteEvent
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $eventDispatcher->dispatch(new AfterRecordWriteEvent($table, 'update', $uid, $data, null));
+
         // Return the result with the original live UID
         return $this->createJsonResult([
             'action' => 'update',
@@ -580,6 +456,10 @@ class WriteTableTool extends AbstractRecordTool
             return $this->createErrorResult('Error deleting record: ' . implode(', ', $dataHandler->errorLog));
         }
         
+        // Dispatch AfterRecordWriteEvent
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $eventDispatcher->dispatch(new AfterRecordWriteEvent($table, 'delete', $uid, [], null));
+
         return $this->createJsonResult([
             'action' => 'delete',
             'table' => $table,
@@ -587,6 +467,149 @@ class WriteTableTool extends AbstractRecordTool
         ]);
     }
     
+    /**
+     * Move/reorder an existing record
+     */
+    protected function moveRecord(string $table, int $uid, string $position, ?int $targetPid = null): CallToolResult
+    {
+        $workspaceUid = $this->resolveToWorkspaceUid($table, $uid);
+        $record = BackendUtility::getRecord($table, $workspaceUid, 'pid');
+        if (!$record) {
+            return $this->createErrorResult('Record not found');
+        }
+
+        // Use target pid for cross-page moves, or current pid for same-page moves
+        $pid = $targetPid ?? (int)$record['pid'];
+
+        $error = $this->applyPosition($table, $workspaceUid, $pid, $position);
+        if ($error !== null) {
+            return $this->createErrorResult('Error moving record: ' . $error);
+        }
+
+        return $this->createJsonResult([
+            'action' => 'move',
+            'table' => $table,
+            'uid' => $uid,
+            'pid' => $pid,
+        ]);
+    }
+
+    /**
+     * Apply a position to a record via DataHandler move command
+     *
+     * @return string|null Error message, or null on success
+     */
+    protected function applyPosition(string $table, int $recordUid, int $pid, string $position): ?string
+    {
+        if ($position === 'top') {
+            // DataHandler: positive pid = first position on that page
+            $cmdMap = [$table => [$recordUid => ['move' => $pid]]];
+        } elseif ($position === 'bottom') {
+            // Find the last record on the page and move after it
+            $sortingField = $this->tableAccessService->getSortingFieldName($table);
+            $currentWorkspace = $GLOBALS['BE_USER']->workspace ?? 0;
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getQueryBuilderForTable($table);
+            $queryBuilder->getRestrictions()->removeAll()
+                ->add(GeneralUtility::makeInstance(DeletedRestriction::class))
+                ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, $currentWorkspace));
+
+            $orderField = $sortingField ?? 'uid';
+            $lastUid = $queryBuilder
+                ->select('uid')
+                ->from($table)
+                ->where(
+                    $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pid, ParameterType::INTEGER)),
+                    $queryBuilder->expr()->neq('uid', $queryBuilder->createNamedParameter($recordUid, ParameterType::INTEGER))
+                )
+                ->orderBy($orderField, 'DESC')
+                ->setMaxResults(1)
+                ->executeQuery()
+                ->fetchOne();
+
+            if ($lastUid) {
+                // DataHandler: negative uid = after that record
+                $cmdMap = [$table => [$recordUid => ['move' => -(int)$lastUid]]];
+            } else {
+                // No other records on page — move to first position on target page
+                $cmdMap = [$table => [$recordUid => ['move' => $pid]]];
+            }
+        } elseif (strpos($position, 'after:') === 0) {
+            // DataHandler: negative uid = after that record
+            $referenceUid = (int)substr($position, 6);
+            $cmdMap = [$table => [$recordUid => ['move' => -$referenceUid]]];
+        } elseif (strpos($position, 'before:') === 0) {
+            // DataHandler has no native "before" — find the previous sibling and insert after it,
+            // or move to first position on the page if the reference is already first.
+            $referenceUid = (int)substr($position, 7);
+            $cmdMap = $this->buildBeforePositionCmdMap($table, $recordUid, $pid, $referenceUid);
+        } else {
+            // Unknown position — skip
+            return null;
+        }
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+        $dataHandler->start([], $cmdMap);
+        $dataHandler->process_cmdmap();
+
+        if (!empty($dataHandler->errorLog)) {
+            return implode(', ', $dataHandler->errorLog);
+        }
+
+        return null;
+    }
+
+    /**
+     * Build a cmdMap for "before:X" positioning.
+     *
+     * DataHandler has no native "before" concept. We find the previous sibling of the
+     * reference record (same pid, lower sorting) and insert after it. If the reference
+     * is already the first record on the page, we insert at the top of the page instead.
+     *
+     * @return array cmdMap ready for DataHandler::start()
+     */
+    protected function buildBeforePositionCmdMap(string $table, int $recordUid, int $pid, int $referenceUid): array
+    {
+        $sortingField = $this->tableAccessService->getSortingFieldName($table);
+
+        // Resolve reference record's pid and sorting in workspace context
+        $refRecord = BackendUtility::getRecord($table, $referenceUid, 'pid' . ($sortingField ? ',' . $sortingField : ''));
+        BackendUtility::workspaceOL($table, $refRecord);
+
+        $refPid = $refRecord ? (int)$refRecord['pid'] : $pid;
+        $refSorting = $sortingField && $refRecord ? (int)$refRecord[$sortingField] : 0;
+
+        if ($sortingField && $refSorting > 0) {
+            // Find the record just before the reference in sort order on the same page
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getQueryBuilderForTable($table);
+            $queryBuilder->getRestrictions()->removeAll()
+                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+
+            $prevUid = $queryBuilder
+                ->select('uid')
+                ->from($table)
+                ->where(
+                    $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($refPid, ParameterType::INTEGER)),
+                    $queryBuilder->expr()->lt($sortingField, $queryBuilder->createNamedParameter($refSorting, ParameterType::INTEGER)),
+                    $queryBuilder->expr()->neq('uid', $queryBuilder->createNamedParameter($recordUid, ParameterType::INTEGER))
+                )
+                ->orderBy($sortingField, 'DESC')
+                ->setMaxResults(1)
+                ->executeQuery()
+                ->fetchOne();
+
+            if ($prevUid) {
+                // Insert after the previous sibling
+                return [$table => [$recordUid => ['move' => -(int)$prevUid]]];
+            }
+        }
+
+        // No previous sibling (or no sorting field) — insert as first on the page
+        return [$table => [$recordUid => ['move' => $refPid]]];
+    }
+
     /**
      * Translate a record to another language
      */
@@ -717,12 +740,8 @@ class WriteTableTool extends AbstractRecordTool
                 continue;
             }
 
-            // Check if field is accessible (filters out file fields and inaccessible inline relations)
+            // Check if field is accessible (filters out inaccessible inline relations)
             if (!$this->tableAccessService->canAccessField($table, $fieldName)) {
-                $fieldType = $fieldConfig['config']['type'] ?? '';
-                if ($fieldType === 'file') {
-                    return "Field '{$fieldName}': File fields are not supported. Please use TYPO3 backend for file operations.";
-                }
                 return "Field '{$fieldName}' is not accessible";
             }
 
@@ -731,7 +750,7 @@ class WriteTableTool extends AbstractRecordTool
             if ($validationError !== null) {
                 return $validationError;
             }
-            
+
             // Handle date/time fields - convert ISO 8601 to timestamp for TYPO3
             if (!empty($fieldConfig['config']['eval'])) {
                 $evalRules = GeneralUtility::trimExplode(',', $fieldConfig['config']['eval'], true);
@@ -747,9 +766,9 @@ class WriteTableTool extends AbstractRecordTool
                     }
                 }
             }
-            
-            // Validate inline field type
-            if ($fieldConfig['config']['type'] === 'inline') {
+
+            // Validate inline and file field types (file fields are inline to sys_file_reference)
+            if (in_array($fieldConfig['config']['type'], ['inline', 'file'], true)) {
                 // Validate inline relation data
                 $validationError = $this->validateInlineRelationData($fieldConfig, $value);
                 if ($validationError !== null) {
@@ -835,249 +854,241 @@ class WriteTableTool extends AbstractRecordTool
     
     
     /**
-     * Extract inline relations from data array
+     * Extract inline relations from data array.
+     *
+     * Removes inline/file fields from $data and returns them separately
+     * so they can be processed via buildInlineDataMap().
      */
     protected function extractInlineRelations(string $table, array &$data): array
     {
         $inlineRelations = [];
-        
+
         if (!isset($GLOBALS['TCA'][$table]['columns'])) {
             return $inlineRelations;
         }
-        
+
         foreach ($data as $fieldName => $value) {
             $fieldConfig = $this->tableAccessService->getFieldConfig($table, $fieldName);
-            if ($fieldConfig && ($fieldConfig['config']['type'] ?? '') === 'inline') {
+            $fieldType = $fieldConfig['config']['type'] ?? '';
+            // Handle both inline and file fields (file is inline to sys_file_reference)
+            if ($fieldConfig && in_array($fieldType, ['inline', 'file'], true)) {
+                $config = $fieldConfig['config'];
+                // For file fields, ensure foreign_table defaults to sys_file_reference
+                if ($fieldType === 'file' && empty($config['foreign_table'])) {
+                    $config['foreign_table'] = 'sys_file_reference';
+                }
+                if ($fieldType === 'file' && empty($config['foreign_field'])) {
+                    $config['foreign_field'] = 'uid_foreign';
+                }
                 $inlineRelations[$fieldName] = [
-                    'config' => $fieldConfig['config'],
+                    'config' => $config,
                     'value' => $value
                 ];
-                // Remove from data array as we'll process it separately
+                // Remove from data array as we'll process it via buildInlineDataMap
                 unset($data[$fieldName]);
             }
         }
-        
+
         return $inlineRelations;
     }
-    
+
     /**
-     * Process inline relations for DataHandler
+     * Build a unified DataHandler dataMap for parent + all inline children.
+     *
+     * Instead of creating parent and children in separate DataHandler calls,
+     * this builds a single dataMap where the parent's inline field is set to
+     * a comma-separated list of child NEW keys (or existing UIDs). DataHandler
+     * natively resolves these references, sets foreign_field values, handles
+     * workspace versioning, and manages relation sync — all atomically.
+     *
+     * @param array &$dataMap The dataMap to add inline children to (parent entry must already exist)
+     * @param string $parentTable The parent table name
+     * @param string|int $parentId The parent's key in the dataMap (NEW key or existing UID)
+     * @param int $pid Page ID for new child records
+     * @param array $inlineRelations Extracted inline relations from extractInlineRelations()
      */
-    protected function processInlineRelations(
+    protected function buildInlineDataMap(
         array &$dataMap,
         string $parentTable,
-        $parentUid,
+        $parentId,
         int $pid,
-        array $inlineRelations,
-        ?int $liveUid = null
+        array $inlineRelations
     ): void {
         foreach ($inlineRelations as $fieldName => $relationData) {
             $config = $relationData['config'];
             $value = $relationData['value'];
             $foreignTable = $config['foreign_table'] ?? '';
             $foreignField = $config['foreign_field'] ?? '';
-            
+
             if (empty($foreignTable) || empty($foreignField)) {
                 continue;
             }
-            
-            // Check if foreign table is hidden (embedded records)
-            $foreignTableTCA = $GLOBALS['TCA'][$foreignTable] ?? [];
-            $isHiddenTable = ($foreignTableTCA['ctrl']['hideTable'] ?? false) === true;
-            
-            if ($isHiddenTable) {
-                // Process embedded inline relations (e.g., tx_news_domain_model_link)
-                $this->processEmbeddedInlineRelations($dataMap, $foreignTable, $foreignField, $parentUid, $pid, $value, $config, $liveUid);
-            } else {
-                // Process independent inline relations (e.g., tt_content)
-                $this->processIndependentInlineRelations($foreignTable, $foreignField, $parentUid, $value, $liveUid);
+
+            $isFileReference = ($foreignTable === 'sys_file_reference');
+
+            // Build the list of child identifiers (NEW keys for new records, UIDs for existing)
+            $childIdentifiers = [];
+
+            foreach ($value as $index => $item) {
+                if (is_array($item) && isset($item['uid']) && is_numeric($item['uid']) && (int)$item['uid'] > 0) {
+                    // Existing record reference via {"uid": N, ...} — keep or update
+                    $existingUid = (int)$item['uid'];
+                    unset($item['uid'], $item[$foreignField]);
+
+                    // If additional fields provided, add as update to dataMap
+                    if (!empty($item)) {
+                        $dataMap[$foreignTable][$existingUid] = $item;
+                    }
+
+                    $childIdentifiers[] = $existingUid;
+                } elseif (is_array($item)) {
+                    // Embedded record data — create a new child record
+                    $childNewId = 'NEW' . bin2hex(random_bytes(8));
+
+                    // Remove foreign field — DataHandler sets it via inline parent context
+                    unset($item[$foreignField]);
+                    $item['pid'] = $pid;
+
+                    // For sys_file_reference, force context fields server-side (don't trust client)
+                    if ($isFileReference) {
+                        $item['tablenames'] = $parentTable;
+                        $item['fieldname'] = $fieldName;
+                        $item['table_local'] = 'sys_file';
+                    }
+
+                    // Recursively handle nested inline relations in the child record
+                    $nestedInlineRelations = $this->extractInlineRelations($foreignTable, $item);
+                    if (!empty($nestedInlineRelations)) {
+                        // Add child to dataMap first so buildInlineDataMap can reference it
+                        $dataMap[$foreignTable][$childNewId] = $item;
+                        $this->buildInlineDataMap($dataMap, $foreignTable, $childNewId, $pid, $nestedInlineRelations);
+                    } else {
+                        $dataMap[$foreignTable][$childNewId] = $item;
+                    }
+
+                    $childIdentifiers[] = $childNewId;
+                } elseif (is_numeric($item) && (int)$item > 0) {
+                    if ($isFileReference) {
+                        // File reference shorthand: plain UID means uid_local (sys_file UID)
+                        $childNewId = 'NEW' . bin2hex(random_bytes(8));
+                        $dataMap[$foreignTable][$childNewId] = [
+                            'uid_local' => (int)$item,
+                            'pid' => $pid,
+                            'tablenames' => $parentTable,
+                            'fieldname' => $fieldName,
+                            'table_local' => 'sys_file',
+                        ];
+                        $childIdentifiers[] = $childNewId;
+                    } else {
+                        // Existing UID — reference it directly
+                        $childIdentifiers[] = (int)$item;
+                    }
+                }
+                // Invalid items were already caught by validateInlineRelationData
             }
+
+            // Set the inline field on the parent to the CSV of child identifiers.
+            // DataHandler resolves NEW keys, sets foreign_field values, and handles
+            // workspace versioning. For creates, this is sufficient. For updates,
+            // syncInlineRelations() must also be called to delete absent children
+            // (DataHandler's raw dataMap does not handle relation sync automatically).
+            $dataMap[$parentTable][$parentId][$fieldName] = implode(',', $childIdentifiers);
         }
     }
-    
+
     /**
-     * Process embedded inline relations (hideTable=true)
+     * Sync inline relations on update: delete/unlink children absent from the new list.
+     *
+     * DataHandler's raw dataMap processing does not automatically remove children
+     * that are no longer referenced (that behavior is part of FormEngine, not DataHandler).
+     * This method explicitly builds cmdMap entries to delete embedded children (hideTable)
+     * or unlink independent children (clear foreign_field) that are absent from the new list.
+     *
+     * @param array &$dataMap The dataMap (read to extract new child identifiers per field)
+     * @param array &$cmdMap The cmdMap to add deletion commands to
+     * @param string $parentTable The parent table name
+     * @param int $parentLiveUid The parent's live UID (used to query existing children)
+     * @param array $inlineRelations The extracted inline relations
      */
-    protected function processEmbeddedInlineRelations(
+    protected function syncInlineRelations(
         array &$dataMap,
-        string $foreignTable,
-        string $foreignField,
-        $parentUid,
-        int $pid,
-        array $records,
-        array $config,
-        ?int $liveUid = null
+        array &$cmdMap,
+        string $parentTable,
+        int $parentLiveUid,
+        array $inlineRelations
     ): void {
-        // If we're updating, handle existing relations
-        if ($liveUid !== null) {
-            $this->handleExistingEmbeddedRelations($foreignTable, $foreignField, $liveUid, $records);
-        }
-        
-        foreach ($records as $index => $recordData) {
-            if (!is_array($recordData)) {
+        foreach ($inlineRelations as $fieldName => $relationData) {
+            $config = $relationData['config'];
+            $foreignTable = $config['foreign_table'] ?? '';
+            $foreignField = $config['foreign_field'] ?? '';
+
+            if (empty($foreignTable) || empty($foreignField)) {
                 continue;
             }
-            
-            // Create new ID for the inline record
-            $newId = 'NEW' . uniqid() . '_' . $index;
-            
-            // Don't set the foreign field here - it will be handled by RelationHandler
-            // Remove it if it was accidentally included
-            unset($recordData[$foreignField]);
-            $recordData['pid'] = $pid;
-            
-            // If we have a sorting field, set it
-            if (isset($config['foreign_sortby'])) {
-                $recordData[$config['foreign_sortby']] = ($index + 1) * 256;
-            }
-            
-            // Add to data map
-            if (!isset($dataMap[$foreignTable])) {
-                $dataMap[$foreignTable] = [];
-            }
-            $dataMap[$foreignTable][$newId] = $recordData;
-        }
-    }
-    
-    /**
-     * Process independent inline relations (UIDs only)
-     */
-    protected function processIndependentInlineRelations(
-        string $foreignTable,
-        string $foreignField,
-        $parentUid,
-        array $uids,
-        ?int $liveUid = null
-    ): void {
-        // For updates, we need to handle existing relations
-        if ($liveUid !== null) {
-            // First, clear existing relations
-            $this->clearExistingInlineRelations($foreignTable, $foreignField, $liveUid);
-        }
-        
-        // Update foreign field on specified records
-        if (!empty($uids)) {
-            $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
-            $dataHandler->BE_USER = $GLOBALS['BE_USER'];
-            
-            $updateMap = [];
-            foreach ($uids as $uid) {
-                if (is_numeric($uid) && $uid > 0) {
-                    $updateMap[$foreignTable][$uid] = [
-                        $foreignField => $liveUid ?? $parentUid
-                    ];
+
+            // Determine which existing UIDs are in the new list
+            $newChildUids = [];
+            // Read the parent's inline field CSV from the dataMap
+            foreach ($dataMap[$parentTable] as $parentData) {
+                if (isset($parentData[$fieldName])) {
+                    $csv = (string)$parentData[$fieldName];
+                    if ($csv !== '') {
+                        foreach (explode(',', $csv) as $identifier) {
+                            // Only collect numeric UIDs (skip NEW keys — those are new records)
+                            if (is_numeric($identifier)) {
+                                $newChildUids[] = (int)$identifier;
+                            }
+                        }
+                    }
                 }
             }
-            
-            if (!empty($updateMap)) {
-                $dataHandler->start($updateMap, []);
-                $dataHandler->process_datamap();
-            }
-        }
-    }
-    
-    /**
-     * Clear existing inline relations
-     */
-    protected function clearExistingInlineRelations(string $foreignTable, string $foreignField, int $parentUid): void
-    {
-        // Get all records that currently have this parent
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable($foreignTable);
-        
-        $queryBuilder->getRestrictions()
-            ->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class))
-            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, $GLOBALS['BE_USER']->workspace ?? 0));
-        
-        $existingRecords = $queryBuilder
-            ->select('uid')
-            ->from($foreignTable)
-            ->where(
-                $queryBuilder->expr()->eq($foreignField, $queryBuilder->createNamedParameter($parentUid, ParameterType::INTEGER))
-            )
-            ->executeQuery()
-            ->fetchAllAssociative();
-        
-        if (!empty($existingRecords)) {
-            // Use DataHandler to clear relations to respect workspaces
-            $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
-            $dataHandler->BE_USER = $GLOBALS['BE_USER'];
-            
-            $updateMap = [];
-            foreach ($existingRecords as $record) {
-                $updateMap[$foreignTable][$record['uid']] = [
-                    $foreignField => 0
-                ];
-            }
-            
-            if (!empty($updateMap)) {
-                $dataHandler->start($updateMap, []);
-                $dataHandler->process_datamap();
+
+            // Query existing children from database.
+            // Use DeletedRestriction only (not WorkspaceRestriction) so we get
+            // live records with their live UIDs. This avoids the mismatch where
+            // WorkspaceRestriction returns workspace overlay UIDs that don't match
+            // the live UIDs in $newChildUids.
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getQueryBuilderForTable($foreignTable);
+            $queryBuilder->getRestrictions()
+                ->removeAll()
+                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+
+            $existingChildren = $queryBuilder
+                ->select('uid')
+                ->from($foreignTable)
+                ->where(
+                    $queryBuilder->expr()->eq(
+                        $foreignField,
+                        $queryBuilder->createNamedParameter($parentLiveUid, ParameterType::INTEGER)
+                    ),
+                    // Only live records (not workspace overlays which have t3ver_oid > 0)
+                    $queryBuilder->expr()->eq('t3ver_oid', 0)
+                )
+                ->executeQuery()
+                ->fetchAllAssociative();
+
+            // Find children that should be removed (exist in DB but not in new list)
+            $foreignTableTCA = $GLOBALS['TCA'][$foreignTable] ?? [];
+            $isEmbeddedTable = !empty($foreignTableTCA['ctrl']['hideTable']);
+
+            foreach ($existingChildren as $existingChild) {
+                $childLiveUid = (int)$existingChild['uid'];
+                if (!in_array($childLiveUid, $newChildUids, true)) {
+                    if ($isEmbeddedTable) {
+                        // Embedded (hideTable) children: delete via DataHandler cmdMap.
+                        // DataHandler handles workspace versioning (creates delete placeholder).
+                        $cmdMap[$foreignTable][$childLiveUid]['delete'] = 1;
+                    } else {
+                        // Independent children: clear foreign_field via DataHandler dataMap.
+                        // DataHandler handles workspace versioning (creates workspace overlay).
+                        $dataMap[$foreignTable][$childLiveUid] = [$foreignField => 0];
+                    }
+                }
             }
         }
     }
-    
-    /**
-     * Handle existing embedded relations during updates
-     */
-    protected function handleExistingEmbeddedRelations(
-        string $foreignTable,
-        string $foreignField,
-        int $parentUid,
-        array $newRecords
-    ): void {
-        // Get all existing child records for this parent
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable($foreignTable);
-        
-        $queryBuilder->getRestrictions()
-            ->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class))
-            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, $GLOBALS['BE_USER']->workspace ?? 0));
-        
-        $existingRecords = $queryBuilder
-            ->select('uid')
-            ->from($foreignTable)
-            ->where(
-                $queryBuilder->expr()->eq($foreignField, $queryBuilder->createNamedParameter($parentUid, ParameterType::INTEGER))
-            )
-            ->executeQuery()
-            ->fetchAllAssociative();
-        
-        if (!empty($existingRecords)) {
-            // Extract UIDs of new records that have UIDs (updates)
-            $keepUids = [];
-            foreach ($newRecords as $record) {
-                if (is_array($record) && isset($record['uid']) && is_numeric($record['uid'])) {
-                    $keepUids[] = (int)$record['uid'];
-                }
-            }
-            
-            // Delete records that are not in the new set
-            $deleteUids = [];
-            foreach ($existingRecords as $existingRecord) {
-                if (!in_array((int)$existingRecord['uid'], $keepUids, true)) {
-                    $deleteUids[] = (int)$existingRecord['uid'];
-                }
-            }
-            
-            if (!empty($deleteUids)) {
-                // Use DataHandler to delete records (respects workspaces)
-                $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
-                $dataHandler->BE_USER = $GLOBALS['BE_USER'];
-                
-                $cmdMap = [];
-                foreach ($deleteUids as $deleteUid) {
-                    $cmdMap[$foreignTable][$deleteUid]['delete'] = 1;
-                }
-                
-                $dataHandler->start([], $cmdMap);
-                $dataHandler->process_cmdmap();
-            }
-        }
-    }
-    
+
     /**
      * Validate inline relation data
      */
@@ -1087,36 +1098,42 @@ class WriteTableTool extends AbstractRecordTool
         if (!is_array($value)) {
             return 'Inline relation field must be an array of UIDs or record data';
         }
-        
+
         // Get foreign table
         $foreignTable = $fieldConfig['config']['foreign_table'] ?? '';
         if (empty($foreignTable)) {
             return 'Invalid inline relation configuration: missing foreign_table';
         }
-        
-        // Check if foreign table is hidden (embedded records)
-        $foreignTableTCA = $GLOBALS['TCA'][$foreignTable] ?? [];
-        $isHiddenTable = ($foreignTableTCA['ctrl']['hideTable'] ?? false) === true;
-        
-        // Validate each item
+
+        $isFileReference = ($foreignTable === 'sys_file_reference');
+
+        // Validate each item - accept both record data arrays and UIDs
         foreach ($value as $index => $item) {
-            if ($isHiddenTable) {
-                // For hidden tables, expect record data arrays
-                if (!is_array($item)) {
-                    return 'Embedded inline relations must contain record data arrays';
+            if ($isFileReference) {
+                // File references accept either plain UIDs (shorthand) or record data arrays
+                if (is_numeric($item) && (int)$item > 0) {
+                    continue;
                 }
-                // Basic validation - must have at least one field
+                if (is_array($item)) {
+                    if (empty($item['uid_local']) || !is_numeric($item['uid_local'])) {
+                        return 'File reference at index ' . $index . ' must contain uid_local (sys_file UID)';
+                    }
+                    continue;
+                }
+                return 'File reference at index ' . $index . ' must be a sys_file UID or an object with uid_local';
+            } elseif (is_array($item)) {
+                // Record data arrays for embedded inline relations
                 if (empty($item)) {
                     return 'Embedded inline relation record at index ' . $index . ' is empty';
                 }
+            } elseif (is_numeric($item) && $item > 0) {
+                // UIDs for independent inline relations
+                continue;
             } else {
-                // For independent tables, expect UIDs
-                if (!is_numeric($item) || $item <= 0) {
-                    return 'Independent inline relations must contain only positive integer UIDs';
-                }
+                return 'Inline relation at index ' . $index . ' must be a record data array or a positive integer UID';
             }
         }
-        
+
         return null;
     }
     
@@ -1150,9 +1167,9 @@ class WriteTableTool extends AbstractRecordTool
                 continue;
             }
 
-            // Check if this is an inline relation field — those genuinely use arrays
+            // Check if this is an inline/file relation field — those genuinely use arrays
             $fieldConfig = $this->tableAccessService->getFieldConfig($table, $fieldName);
-            if ($fieldConfig && ($fieldConfig['config']['type'] ?? '') === 'inline') {
+            if ($fieldConfig && in_array($fieldConfig['config']['type'] ?? '', ['inline', 'file'], true)) {
                 continue;
             }
 

--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hn\McpServer\Service;
 
+use Hn\McpServer\Event\ModifyAvailableFieldsEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
@@ -306,7 +308,12 @@ class TableAccessService implements SingletonInterface
                 unset($fields[$fieldName]);
             }
         }
-        
+
+        // Allow extensions to modify the field list
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $event = $eventDispatcher->dispatch(new ModifyAvailableFieldsEvent($table, $type, $fields));
+        $fields = $event->getFields();
+
         return $fields;
     }
     
@@ -423,6 +430,7 @@ class TableAccessService implements SingletonInterface
             // Allow some safe root-level tables
             $allowedRootTables = [
                 'sys_file_storage', // File storage configuration
+                'sys_file_reference', // FAL reference table - needed for file operations
                 'sys_domain', // Domain configuration
                 'sys_category', // Category system - safe for read operations
             ];
@@ -447,7 +455,6 @@ class TableAccessService implements SingletonInterface
             'cache_hash', // Cache tables - managed by system
             'sys_be_shortcuts', // User shortcuts - user-specific
             'sys_news', // System news - admin-only
-            'sys_file_reference', // FAL reference table - file handling not supported yet
         ];
         
         if (in_array($table, $restrictedTables)) {
@@ -599,10 +606,15 @@ class TableAccessService implements SingletonInterface
     {
         $fieldConfig = $GLOBALS['TCA'][$table]['columns'][$fieldName] ?? [];
 
-        // Block file fields - file handling not supported yet
         $fieldType = $fieldConfig['config']['type'] ?? '';
+
+        // Treat file fields like inline relations (both use sys_file_reference)
         if ($fieldType === 'file') {
-            return false;
+            $foreignTable = $fieldConfig['config']['foreign_table'] ?? 'sys_file_reference';
+            if (!$this->canAccessTable($foreignTable)) {
+                return false;
+            }
+            return true;
         }
 
         // Block inline relations where foreign table isn't writable
@@ -885,24 +897,24 @@ class TableAccessService implements SingletonInterface
             return ['1' => 'Default'];
         }
 
-        // Defense-in-depth: foreign type notation should already be caught by
-        // getTypeFieldName() returning null, but guard here in case that changes.
+        // Handle foreign type notation (e.g. "uid_local:type" in sys_file_reference).
+        // The type is derived from a related record's field and has no local column or items list.
         if (str_contains($typeField, ':')) {
             return ['0' => 'Default'];
         }
 
         $typeConfig = $GLOBALS['TCA'][$table]['columns'][$typeField]['config'] ?? [];
         $items = $typeConfig['items'] ?? [];
-        
+
         // Use the shared parseSelectItems method
         $parsed = $this->parseSelectItems($items);
-        
+
         // Convert to the expected format (value => label)
         $types = [];
         foreach ($parsed['values'] as $value) {
             $types[$value] = $parsed['labels'][$value] ?? $value;
         }
-        
+
         return $types;
     }
     

--- a/Classes/Traits/ExceptionHandlerTrait.php
+++ b/Classes/Traits/ExceptionHandlerTrait.php
@@ -50,10 +50,10 @@ trait ExceptionHandlerTrait
         
         // Determine user-friendly message
         $userMessage = $this->getUserFriendlyMessage($e, $operation);
-        
+
         return $this->createErrorResult($userMessage);
     }
-    
+
     /**
      * Log exception with context
      * 

--- a/Classes/Utility/TcaFormattingUtility.php
+++ b/Classes/Utility/TcaFormattingUtility.php
@@ -143,7 +143,25 @@ class TcaFormattingUtility
             case 'inline':
                 // Add foreign table if available
                 if (isset($config['foreign_table'])) {
-                    $result .= " [foreign table: " . $config['foreign_table'] . "]";
+                    $foreignTable = $config['foreign_table'];
+                    $foreignField = $config['foreign_field'] ?? '';
+                    $foreignTableTCA = $GLOBALS['TCA'][$foreignTable] ?? [];
+                    $isHiddenTable = !empty($foreignTableTCA['ctrl']['hideTable']);
+                    $foreignFieldType = $foreignTableTCA['columns'][$foreignField]['config']['type'] ?? '';
+                    $isPassthrough = ($foreignFieldType === 'passthrough');
+
+                    $result .= " [foreign table: " . $foreignTable . "]";
+                    if (!empty($foreignField)) {
+                        $result .= " [foreign_field: " . $foreignField . "]";
+                    }
+
+                    if ($isHiddenTable || $isPassthrough) {
+                        $result .= " [EMBEDDED: when creating pass record data arrays;"
+                            . " when updating pass existing UIDs to keep them"
+                            . " and new record data arrays to add — order defines sorting]";
+                    } else {
+                        $result .= " [INDEPENDENT: pass existing UIDs to link, or record data arrays to create and link]";
+                    }
                 }
                 break;
                 

--- a/Documentation/Architecture/InlineRelations.md
+++ b/Documentation/Architecture/InlineRelations.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-TYPO3 inline relations (IRRE - Inline Relational Record Editing) allow records to be related to each other in parent-child relationships. The MCP tools support both reading and writing inline relations with some limitations.
+TYPO3 inline relations (IRRE - Inline Relational Record Editing) allow records to be related to each other in parent-child relationships. The MCP tools support both reading and writing inline relations using DataHandler's native inline handling.
 
 ## Types of Inline Relations
 
@@ -10,7 +10,7 @@ TYPO3 inline relations (IRRE - Inline Relational Record Editing) allow records t
 - Tables that exist independently (e.g., `tt_content`)
 - Have `hideTable = false` in TCA
 - Displayed as UIDs in read results
-- Can be managed through foreign field updates
+- Written by passing an array of UIDs
 
 Example:
 ```php
@@ -19,7 +19,7 @@ $result = $readTool->execute([
     'table' => 'tx_news_domain_model_news',
     'uid' => 123
 ]);
-// Returns: 
+// Returns:
 // ['content_elements' => [456, 789, 1011]]  // Array of UIDs
 ```
 
@@ -27,7 +27,7 @@ $result = $readTool->execute([
 - Tables that only exist as children (e.g., `sys_file_reference`, `tx_news_domain_model_link`)
 - Have `hideTable = true` in TCA
 - Displayed as full embedded records in read results
-- Should be created together with parent record
+- Written by passing record data arrays
 
 Example:
 ```php
@@ -45,8 +45,8 @@ $result = $readTool->execute([
 
 ## Writing Inline Relations
 
-### Method 1: Foreign Field Update (Currently Working)
-For independent relations, update the foreign field on child records:
+### Method 1: Foreign Field Update
+For independent relations, update the foreign field on child records directly:
 
 ```php
 // Create content element related to news
@@ -62,7 +62,7 @@ $writeTool->execute([
 ]);
 ```
 
-### Method 2: Parent Record Update with UIDs (Implemented)
+### Method 2: Parent Record with UIDs
 For independent relations, pass array of UIDs when updating parent:
 
 ```php
@@ -75,10 +75,11 @@ $writeTool->execute([
         'content_elements' => [456, 789, 1011]  // Array of UIDs
     ]
 ]);
+// Children not in the list are automatically unlinked (foreign_field set to 0)
 ```
 
-### Method 3: Embedded Record Creation (Partially Working)
-For dependent relations, pass record data when creating parent:
+### Method 3: Embedded Record Creation
+For dependent relations, pass record data arrays:
 
 ```php
 // Create news with embedded links
@@ -94,42 +95,86 @@ $writeTool->execute([
         ]
     ]
 ]);
+// On update, children not in the list are automatically deleted
 ```
 
-## Current Implementation
+### File References
+File fields accept sys_file UIDs or record data objects:
 
-### 1. Embedded Relations with Direct Database Updates
-- Creating embedded relations through parent record works with a two-step process:
-  1. DataHandler creates the child records with placeholder IDs
-  2. Direct database UPDATE sets the foreign field after creation
-- The foreign field (e.g., `parent` in `tx_news_domain_model_link`) is NOT defined in the child table's TCA columns by design
-- DataHandler only processes fields that are defined in TCA columns, so it ignores the foreign field
-- **Solution**: After DataHandler creates child records, we directly update the foreign field in the database
-- **Working Example**: Creating news with embedded links now works correctly
+```php
+$writeTool->execute([
+    'table' => 'tt_content',
+    'action' => 'create',
+    'pid' => 1,
+    'data' => [
+        'header' => 'With images',
+        'CType' => 'textmedia',
+        'assets' => [3, 4]  // sys_file UIDs (shorthand)
+    ]
+]);
+// Context fields (tablenames, fieldname, table_local) are set server-side
+```
 
-### 2. Restricted Tables
-- `sys_file_reference` is intentionally restricted in MCP tools because file references don't properly support workspaces
-- This is a deliberate limitation for now to ensure data integrity in workspace contexts
-- File uploads and media management require special handling outside of MCP tools
+## Implementation
 
-### 3. Automatic Workspace Handling
+### Single DataHandler Call (Unified dataMap)
+
+All inline relations — parent record and children — are processed in a **single DataHandler call** using a unified `$dataMap`. DataHandler natively resolves NEW key references, sets foreign_field values, and handles workspace versioning atomically.
+
+```php
+$dataMap = [
+    'tx_news_domain_model_news' => [
+        'NEWparent' => [
+            'title' => 'News with links',
+            'pid' => 1,
+            'related_links' => 'NEWchild1,NEWchild2',  // CSV of child keys
+        ],
+    ],
+    'tx_news_domain_model_link' => [
+        'NEWchild1' => ['title' => 'Link 1', 'uri' => 'https://example.com', 'pid' => 1],
+        'NEWchild2' => ['title' => 'Link 2', 'uri' => 't3://page?uid=42', 'pid' => 1],
+    ],
+];
+$dataHandler->start($dataMap, []);
+$dataHandler->process_datamap();
+```
+
+Key methods:
+- **`extractInlineRelations()`** — Separates inline/file fields from parent data
+- **`buildInlineDataMap()`** — Builds the unified dataMap with NEW keys and CSV references, handles nested inline relations recursively
+- **`syncInlineRelations()`** — On updates only: deletes/unlinks children absent from the new list (DataHandler's raw dataMap does not handle relation sync — that's FormEngine's job)
+
+### Relation Sync on Updates
+
+DataHandler's raw `process_datamap()` does **not** automatically remove children that are no longer listed. The `syncInlineRelations()` method handles this explicitly:
+
+- **Embedded tables** (`hideTable = true`): Absent children are deleted via DataHandler `cmdMap`
+- **Independent tables** (`hideTable = false`): Absent children have their `foreign_field` cleared via DataHandler `dataMap`
+
+Both paths go through DataHandler, ensuring proper workspace versioning.
+
+### File Reference Security
+
+For `sys_file_reference`, context fields are **always set server-side**:
+- `tablenames` → parent table name
+- `fieldname` → parent field name
+- `table_local` → `sys_file`
+
+Client-supplied values for these fields are overwritten to prevent cross-table reference manipulation.
+
+### Automatic Workspace Handling
 - Both ReadTableTool and WriteTableTool automatically initialize workspace context via `WorkspaceContextService`
 - The service finds the first writable workspace or creates a new "MCP Workspace" if needed
 - All operations (read/write) happen in the same workspace automatically
-- No manual workspace management is needed in tests or usage
-- Workspace transparency is maintained - tools work consistently across workspaces
-
-### 4. Sorting and Positioning
-- Sorting is handled through `sorting` or `sorting_foreign` fields
-- Position management (before/after) not fully implemented for inline relations
+- Workspace transparency is maintained — tools expose live UIDs only
 
 ## Best Practices
 
-1. **Use Foreign Field Method**: Most reliable method for creating inline relations
-2. **Check Table Configuration**: Verify if table has `hideTable` to determine relation type
-3. **Validate Data**: Ensure proper validation for inline relation data
-4. **Handle Errors**: Check DataHandler error log for detailed error messages
-5. **Test Thoroughly**: Inline relations can behave differently in various contexts
+1. **Use Embedded Data for Hidden Tables**: Pass record data arrays for `hideTable` relations, UIDs for independent tables
+2. **Check Table Configuration**: Verify `hideTable` in TCA to determine the relation type
+3. **Update Replaces Relations**: On updates, the provided list is the complete new state — absent children are removed
+4. **Nested Relations**: Supported recursively (e.g., file references on inline children)
+5. **Test Thoroughly**: Check all MCP tool calls for failure: `$this->assertFalse($result->isError, ...)`
 
 ## Technical Details
 
@@ -147,26 +192,18 @@ Inline relations are defined in TCA with type 'inline':
 ]
 ```
 
-### DataHandler Multi-Table Format
-DataHandler supports multi-table operations with placeholders:
+### Read vs Write Behavior
 
-```php
-$dataMap = [
-    'parent_table' => [
-        'NEW123' => ['field' => 'value']
-    ],
-    'child_table' => [
-        'NEW456' => ['other_field' => 'value']  // Note: foreign field NOT included
-    ]
-];
-// After DataHandler processing, foreign fields are updated directly:
-$connection->update('child_table', ['parent_field' => $parentUid], ['uid' => $childUid]);
-```
+| Aspect | Read (ReadTableTool) | Write (WriteTableTool) |
+|--------|---------------------|----------------------|
+| **Detection** | `hideTable` TCA flag | Per-item: arrays = embedded, integers = UIDs |
+| **Hidden tables** | Full embedded records | Accepts record data arrays |
+| **Visible tables** | UIDs only | Accepts UID arrays |
+| **Sorting** | `foreign_sortby` or default | CSV position determines order |
 
 ## Future Improvements
 
-1. **File Reference Support**: Add special handling for sys_file_reference when workspace support improves
-2. **Batch Operations**: Support for bulk inline relation updates
-3. **Position Management**: Full support for positioning inline records (before/after specific records)
-4. **Validation Enhancement**: More comprehensive validation for embedded record data
-5. **Performance Optimization**: Batch foreign field updates instead of individual UPDATE queries
+1. **Batch Operations**: Optimized bulk inline relation updates
+2. **Position Management**: Full support for positioning inline records (before/after specific records)
+3. **Recursion Limits**: Configurable depth limit for nested inline relations
+4. **Field Allowlisting**: Restrict which fields can be set on inline children

--- a/Tests/Functional/Event/ModifyAvailableFieldsEventTest.php
+++ b/Tests/Functional/Event/ModifyAvailableFieldsEventTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\Event;
+
+use Hn\McpServer\Event\ModifyAvailableFieldsEvent;
+use Hn\McpServer\Service\TableAccessService;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use TYPO3\CMS\Core\EventDispatcher\ListenerProvider;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Stateful test listener for ModifyAvailableFieldsEvent
+ */
+class ModifyAvailableFieldsTestListener
+{
+    public static bool $dispatched = false;
+    public static string $table = '';
+    public static string $type = '';
+    public static ?string $removeField = null;
+    public static ?array $addField = null;
+    public static ?array $replaceFields = null;
+
+    public static function reset(): void
+    {
+        self::$dispatched = false;
+        self::$table = '';
+        self::$type = '';
+        self::$removeField = null;
+        self::$addField = null;
+        self::$replaceFields = null;
+    }
+
+    public function __invoke(ModifyAvailableFieldsEvent $event): void
+    {
+        self::$dispatched = true;
+        self::$table = $event->getTable();
+        self::$type = $event->getType();
+
+        if (self::$removeField !== null) {
+            $event->removeField(self::$removeField);
+        }
+
+        if (self::$addField !== null) {
+            $event->addField(self::$addField['name'], self::$addField['config']);
+        }
+
+        if (self::$replaceFields !== null) {
+            $event->setFields(self::$replaceFields);
+        }
+    }
+}
+
+/**
+ * Tests for ModifyAvailableFieldsEvent
+ */
+class ModifyAvailableFieldsEventTest extends AbstractFunctionalTest
+{
+    private TableAccessService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = GeneralUtility::makeInstance(TableAccessService::class);
+
+        ModifyAvailableFieldsTestListener::reset();
+
+        $container = GeneralUtility::getContainer();
+        $container->set(ModifyAvailableFieldsTestListener::class, new ModifyAvailableFieldsTestListener());
+
+        $listenerProvider = $container->get(ListenerProvider::class);
+        $listenerProvider->addListener(ModifyAvailableFieldsEvent::class, ModifyAvailableFieldsTestListener::class);
+    }
+
+    /**
+     * Event is dispatched when getting available fields
+     */
+    public function testEventIsDispatched(): void
+    {
+        $this->service->getAvailableFields('pages');
+
+        $this->assertTrue(ModifyAvailableFieldsTestListener::$dispatched);
+        $this->assertEquals('pages', ModifyAvailableFieldsTestListener::$table);
+    }
+
+    /**
+     * Listener can remove fields
+     */
+    public function testListenerCanRemoveFields(): void
+    {
+        $fieldsBefore = $this->service->getAvailableFields('pages');
+        $this->assertArrayHasKey('title', $fieldsBefore);
+
+        ModifyAvailableFieldsTestListener::$removeField = 'title';
+
+        $fieldsAfter = $this->service->getAvailableFields('pages');
+        $this->assertArrayNotHasKey('title', $fieldsAfter);
+    }
+
+    /**
+     * Listener can add fields
+     */
+    public function testListenerCanAddFields(): void
+    {
+        ModifyAvailableFieldsTestListener::$addField = [
+            'name' => 'custom_computed',
+            'config' => ['config' => ['type' => 'input'], 'label' => 'Custom'],
+        ];
+
+        $fields = $this->service->getAvailableFields('pages');
+        $this->assertArrayHasKey('custom_computed', $fields);
+    }
+
+    /**
+     * Event receives correct type parameter
+     */
+    public function testEventReceivesType(): void
+    {
+        $this->service->getAvailableFields('tt_content', 'textmedia');
+
+        $this->assertEquals('textmedia', ModifyAvailableFieldsTestListener::$type);
+    }
+
+    /**
+     * setFields replaces entire field list
+     */
+    public function testSetFieldsReplacesAll(): void
+    {
+        ModifyAvailableFieldsTestListener::$replaceFields = [
+            'only_field' => ['config' => ['type' => 'input']],
+        ];
+
+        $fields = $this->service->getAvailableFields('pages');
+        $this->assertCount(1, $fields);
+        $this->assertArrayHasKey('only_field', $fields);
+    }
+}

--- a/Tests/Functional/Event/RecordWriteEventTest.php
+++ b/Tests/Functional/Event/RecordWriteEventTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\Event;
+
+use Hn\McpServer\Event\AfterRecordWriteEvent;
+use Hn\McpServer\Event\BeforeRecordWriteEvent;
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use Hn\McpServer\Tests\Functional\Traits\McpAssertionsTrait;
+use TYPO3\CMS\Core\EventDispatcher\ListenerProvider;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Stateful test listener for BeforeRecordWriteEvent
+ */
+class BeforeRecordWriteTestListener
+{
+    public static bool $dispatched = false;
+    public static string $table = '';
+    public static string $action = '';
+    public static bool $shouldVeto = false;
+    public static string $vetoReason = '';
+    public static ?string $overrideTitle = null;
+
+    public static function reset(): void
+    {
+        self::$dispatched = false;
+        self::$table = '';
+        self::$action = '';
+        self::$shouldVeto = false;
+        self::$vetoReason = '';
+        self::$overrideTitle = null;
+    }
+
+    public function __invoke(BeforeRecordWriteEvent $event): void
+    {
+        self::$dispatched = true;
+        self::$table = $event->getTable();
+        self::$action = $event->getAction();
+
+        if (self::$shouldVeto) {
+            $event->veto(self::$vetoReason);
+        }
+
+        if (self::$overrideTitle !== null) {
+            $data = $event->getData();
+            $data['title'] = self::$overrideTitle;
+            $event->setData($data);
+        }
+    }
+}
+
+/**
+ * Stateful test listener for AfterRecordWriteEvent
+ */
+class AfterRecordWriteTestListener
+{
+    public static bool $dispatched = false;
+    public static int $uid = 0;
+    public static string $action = '';
+
+    public static function reset(): void
+    {
+        self::$dispatched = false;
+        self::$uid = 0;
+        self::$action = '';
+    }
+
+    public function __invoke(AfterRecordWriteEvent $event): void
+    {
+        self::$dispatched = true;
+        self::$uid = $event->getUid();
+        self::$action = $event->getAction();
+    }
+}
+
+/**
+ * Tests for BeforeRecordWriteEvent and AfterRecordWriteEvent
+ */
+class RecordWriteEventTest extends AbstractFunctionalTest
+{
+    use McpAssertionsTrait;
+
+    private WriteTableTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tool = new WriteTableTool();
+
+        BeforeRecordWriteTestListener::reset();
+        AfterRecordWriteTestListener::reset();
+
+        // Register test listeners in the DI container so ListenerProvider can resolve them
+        $container = GeneralUtility::getContainer();
+        $container->set(BeforeRecordWriteTestListener::class, new BeforeRecordWriteTestListener());
+        $container->set(AfterRecordWriteTestListener::class, new AfterRecordWriteTestListener());
+
+        $listenerProvider = $container->get(ListenerProvider::class);
+        $listenerProvider->addListener(BeforeRecordWriteEvent::class, BeforeRecordWriteTestListener::class);
+        $listenerProvider->addListener(AfterRecordWriteEvent::class, AfterRecordWriteTestListener::class);
+    }
+
+    /**
+     * BeforeRecordWriteEvent is dispatched on create
+     */
+    public function testBeforeRecordWriteEventDispatchedOnCreate(): void
+    {
+        $result = $this->tool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => $this->getRootPageUid(),
+            'data' => ['title' => 'Event test page'],
+        ]);
+
+        $this->assertSuccessfulToolResult($result);
+        $this->assertTrue(BeforeRecordWriteTestListener::$dispatched, 'BeforeRecordWriteEvent should be dispatched');
+        $this->assertEquals('pages', BeforeRecordWriteTestListener::$table);
+        $this->assertEquals('create', BeforeRecordWriteTestListener::$action);
+    }
+
+    /**
+     * BeforeRecordWriteEvent veto stops the write operation
+     */
+    public function testBeforeRecordWriteEventVetoStopsOperation(): void
+    {
+        BeforeRecordWriteTestListener::$shouldVeto = true;
+        BeforeRecordWriteTestListener::$vetoReason = 'Policy violation: no pages allowed';
+
+        $result = $this->tool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => $this->getRootPageUid(),
+            'data' => ['title' => 'Should not be created'],
+        ]);
+
+        $this->assertToolError($result, 'vetoed');
+    }
+
+    /**
+     * BeforeRecordWriteEvent can modify data before write
+     */
+    public function testBeforeRecordWriteEventCanModifyData(): void
+    {
+        BeforeRecordWriteTestListener::$overrideTitle = 'Modified by listener';
+
+        $result = $this->tool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => $this->getRootPageUid(),
+            'data' => ['title' => 'Original title'],
+        ]);
+
+        $this->assertSuccessfulToolResult($result);
+        $data = $this->extractJsonFromResult($result);
+
+        // Use ReadTableTool to read the record (handles workspace overlay)
+        $readTool = new \Hn\McpServer\MCP\Tool\Record\ReadTableTool();
+        $readResult = $readTool->execute([
+            'table' => 'pages',
+            'uid' => $data['uid'],
+            'fields' => ['title'],
+        ]);
+        $readData = json_decode($readResult->content[0]->text, true);
+        $this->assertEquals('Modified by listener', $readData['records'][0]['title']);
+    }
+
+    /**
+     * AfterRecordWriteEvent is dispatched after successful create
+     */
+    public function testAfterRecordWriteEventDispatchedOnCreate(): void
+    {
+        $result = $this->tool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => $this->getRootPageUid(),
+            'data' => ['title' => 'After event test'],
+        ]);
+
+        $this->assertSuccessfulToolResult($result);
+        $this->assertTrue(AfterRecordWriteTestListener::$dispatched, 'AfterRecordWriteEvent should be dispatched');
+        $this->assertGreaterThan(0, AfterRecordWriteTestListener::$uid);
+        $this->assertEquals('create', AfterRecordWriteTestListener::$action);
+    }
+
+    /**
+     * AfterRecordWriteEvent is dispatched on delete
+     */
+    public function testAfterRecordWriteEventDispatchedOnDelete(): void
+    {
+        $createResult = $this->tool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => $this->getRootPageUid(),
+            'data' => ['title' => 'To be deleted'],
+        ]);
+        $createData = $this->extractJsonFromResult($createResult);
+
+        AfterRecordWriteTestListener::reset();
+
+        $result = $this->tool->execute([
+            'action' => 'delete',
+            'table' => 'pages',
+            'uid' => $createData['uid'],
+        ]);
+
+        $this->assertSuccessfulToolResult($result);
+        $this->assertEquals('delete', AfterRecordWriteTestListener::$action);
+    }
+
+    /**
+     * AfterRecordWriteEvent is NOT dispatched when BeforeEvent vetoes
+     */
+    public function testAfterEventNotDispatchedOnVeto(): void
+    {
+        BeforeRecordWriteTestListener::$shouldVeto = true;
+        BeforeRecordWriteTestListener::$vetoReason = 'Blocked';
+
+        $this->tool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => $this->getRootPageUid(),
+            'data' => ['title' => 'Vetoed page'],
+        ]);
+
+        $this->assertFalse(AfterRecordWriteTestListener::$dispatched, 'AfterRecordWriteEvent should NOT fire on veto');
+    }
+}

--- a/Tests/Functional/Fixtures/sys_file_storage.csv
+++ b/Tests/Functional/Fixtures/sys_file_storage.csv
@@ -1,0 +1,4 @@
+"sys_file_storage"
+,"uid","pid","name","driver","configuration","is_browsable","is_public","is_writable","is_online","is_default"
+,1,0,"fileadmin","Local","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""basePath""><value index=""vDEF"">fileadmin/</value></field><field index=""pathType""><value index=""vDEF"">relative</value></field></language></sheet></data></T3FlexForms>",1,1,1,1,1
+,2,0,"Second Storage","Local","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""basePath""><value index=""vDEF"">fileadmin2/</value></field><field index=""pathType""><value index=""vDEF"">relative</value></field></language></sheet></data></T3FlexForms>",1,0,1,1,0

--- a/Tests/Functional/MCP/Tool/File/BrowseFolderToolTest.php
+++ b/Tests/Functional/MCP/Tool/File/BrowseFolderToolTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool\File;
+
+use Hn\McpServer\MCP\Tool\File\BrowseFolderTool;
+use Mcp\Types\TextContent;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class BrowseFolderToolTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+        'frontend',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'mcp_server',
+    ];
+
+    private string $storageBasePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../../../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../../Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../../Fixtures/sys_file_storage.csv');
+
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('default');
+
+        $backendUser = $this->setUpBackendUser(1);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $this->createTestFolderStructure();
+    }
+
+    /**
+     * Create test folders and files in the default storage
+     */
+    private function createTestFolderStructure(): void
+    {
+        $this->storageBasePath = $this->instancePath . '/fileadmin';
+        @mkdir($this->storageBasePath, 0777, true);
+
+        // Create folder structure
+        @mkdir($this->storageBasePath . '/images', 0777, true);
+        @mkdir($this->storageBasePath . '/documents', 0777, true);
+
+        // Create test files using GD (1x1px PNG)
+        $image = imagecreatetruecolor(1, 1);
+        imagepng($image, $this->storageBasePath . '/images/logo.png');
+        imagedestroy($image);
+
+        $image = imagecreatetruecolor(1, 1);
+        $red = imagecolorallocate($image, 255, 0, 0);
+        imagesetpixel($image, 0, 0, $red);
+        imagepng($image, $this->storageBasePath . '/images/banner.png');
+        imagedestroy($image);
+
+        // Create a simple text file
+        file_put_contents($this->storageBasePath . '/documents/readme.txt', 'Test document');
+    }
+
+    public function testBrowseRootFolder(): void
+    {
+        $tool = new BrowseFolderTool();
+
+        $result = $tool->execute(['folder' => '1:/']);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $this->assertCount(1, $result->content);
+        $this->assertInstanceOf(TextContent::class, $result->content[0]);
+
+        $content = $result->content[0]->text;
+
+        $this->assertStringContainsString('📁 Storage: fileadmin', $content);
+        $this->assertStringContainsString('📂 /', $content);
+        $this->assertStringContainsString('images', $content);
+        $this->assertStringContainsString('documents', $content);
+    }
+
+    public function testBrowseSubfolder(): void
+    {
+        $tool = new BrowseFolderTool();
+
+        $result = $tool->execute(['folder' => '1:/images/']);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $content = $result->content[0]->text;
+
+        $this->assertStringContainsString('📂 /images/', $content);
+        $this->assertStringContainsString('logo.png', $content);
+        $this->assertStringContainsString('banner.png', $content);
+    }
+
+    public function testShowsFileMetadata(): void
+    {
+        $tool = new BrowseFolderTool();
+
+        $result = $tool->execute(['folder' => '1:/documents/']);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $content = $result->content[0]->text;
+
+        $this->assertStringContainsString('readme.txt', $content);
+        // File should show size info
+        $this->assertMatchesRegularExpression('/\d+ B/', $content);
+    }
+
+    public function testShowsSubfolderFileCount(): void
+    {
+        $tool = new BrowseFolderTool();
+
+        $result = $tool->execute(['folder' => '1:/']);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $content = $result->content[0]->text;
+
+        // images folder has 2 files
+        $this->assertStringContainsString('images (2 files)', $content);
+        // documents folder has 1 file
+        $this->assertStringContainsString('documents (1 files)', $content);
+    }
+
+    public function testShowsCombinedIdentifierForSubfolders(): void
+    {
+        $tool = new BrowseFolderTool();
+
+        $result = $tool->execute(['folder' => '1:/']);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $content = $result->content[0]->text;
+
+        $this->assertStringContainsString('1:/images/', $content);
+        $this->assertStringContainsString('1:/documents/', $content);
+    }
+
+    public function testEmptyFolder(): void
+    {
+        @mkdir($this->storageBasePath . '/empty', 0777, true);
+
+        $tool = new BrowseFolderTool();
+
+        $result = $tool->execute(['folder' => '1:/empty/']);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $content = $result->content[0]->text;
+
+        $this->assertStringContainsString('(empty folder)', $content);
+    }
+
+    public function testRecursiveListing(): void
+    {
+        $tool = new BrowseFolderTool();
+
+        $result = $tool->execute([
+            'folder' => '1:/',
+            'recursive' => true,
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $content = $result->content[0]->text;
+
+        // Should show subfolder contents too
+        $this->assertStringContainsString('images', $content);
+        $this->assertStringContainsString('logo.png', $content);
+        $this->assertStringContainsString('banner.png', $content);
+        $this->assertStringContainsString('documents', $content);
+        $this->assertStringContainsString('readme.txt', $content);
+    }
+}

--- a/Tests/Functional/MCP/Tool/File/FileReferenceWriteTest.php
+++ b/Tests/Functional/MCP/Tool/File/FileReferenceWriteTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool\File;
+
+use Hn\McpServer\MCP\Tool\Record\ReadTableTool;
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use Hn\McpServer\Tests\Functional\Traits\McpAssertionsTrait;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Tests for file reference creation and reading via type=file fields
+ */
+class FileReferenceWriteTest extends AbstractFunctionalTest
+{
+    use McpAssertionsTrait;
+
+    private WriteTableTool $writeTool;
+    private ReadTableTool $readTool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Ensure sys_file fixtures exist
+        $this->importCSVDataSet(__DIR__ . '/../../../Fixtures/sys_file.csv');
+
+        $this->writeTool = new WriteTableTool();
+        $this->readTool = new ReadTableTool();
+    }
+
+    /**
+     * Creating a page with file references using plain sys_file UIDs
+     */
+    public function testCreatePageWithFileReferenceUidShorthand(): void
+    {
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => $this->getRootPageUid(),
+            'data' => [
+                'title' => 'Page with media',
+                'media' => [1],
+            ],
+        ]);
+
+        $this->assertSuccessfulToolResult($result);
+        $data = $this->extractJsonFromResult($result);
+        $this->assertArrayHasKey('uid', $data);
+
+        // Verify sys_file_reference was created
+        $references = $this->getFileReferences('pages', 'media', $data['uid']);
+        $this->assertCount(1, $references);
+        $this->assertEquals(1, $references[0]['uid_local']);
+        $this->assertEquals('pages', $references[0]['tablenames']);
+        $this->assertEquals('media', $references[0]['fieldname']);
+    }
+
+    /**
+     * Creating a page with file references using object format with metadata
+     */
+    public function testCreatePageWithFileReferenceObjectFormat(): void
+    {
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => $this->getRootPageUid(),
+            'data' => [
+                'title' => 'Page with titled media',
+                'media' => [
+                    ['uid_local' => 1, 'title' => 'Test Image', 'alternative' => 'Alt text'],
+                ],
+            ],
+        ]);
+
+        $this->assertSuccessfulToolResult($result);
+        $data = $this->extractJsonFromResult($result);
+
+        $references = $this->getFileReferences('pages', 'media', $data['uid']);
+        $this->assertCount(1, $references);
+        $this->assertEquals(1, $references[0]['uid_local']);
+        $this->assertEquals('Test Image', $references[0]['title']);
+        $this->assertEquals('Alt text', $references[0]['alternative']);
+    }
+
+    /**
+     * Creating content with multiple file references
+     */
+    public function testCreateContentWithMultipleFileReferences(): void
+    {
+        // Create additional sys_file records
+        $connection = $this->getConnectionForTable('sys_file');
+        $connection->insert('sys_file', [
+            'uid' => 2,
+            'pid' => 0,
+            'name' => 'test2.jpg',
+            'identifier' => '/test2.jpg',
+            'storage' => 1,
+            'type' => 2,
+            'size' => 654321,
+        ]);
+
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => $this->getRootPageUid(),
+            'data' => [
+                'CType' => 'textmedia',
+                'header' => 'Content with assets',
+                'assets' => [1, 2],
+            ],
+        ]);
+
+        $this->assertSuccessfulToolResult($result);
+        $data = $this->extractJsonFromResult($result);
+
+        $references = $this->getFileReferences('tt_content', 'assets', $data['uid']);
+        $this->assertCount(2, $references);
+    }
+
+    /**
+     * File field validation rejects invalid data (string instead of array)
+     */
+    public function testFileFieldRejectsStringValue(): void
+    {
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => $this->getRootPageUid(),
+            'data' => [
+                'title' => 'Invalid media',
+                'media' => 'not_an_array',
+            ],
+        ]);
+
+        $this->assertToolError($result);
+    }
+
+    /**
+     * File field validation rejects objects without uid_local
+     */
+    public function testFileFieldRejectsObjectWithoutUidLocal(): void
+    {
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => $this->getRootPageUid(),
+            'data' => [
+                'title' => 'Missing uid_local',
+                'media' => [
+                    ['title' => 'No uid_local provided'],
+                ],
+            ],
+        ]);
+
+        $this->assertToolError($result, 'uid_local');
+    }
+
+    /**
+     * ReadTableTool expands file field relations
+     */
+    public function testReadTableExpandsFileFields(): void
+    {
+        // Create a page with file reference first
+        $createResult = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => $this->getRootPageUid(),
+            'data' => [
+                'title' => 'Page for reading',
+                'media' => [
+                    ['uid_local' => 1, 'title' => 'Readable Image'],
+                ],
+            ],
+        ]);
+
+        $this->assertSuccessfulToolResult($createResult);
+        $createData = $this->extractJsonFromResult($createResult);
+
+        // Now read the page and check that media field is expanded
+        $readResult = $this->readTool->execute([
+            'table' => 'pages',
+            'uid' => $createData['uid'],
+            'fields' => ['title', 'media'],
+        ]);
+
+        $this->assertSuccessfulToolResult($readResult);
+        $readData = json_decode($readResult->content[0]->text, true);
+
+        // The media field should contain expanded file reference records
+        $records = $readData['records'] ?? [];
+        $this->assertNotEmpty($records);
+
+        $record = $records[0];
+        $this->assertEquals('Page for reading', $record['title']);
+        $this->assertIsArray($record['media']);
+    }
+
+    /**
+     * Helper: get sys_file_reference records for a parent record
+     */
+    private function getFileReferences(string $tablenames, string $fieldname, int $uidForeign): array
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('sys_file_reference');
+
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return $queryBuilder
+            ->select('*')
+            ->from('sys_file_reference')
+            ->where(
+                $queryBuilder->expr()->eq('tablenames', $queryBuilder->createNamedParameter($tablenames)),
+                $queryBuilder->expr()->eq('fieldname', $queryBuilder->createNamedParameter($fieldname)),
+                $queryBuilder->expr()->eq('uid_foreign', $queryBuilder->createNamedParameter($uidForeign, \Doctrine\DBAL\ParameterType::INTEGER)),
+                $queryBuilder->expr()->eq('deleted', 0)
+            )
+            ->orderBy('sorting_foreign', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
+}

--- a/Tests/Functional/MCP/Tool/File/ListStoragesToolTest.php
+++ b/Tests/Functional/MCP/Tool/File/ListStoragesToolTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool\File;
+
+use Hn\McpServer\MCP\Tool\File\ListStoragesTool;
+use Mcp\Types\TextContent;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class ListStoragesToolTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+        'frontend',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'mcp_server',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../../../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../../Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../../Fixtures/sys_file_storage.csv');
+
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('default');
+
+        $backendUser = $this->setUpBackendUser(1);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        // Create storage base paths so TYPO3 considers them online
+        @mkdir($this->instancePath . '/fileadmin', 0777, true);
+        @mkdir($this->instancePath . '/fileadmin2', 0777, true);
+    }
+
+    public function testListsDefaultStorage(): void
+    {
+        $tool = new ListStoragesTool();
+
+        $result = $tool->execute([]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $this->assertCount(1, $result->content);
+        $this->assertInstanceOf(TextContent::class, $result->content[0]);
+
+        $content = $result->content[0]->text;
+
+        $this->assertStringContainsString('FILE STORAGES', $content);
+        $this->assertStringContainsString('fileadmin', $content);
+        $this->assertStringContainsString('Storage 1:', $content);
+        $this->assertStringContainsString('default', $content);
+    }
+
+    public function testListsMultipleStorages(): void
+    {
+        $tool = new ListStoragesTool();
+
+        $result = $tool->execute([]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $content = $result->content[0]->text;
+
+        $this->assertStringContainsString('Storage 1:', $content);
+        $this->assertStringContainsString('Storage 2:', $content);
+        $this->assertStringContainsString('Second Storage', $content);
+    }
+
+    public function testShowsStorageFlags(): void
+    {
+        $tool = new ListStoragesTool();
+
+        $result = $tool->execute([]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $content = $result->content[0]->text;
+
+        // Storage 1 is public, writable, default
+        $this->assertStringContainsString('public', $content);
+        $this->assertStringContainsString('writable', $content);
+        $this->assertStringContainsString('default', $content);
+    }
+
+    public function testShowsRootFolderPath(): void
+    {
+        $tool = new ListStoragesTool();
+
+        $result = $tool->execute([]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $content = $result->content[0]->text;
+
+        $this->assertStringContainsString('Root: 1:/', $content);
+    }
+
+    public function testShowsTotalCount(): void
+    {
+        $tool = new ListStoragesTool();
+
+        $result = $tool->execute([]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $content = $result->content[0]->text;
+
+        $this->assertMatchesRegularExpression('/Total: \d+ storage\(s\)/', $content);
+    }
+}

--- a/Tests/Functional/MCP/Tool/InlineRelationWriteTest.php
+++ b/Tests/Functional/MCP/Tool/InlineRelationWriteTest.php
@@ -6,6 +6,7 @@ namespace Hn\McpServer\Tests\Functional\MCP\Tool;
 
 use Hn\McpServer\MCP\Tool\Record\ReadTableTool;
 use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -30,6 +31,7 @@ class InlineRelationWriteTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../../Fixtures/be_users.csv');
         $this->importCSVDataSet(__DIR__ . '/../../Fixtures/sys_file.csv');
         $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('default');
     }
 
     /**
@@ -113,11 +115,14 @@ class InlineRelationWriteTest extends FunctionalTestCase
     }
 
     /**
-     * Test writing inline relations for hidden tables (sys_file_reference)
+     * Test writing file references via file field type
      */
-    public function testWriteHiddenTableInlineRelation(): void
+    public function testWriteFileReferencesViaFileField(): void
     {
-        $this->markTestSkipped('sys_file_reference is intentionally restricted due to workspace limitations');
+        // File field support is now enabled — sys_file_reference is accessible
+        $service = GeneralUtility::makeInstance(\Hn\McpServer\Service\TableAccessService::class);
+        $canAccess = $service->canAccessField('pages', 'media');
+        $this->assertTrue($canAccess, 'File fields should be accessible now');
     }
 
     /**
@@ -270,7 +275,7 @@ class InlineRelationWriteTest extends FunctionalTestCase
     public function testInlineRelationSorting(): void
     {
         $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
-        
+
         // Create page and news
         $result = $writeTool->execute([
             'table' => 'pages',
@@ -281,6 +286,7 @@ class InlineRelationWriteTest extends FunctionalTestCase
                 'doktype' => 1,
             ],
         ]);
+        $this->assertFalse($result->isError, 'Page create: ' . ($result->content[0]->text ?? ''));
         $pageUid = json_decode($result->content[0]->text, true)['uid'];
         
         $result = $writeTool->execute([
@@ -293,12 +299,12 @@ class InlineRelationWriteTest extends FunctionalTestCase
         ]);
         $newsUid = json_decode($result->content[0]->text, true)['uid'];
         
-        // Create content elements in reverse order because DataHandler assigns
-        // lower sorting values to newer records when using default 'bottom' position
+        // Create content elements in order — default 'bottom' position assigns
+        // ascending sorting values automatically via DataHandler move commands
         $contentData = [
-            ['header' => 'Third', 'sorting' => 300],
-            ['header' => 'Second', 'sorting' => 200],
-            ['header' => 'First', 'sorting' => 100],
+            ['header' => 'First'],
+            ['header' => 'Second'],
+            ['header' => 'Third'],
         ];
         
         $createdUids = [];
@@ -312,7 +318,7 @@ class InlineRelationWriteTest extends FunctionalTestCase
                     'tx_news_related_news' => $newsUid,
                 ]),
             ]);
-            $this->assertFalse($result->isError);
+            $this->assertFalse($result->isError, 'Create failed: ' . ($result->content[0]->text ?? 'no content'));
             $uid = json_decode($result->content[0]->text, true)['uid'];
             $createdUids[$data['header']] = $uid;
         }
@@ -513,7 +519,7 @@ class InlineRelationWriteTest extends FunctionalTestCase
         $this->assertTrue($result->isError);
         $this->assertStringContainsString('must be an array of UIDs', $result->jsonSerialize()['content'][0]->text);
         
-        // Test 2: Array with non-numeric values
+        // Test 2: Array with non-numeric, non-array values
         $result = $writeTool->execute([
             'table' => 'tx_news_domain_model_news',
             'action' => 'update',
@@ -523,8 +529,8 @@ class InlineRelationWriteTest extends FunctionalTestCase
             ],
         ]);
         $this->assertTrue($result->isError);
-        $this->assertStringContainsString('must contain only positive integer UIDs', $result->jsonSerialize()['content'][0]->text);
-        
+        $this->assertStringContainsString('must be a record data array or a positive integer UID', $result->jsonSerialize()['content'][0]->text);
+
         // Test 3: Array with negative values
         $result = $writeTool->execute([
             'table' => 'tx_news_domain_model_news',
@@ -535,9 +541,9 @@ class InlineRelationWriteTest extends FunctionalTestCase
             ],
         ]);
         $this->assertTrue($result->isError);
-        $this->assertStringContainsString('must contain only positive integer UIDs', $result->jsonSerialize()['content'][0]->text);
+        $this->assertStringContainsString('must be a record data array or a positive integer UID', $result->jsonSerialize()['content'][0]->text);
         
-        // Test 4: Array with data objects (not supported yet)
+        // Test 4: Array with data objects for independent tables is now valid (embedded creation)
         $result = $writeTool->execute([
             'table' => 'tx_news_domain_model_news',
             'action' => 'update',
@@ -548,7 +554,244 @@ class InlineRelationWriteTest extends FunctionalTestCase
                 ],
             ],
         ]);
-        $this->assertTrue($result->isError);
-        $this->assertStringContainsString('must contain only positive integer UIDs', $result->jsonSerialize()['content'][0]->text);
+        $this->assertFalse($result->isError, 'Passing record data arrays for inline fields should be valid: ' . json_encode($result->jsonSerialize()));
+    }
+
+    /**
+     * Referencing existing inline children via {"uid": N} object syntax on update
+     */
+    public function testUidObjectReferencesExistingInlineChildren(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+
+        // Create page + news
+        $result = $writeTool->execute([
+            'table' => 'pages',
+            'action' => 'create',
+            'pid' => 0,
+            'data' => ['title' => 'UID object test page', 'doktype' => 1],
+        ]);
+        $pageUid = json_decode($result->content[0]->text, true)['uid'];
+
+        $result = $writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'create',
+            'pid' => $pageUid,
+            'data' => ['title' => 'News for uid object test'],
+        ]);
+        $newsUid = json_decode($result->content[0]->text, true)['uid'];
+
+        // Create 2 content elements linked to the news
+        $contentUids = [];
+        for ($i = 1; $i <= 2; $i++) {
+            $result = $writeTool->execute([
+                'table' => 'tt_content',
+                'action' => 'create',
+                'pid' => $pageUid,
+                'data' => [
+                    'header' => "Existing content $i",
+                    'CType' => 'text',
+                    'tx_news_related_news' => $newsUid,
+                ],
+            ]);
+            $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+            $contentUids[] = json_decode($result->content[0]->text, true)['uid'];
+        }
+
+        // Update news: keep existing via {"uid": N}, update one header, add a new element
+        $result = $writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'update',
+            'uid' => $newsUid,
+            'data' => [
+                'content_elements' => [
+                    ['uid' => $contentUids[0]],                                    // keep as-is
+                    ['uid' => $contentUids[1], 'header' => 'Updated header'],      // keep + update
+                    ['header' => 'Brand new element', 'CType' => 'text'],          // create new
+                ],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        // Verify: 3 children linked to this news
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $result = $readTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'uid' => $newsUid,
+        ]);
+        $news = json_decode($result->content[0]->text, true)['records'][0];
+        $this->assertCount(3, $news['content_elements'], 'Should have 3 content elements');
+
+        // Verify: first element unchanged
+        $this->assertContains($contentUids[0], $news['content_elements']);
+
+        // Verify: second element still linked and header updated
+        $this->assertContains($contentUids[1], $news['content_elements']);
+        $queryBuilder = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Database\ConnectionPool::class)
+            ->getQueryBuilderForTable('tt_content');
+        $queryBuilder->getRestrictions()->removeAll();
+        $updatedRecord = $queryBuilder->select('header')
+            ->from('tt_content')
+            ->where($queryBuilder->expr()->eq('uid', $contentUids[1]))
+            ->executeQuery()
+            ->fetchAssociative();
+        $this->assertSame('Updated header', $updatedRecord['header']);
+    }
+
+    /**
+     * Creating content elements with embedded record data arrays in the parent
+     */
+    public function testCreateContentElementsAsEmbeddedRecordData(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+
+        // Create a page
+        $result = $writeTool->execute([
+            'table' => 'pages',
+            'action' => 'create',
+            'pid' => 0,
+            'data' => ['title' => 'Embedded test page', 'doktype' => 1],
+        ]);
+        $this->assertFalse($result->isError);
+        $pageUid = json_decode($result->content[0]->text, true)['uid'];
+
+        // Create news with content_elements as embedded record data (not UIDs)
+        $result = $writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'create',
+            'pid' => $pageUid,
+            'data' => [
+                'title' => 'News with embedded content elements',
+                'content_elements' => [
+                    ['header' => 'First element', 'CType' => 'text', 'bodytext' => 'Body 1'],
+                    ['header' => 'Second element', 'CType' => 'text', 'bodytext' => 'Body 2'],
+                ],
+            ],
+        ]);
+        $this->assertFalse($result->isError, 'Creating with embedded record data should work: ' . json_encode($result->jsonSerialize()));
+        $newsUid = json_decode($result->content[0]->text, true)['uid'];
+
+        // Verify the content elements were created and linked
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $result = $readTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'uid' => $newsUid,
+        ]);
+        $this->assertFalse($result->isError);
+        $news = json_decode($result->content[0]->text, true)['records'][0];
+
+        $this->assertArrayHasKey('content_elements', $news);
+        $this->assertCount(2, $news['content_elements'], 'Two content elements should be linked to the news record');
+
+        // Verify content elements have correct data
+        foreach ($news['content_elements'] as $contentUid) {
+            $this->assertIsInt($contentUid);
+            $result = $readTool->execute(['table' => 'tt_content', 'uid' => $contentUid]);
+            $content = json_decode($result->content[0]->text, true)['records'][0];
+            $this->assertEquals('text', $content['CType']);
+            $this->assertContains($content['header'], ['First element', 'Second element']);
+        }
+    }
+
+    /**
+     * Nested inline relations: news → content elements (embedded) → file references (embedded)
+     *
+     * Verifies that inline children of inline children are created recursively.
+     * This is the pattern that failed for lia_ctypes: tt_content → tx_liactypes_ctypes.
+     */
+    public function testNestedInlineRelationsAreCreatedRecursively(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+
+        // Create a page
+        $result = $writeTool->execute([
+            'table' => 'pages',
+            'action' => 'create',
+            'pid' => 0,
+            'data' => ['title' => 'Nested inline test', 'doktype' => 1],
+        ]);
+        $this->assertFalse($result->isError);
+        $pageUid = json_decode($result->content[0]->text, true)['uid'];
+
+        // Create news with nested inline: content_elements contain media (sys_file_reference)
+        $result = $writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'create',
+            'pid' => $pageUid,
+            'data' => [
+                'title' => 'News with nested inline',
+                'content_elements' => [
+                    [
+                        'header' => 'Content with image',
+                        'CType' => 'text',
+                        'media' => [
+                            ['uid_local' => 1, 'title' => 'Test image'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $this->assertFalse($result->isError, 'Nested inline creation should work: ' . json_encode($result->jsonSerialize()));
+        $newsUid = json_decode($result->content[0]->text, true)['uid'];
+
+        // Verify the content element was created
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $result = $readTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'uid' => $newsUid,
+        ]);
+        $news = json_decode($result->content[0]->text, true)['records'][0];
+        $this->assertCount(1, $news['content_elements'], 'One content element should be linked');
+
+        // Verify the file reference was created on the content element
+        $contentUid = $news['content_elements'][0];
+        $result = $readTool->execute(['table' => 'tt_content', 'uid' => $contentUid]);
+        $content = json_decode($result->content[0]->text, true)['records'][0];
+        $this->assertEquals('Content with image', $content['header']);
+
+        // Check ALL sys_file_reference records to debug
+        $queryBuilder = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+            \TYPO3\CMS\Core\Database\ConnectionPool::class
+        )->getQueryBuilderForTable('sys_file_reference');
+        $queryBuilder->getRestrictions()->removeAll();
+        $allFileReferences = $queryBuilder
+            ->select('*')
+            ->from('sys_file_reference')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        // Filter for our content element
+        $fileReferences = array_filter($allFileReferences, fn($r) => (int)$r['uid_foreign'] === $contentUid && $r['tablenames'] === 'tt_content');
+
+        $debugInfo = 'Content UID: ' . $contentUid . ', All sys_file_reference records: ' . json_encode(
+            array_map(fn($r) => ['uid' => $r['uid'], 'uid_local' => $r['uid_local'], 'uid_foreign' => $r['uid_foreign'], 'tablenames' => $r['tablenames'], 'fieldname' => $r['fieldname'], 'title' => $r['title']], $allFileReferences)
+        );
+
+        $this->assertCount(1, $fileReferences, 'One file reference should be created for the content element. ' . $debugInfo);
+        $ref = reset($fileReferences);
+        $this->assertEquals(1, $ref['uid_local'], 'File reference should point to sys_file uid 1');
+        $this->assertEquals('Test image', $ref['title']);
+    }
+
+    /**
+     * Embedded links with hideTable=true work with string '1' value
+     *
+     * tx_news_domain_model_link has hideTable=true (boolean).
+     * This test verifies the !empty() check works for both boolean true and string '1'.
+     */
+    public function testHideTableStringOneIsRecognized(): void
+    {
+        // Verify that news link table has hideTable set
+        $linkTCA = $GLOBALS['TCA']['tx_news_domain_model_link']['ctrl'] ?? [];
+        $this->assertNotEmpty($linkTCA['hideTable'] ?? false, 'tx_news_domain_model_link should have hideTable set');
+
+        // This test is implicitly covered by NewsLinkInlineTest::testCreateNewsWithEmbeddedLinks
+        // but we explicitly verify the !empty() check handles both true and '1'
+        $this->assertTrue(!empty(true), 'Boolean true should pass !empty()');
+        $this->assertTrue(!empty('1'), 'String "1" should pass !empty()');
+        $this->assertTrue(!empty(1), 'Integer 1 should pass !empty()');
+        $this->assertFalse(!empty(false), 'Boolean false should fail !empty()');
+        $this->assertFalse(!empty(''), 'Empty string should fail !empty()');
+        $this->assertFalse(!empty(0), 'Integer 0 should fail !empty()');
     }
 }

--- a/Tests/Functional/MCP/Tool/ListTablesToolTest.php
+++ b/Tests/Functional/MCP/Tool/ListTablesToolTest.php
@@ -52,7 +52,7 @@ class ListTablesToolTest extends FunctionalTestCase
         // Verify listing contains expected sections
         $this->assertStringContainsString('ACCESSIBLE TABLES IN TYPO3 (via MCP)', $content);
         $this->assertStringContainsString('=====================================', $content);
-        $this->assertStringContainsString('workspace-capable and accessible', $content);
+        $this->assertStringContainsString('accessible by the current user', $content);
         
         // Verify core tables are present
         $this->assertStringContainsString('pages', $content);
@@ -142,8 +142,8 @@ class ListTablesToolTest extends FunctionalTestCase
         
         $content = $result->content[0]->text;
         
-        // Verify workspace information - the tool states "workspace-capable and accessible"
-        $this->assertStringContainsString('workspace-capable and accessible', $content);
+        // Verify workspace information - the tool states "accessible by the current user"
+        $this->assertStringContainsString('accessible by the current user', $content);
         
         // All listed tables should be workspace-capable since that's the filtering criteria
         $this->assertStringContainsString('pages (Page)', $content);
@@ -258,7 +258,7 @@ class ListTablesToolTest extends FunctionalTestCase
         
         // ⚠️ ISSUE: No summary statistics provided by the tool
         // This would be useful for LLM context. For now, verify basic functionality.
-        $this->assertStringContainsString('workspace-capable and accessible', $content);
+        $this->assertStringContainsString('accessible by the current user', $content);
         // Note: [READ-ONLY] is mentioned in the description but not shown in actual data
         
         // Verify we have core tables

--- a/Tests/Functional/MCP/Tool/WriteTableToolErrorTest.php
+++ b/Tests/Functional/MCP/Tool/WriteTableToolErrorTest.php
@@ -272,23 +272,22 @@ class WriteTableToolErrorTest extends FunctionalTestCase
     }
     
     /**
-     * Test that file fields are not supported
+     * Test that file fields require valid file reference data
      */
-    public function testFileFieldsNotSupported(): void
+    public function testFileFieldsRequireValidData(): void
     {
-        // The 'media' field on pages table is type='file', which is not supported
+        // The 'media' field on pages table is type='file' — it now accepts file reference arrays
         $result = $this->tool->execute([
             'action' => 'create',
             'table' => 'pages',
             'pid' => 0,
             'data' => [
                 'title' => 'Test Page',
-                'media' => 'some_value' // File fields should be rejected regardless of value
+                'media' => 'some_value' // String values should be rejected for file fields
             ]
         ]);
 
-        $this->assertTrue($result->isError, 'File fields should be rejected');
-        $this->assertStringContainsString('File fields are not supported', $result->content[0]->text);
+        $this->assertTrue($result->isError, 'Invalid file field data should be rejected');
         $this->assertStringContainsString('media', $result->content[0]->text);
     }
     

--- a/Tests/Functional/NewsExtension/NewsLinkInlineTest.php
+++ b/Tests/Functional/NewsExtension/NewsLinkInlineTest.php
@@ -306,7 +306,7 @@ class NewsLinkInlineTest extends FunctionalTestCase
             ],
         ]);
         $this->assertTrue($result->isError);
-        $this->assertStringContainsString('must contain record data arrays', $result->jsonSerialize()['content'][0]->text);
+        $this->assertStringContainsString('must be a record data array or a positive integer UID', $result->jsonSerialize()['content'][0]->text);
         
         // Test empty record data
         $result = $writeTool->execute([

--- a/Tests/Functional/NewsExtension/NewsSchemaTest.php
+++ b/Tests/Functional/NewsExtension/NewsSchemaTest.php
@@ -130,14 +130,12 @@ class NewsSchemaTest extends FunctionalTestCase
     {
         $tool = new GetTableSchemaTool();
         
-        // News extends sys_file_reference, but this table is restricted
+        // sys_file_reference is now accessible for FAL operations
         $result = $tool->execute([
             'table' => 'sys_file_reference'
         ]);
-        
-        // sys_file_reference is restricted for security reasons
-        $this->assertTrue($result->isError);
-        $this->assertStringContainsString('restricted', $result->content[0]->text);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
     }
 
     /**

--- a/Tests/Functional/Service/TableAccessServiceFieldAccessTest.php
+++ b/Tests/Functional/Service/TableAccessServiceFieldAccessTest.php
@@ -34,75 +34,54 @@ class TableAccessServiceFieldAccessTest extends FunctionalTestCase
     }
 
     /**
-     * Test that file type fields are not accessible
+     * Test that file type fields are accessible (file field support enabled)
      */
-    public function testFileFieldsAreNotAccessible(): void
+    public function testFileFieldsAreAccessible(): void
     {
         // The 'media' field on pages table is type='file'
         $canAccess = $this->service->canAccessField('pages', 'media');
 
-        $this->assertFalse($canAccess, 'File fields should not be accessible');
+        $this->assertTrue($canAccess, 'File fields should be accessible');
     }
 
     /**
-     * Test that file fields are hidden from available fields
+     * Test that file fields are included in available fields
      */
-    public function testFileFieldsAreHiddenFromSchema(): void
+    public function testFileFieldsAreInSchema(): void
     {
         $fields = $this->service->getAvailableFields('pages');
 
-        $this->assertArrayNotHasKey('media', $fields, 'File field "media" should not be in available fields');
+        $this->assertArrayHasKey('media', $fields, 'File field "media" should be in available fields');
     }
 
     /**
-     * Test that sys_file_reference table is not accessible
+     * Test that sys_file_reference table is accessible (needed for FAL operations)
      */
-    public function testSysFileReferenceTableIsRestricted(): void
+    public function testSysFileReferenceTableIsAccessible(): void
     {
         $canAccess = $this->service->canAccessTable('sys_file_reference');
 
-        $this->assertFalse($canAccess, 'sys_file_reference table should be restricted');
+        $this->assertTrue($canAccess, 'sys_file_reference table should be accessible for FAL operations');
     }
 
     /**
-     * Test that inline relations to sys_file_reference are filtered out
+     * Test that file fields referencing sys_file_reference are accessible
      */
-    public function testInlineRelationsToSysFileReferenceAreHidden(): void
+    public function testFileFieldsToSysFileReferenceAreAccessible(): void
     {
-        // tt_content has 'assets' field which is type='inline' with foreign_table='sys_file_reference'
-        if (!isset($GLOBALS['TCA']['tt_content']['columns']['assets'])) {
-            $this->markTestSkipped('tt_content.assets field not available in this TYPO3 version');
+        // pages has 'media' field which is type='file' referencing sys_file_reference
+        if (!isset($GLOBALS['TCA']['pages']['columns']['media'])) {
+            $this->markTestSkipped('pages.media field not available in this TYPO3 version');
         }
 
-        $fieldConfig = $GLOBALS['TCA']['tt_content']['columns']['assets'] ?? [];
-        if (($fieldConfig['config']['type'] ?? '') !== 'inline') {
-            $this->markTestSkipped('tt_content.assets is not an inline field in this TYPO3 version');
+        $fieldConfig = $GLOBALS['TCA']['pages']['columns']['media'] ?? [];
+        if (($fieldConfig['config']['type'] ?? '') !== 'file') {
+            $this->markTestSkipped('pages.media is not a file field in this TYPO3 version');
         }
 
-        $foreignTable = $fieldConfig['config']['foreign_table'] ?? '';
-        if ($foreignTable !== 'sys_file_reference') {
-            $this->markTestSkipped('tt_content.assets does not reference sys_file_reference in this TYPO3 version');
-        }
+        $canAccess = $this->service->canAccessField('pages', 'media');
 
-        $canAccess = $this->service->canAccessField('tt_content', 'assets');
-
-        $this->assertFalse($canAccess, 'Inline relations to sys_file_reference should not be accessible');
-    }
-
-    /**
-     * Test that inline relations to inaccessible tables are filtered
-     */
-    public function testInlineRelationsToInaccessibleTablesAreHidden(): void
-    {
-        // Create a mock inline field config for testing
-        // We'll check if an inline field referencing a restricted table is blocked
-
-        // First, verify that a normal accessible inline relation works
-        // (if there are any in the system)
-
-        // Then verify that inline to restricted table doesn't work
-        // This is implicitly tested by sys_file_reference test above
-        $this->assertTrue(true, 'Inline relation filtering is tested via sys_file_reference test');
+        $this->assertTrue($canAccess, 'File fields referencing sys_file_reference should be accessible');
     }
 
     /**
@@ -119,9 +98,9 @@ class TableAccessServiceFieldAccessTest extends FunctionalTestCase
     }
 
     /**
-     * Test that available fields properly filters file fields
+     * Test that available fields includes file fields
      */
-    public function testAvailableFieldsFiltersFileFields(): void
+    public function testAvailableFieldsIncludesFileFields(): void
     {
         $fields = $this->service->getAvailableFields('pages');
 
@@ -129,32 +108,31 @@ class TableAccessServiceFieldAccessTest extends FunctionalTestCase
         $this->assertArrayHasKey('title', $fields, 'Title field should be available');
         $this->assertArrayHasKey('description', $fields, 'Description field should be available');
 
-        // Check that file field is not present
-        $this->assertArrayNotHasKey('media', $fields, 'Media file field should not be available');
+        // Check that file field is present (now supported)
+        $this->assertArrayHasKey('media', $fields, 'Media file field should be available');
     }
 
     /**
-     * Test that tt_content fields properly filter file/inline fields
+     * Test that tt_content fields include file fields
      */
-    public function testTtContentFieldsFilterFileAndInlineRelations(): void
+    public function testTtContentFieldsIncludeFileFields(): void
     {
-        $fields = $this->service->getAvailableFields('tt_content', 'text');
+        $fields = $this->service->getAvailableFields('tt_content', 'textmedia');
 
         // Check that normal fields are present
         $this->assertArrayHasKey('header', $fields, 'Header field should be available');
         $this->assertArrayHasKey('bodytext', $fields, 'Bodytext field should be available');
 
-        // Check that assets field (inline to sys_file_reference) is not present
+        // Check that assets field is now present (file fields are supported)
         if (isset($GLOBALS['TCA']['tt_content']['columns']['assets'])) {
-            $this->assertArrayNotHasKey('assets', $fields, 'Assets field (inline to sys_file_reference) should not be available');
+            $this->assertArrayHasKey('assets', $fields, 'Assets field should be available for file references');
         }
 
-        // Check that image field (if type=file) is not present
-        if (isset($GLOBALS['TCA']['tt_content']['columns']['image'])) {
-            $imageConfig = $GLOBALS['TCA']['tt_content']['columns']['image'] ?? [];
-            if (($imageConfig['config']['type'] ?? '') === 'file') {
-                $this->assertArrayNotHasKey('image', $fields, 'Image file field should not be available');
-            }
+        // 'image' was removed in TYPO3 v13 (replaced by 'assets') — only assert if it exists in TCA
+        // AND is part of the textmedia type's showitem definition
+        $imageConfig = $GLOBALS['TCA']['tt_content']['columns']['image'] ?? [];
+        if (($imageConfig['config']['type'] ?? '') === 'file' && isset($fields['image'])) {
+            $this->assertArrayHasKey('image', $fields, 'Image file field should be available');
         }
     }
 


### PR DESCRIPTION
Read-only FAL tools:
- ListStoragesTool: list available file storages with capabilities
- BrowseFolderTool: browse folder contents with metadata (100 file limit)
- SearchFileTool: search files by name/extension/folder/MIME with thumbnails

File reference support in ReadTable/WriteTable:
- ReadTable: file fields (type=file) now included in inline relation output
- WriteTable: file fields accept sys_file UIDs or objects with metadata (uid_local, title, alternative, description)
- Inline relation refactoring: single DataHandler call, workspace-safe sync, random NEW keys to avoid collisions
- Support {"uid": N} syntax to reference existing inline children on update
- Replace-all semantics documented in schema descriptions

Infrastructure:
- TableAccessService: unlock file fields and sys_file_reference table, handle foreign type notation (uid_local:type), ModifyAvailableFieldsEvent
- TcaFormattingUtility: improved EMBEDDED/INDEPENDENT hints for AI clients
- McpEndpoint: disable deferred image processing for MCP context
- Events: AfterRecordWrite, BeforeRecordWrite, ModifyAvailableFields
- Workspace overlay support in GetPage/GetPageTree tools
- Schema descriptions aligned with actual code behavior across all tools