### PR TITLE
Simplify table access control by removing read-only access tier

### DIFF
--- a/Classes/MCP/Tool/SearchTool.php
+++ b/Classes/MCP/Tool/SearchTool.php
@@ -493,9 +493,11 @@ class SearchTool extends AbstractRecordTool
             return [$specificTable];
         }
 
-        // Get all readable tables (includes non-workspace-capable tables for read operations)
-        $accessibleTables = $this->tableAccessService->getReadableTables();
-        
+        // Use the same access set as ReadTableTool so search never surfaces
+        // records the caller could not read via ReadTableTool. $includeReadOnly
+        // is true so read-only (but accessible) tables remain searchable.
+        $accessibleTables = $this->tableAccessService->getAccessibleTables(true);
+
         // Filter for tables that have searchable fields
         $searchableTables = [];
         foreach ($accessibleTables as $tableName => $accessInfo) {

--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -69,28 +69,8 @@ class TableAccessService implements SingletonInterface
     }
     
     /**
-     * Get all tables that are readable (less restrictive - no workspace capability required)
-     * 
-     * @return array Array of table names with access information
-     */
-    public function getReadableTables(): array
-    {
-        $readableTables = [];
-        
-        foreach (array_keys($GLOBALS['TCA']) as $table) {
-            $accessInfo = $this->getTableAccessInfo($table, false); // Don't require workspace capability
-            
-            if ($accessInfo['accessible']) {
-                $readableTables[$table] = $accessInfo;
-            }
-        }
-        
-        return $readableTables;
-    }
-    
-    /**
      * Check if a table can be accessed by the current user
-     * 
+     *
      * @param string $table Table name
      * @return bool
      */
@@ -99,27 +79,14 @@ class TableAccessService implements SingletonInterface
         $accessInfo = $this->getTableAccessInfo($table);
         return $accessInfo['accessible'];
     }
-    
-    /**
-     * Check if a table can be accessed for read operations (less restrictive)
-     * 
-     * @param string $table Table name
-     * @return bool
-     */
-    public function canReadTable(string $table): bool
-    {
-        $accessInfo = $this->getTableAccessInfo($table, false); // Don't require workspace capability
-        return $accessInfo['accessible'];
-    }
-    
+
     /**
      * Get detailed access information for a table
-     * 
+     *
      * @param string $table Table name
-     * @param bool $requireWorkspaceCapability Whether workspace capability is required (default: true)
      * @return array Detailed access information
      */
-    public function getTableAccessInfo(string $table, bool $requireWorkspaceCapability = true): array
+    public function getTableAccessInfo(string $table): array
     {
         // Start with default values
         $info = [
@@ -147,10 +114,11 @@ class TableAccessService implements SingletonInterface
             return $info;
         }
         
-        // Check workspace capability (required for write operations)
+        // Check workspace capability. All MCP tools operate through workspaces,
+        // so a non-workspace-capable table cannot be exposed - not even for read.
         $info['workspace_capable'] = BackendUtility::isTableWorkspaceEnabled($table);
-        if ($requireWorkspaceCapability && !$info['workspace_capable']) {
-            $info['reasons'][] = 'Table is not workspace-capable (required for write operations)';
+        if (!$info['workspace_capable']) {
+            $info['reasons'][] = 'Table is not workspace-capable';
             return $info;
         }
         


### PR DESCRIPTION
## Summary
This PR removes the dual-tier access control system that distinguished between "readable" (less restrictive) and "accessible" (more restrictive) tables. All MCP tools now use a unified access model where workspace capability is required for any table exposure. In the future, this will likely expand to some read-only tables.

## Key Changes
- **Removed methods from TableAccessService:**
  - `getReadableTables()` - no longer needed with unified access model
  - `canReadTable()` - replaced by `canAccessTable()`

- **Simplified `getTableAccessInfo()` method:**
  - Removed `$requireWorkspaceCapability` parameter (now always required)
  - Updated logic to reject non-workspace-capable tables unconditionally
  - Updated reason message to reflect that workspace capability is required for all access, not just write operations

- **Updated SearchTool:**
  - Changed from using `getReadableTables()` to `getAccessibleTables(true)`
  - This ensures SearchTool uses the same access restrictions as ReadTableTool
  - Added clarifying comments explaining the unified access model