### PR TITLE
Fix publish_access default value in MCP workspace creation

### DIFF
--- a/Classes/Service/WorkspaceContextService.php
+++ b/Classes/Service/WorkspaceContextService.php
@@ -178,7 +178,7 @@ class WorkspaceContextService
                 'members' => '',
                 'db_mountpoints' => '', // Inherit from user
                 'file_mountpoints' => '', // Inherit from user
-                'publish_access' => 1, // Allow publishing
+                'publish_access' => 0, // No publishing restrictions (matches TCA default)
                 'stagechg_notification' => 0, // No email notifications by default
                 'freeze' => 0, // Not frozen
                 'live_edit' => 0, // No live edit


### PR DESCRIPTION
## Summary
Corrected the default value for `publish_access` when creating MCP workspaces to align with the TCA default configuration.

## Changes
- Changed `publish_access` from `1` (Publish only content in publish stage) to `0` (No publishing restrictions) in the `createMcpWorkspace()` method
- Updated the inline comment to clarify that the value matches the TCA default behavior

## Details
The `publish_access` field default was incorrectly set to `1`, which restricts publishing. The correct default value of `0` removes publishing restrictions and matches the TCA configuration default. This ensures newly created MCP workspaces have the expected publishing permissions out of the box.
