### PR TITLE
Improve content positioning logic for before/after element placement

### DIFF
--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -309,8 +309,67 @@ class WriteTableTool extends AbstractRecordTool
             // Resolve live UID to workspace UID if needed, since DataHandler works with real UIDs
             $wsUid = $this->resolveToWorkspaceUid($table, $referenceUid);
             $newRecordData['pid'] = -$wsUid;
+        } elseif (strpos($position, 'before:') === 0) {
+            $referenceUid = (int)substr($position, strlen('before:'));
+            $sortingField = $this->tableAccessService->getSortingFieldName($table);
+
+            if ($sortingField !== null) {
+                // Look up the reference record to get its page and sorting value
+                $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+                    ->getQueryBuilderForTable($table);
+                $queryBuilder->getRestrictions()->removeAll()
+                    ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+
+                $refRecord = $queryBuilder
+                    ->select('uid', 'pid', $sortingField)
+                    ->from($table)
+                    ->where(
+                        $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($referenceUid, ParameterType::INTEGER))
+                    )
+                    ->executeQuery()
+                    ->fetchAssociative();
+
+                if ($refRecord) {
+                    $refPid = (int)$refRecord['pid'];
+                    $refSorting = (int)$refRecord[$sortingField];
+
+                    // Find the record immediately before the reference in sorting order
+                    $qb2 = GeneralUtility::makeInstance(ConnectionPool::class)
+                        ->getQueryBuilderForTable($table);
+                    $qb2->getRestrictions()->removeAll()
+                        ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+
+                    $predecessorRecord = $qb2
+                        ->select('uid')
+                        ->from($table)
+                        ->where(
+                            $qb2->expr()->eq('pid', $qb2->createNamedParameter($refPid, ParameterType::INTEGER)),
+                            $qb2->expr()->lt($sortingField, $qb2->createNamedParameter($refSorting, ParameterType::INTEGER))
+                        )
+                        ->orderBy($sortingField, 'DESC')
+                        ->addOrderBy('uid', 'DESC')
+                        ->setMaxResults(1)
+                        ->executeQuery()
+                        ->fetchAssociative();
+
+                    if ($predecessorRecord) {
+                        // Insert after the predecessor = before the reference
+                        $wsUid = $this->resolveToWorkspaceUid($table, (int)$predecessorRecord['uid']);
+                        $newRecordData['pid'] = -$wsUid;
+                    } else {
+                        // Reference is the first record on its page — insert at top
+                        $newRecordData['pid'] = $refPid;
+                    }
+                } else {
+                    // Reference record not found — fall back to user-provided pid
+                    $newRecordData['pid'] = $pid;
+                }
+            } else {
+                // Table has no sorting field — fall back to user-provided pid
+                $newRecordData['pid'] = $pid;
+            }
         } else {
-            // 'top', 'before:UID', or default — use positive pid (DataHandler inserts at top)
+            // 'top' or default — use positive pid (DataHandler inserts at top)
             $newRecordData['pid'] = $pid;
         }
 
@@ -408,38 +467,7 @@ class WriteTableTool extends AbstractRecordTool
                 }
             }
         }
-        
-        
-        // Handle before positioning via move command (after is already handled via negative pid)
-        if (strpos($position, 'before:') === 0) {
-            $referenceUid = (int)substr($position, strlen('before:'));
 
-            // Set up the command map for moving the record
-            $cmdMap = [];
-            $cmdMap[$table][$parentUid]['move'] = [
-                'action' => 'before',
-                'target' => $referenceUid,
-            ];
-
-            // Initialize a new DataHandler for the move operation
-            $moveDataHandler = GeneralUtility::makeInstance(DataHandler::class);
-            $moveDataHandler->BE_USER = $GLOBALS['BE_USER'];
-            $moveDataHandler->start([], $cmdMap);
-            $moveDataHandler->process_cmdmap();
-
-            // Check for errors in the move operation
-            if (!empty($moveDataHandler->errorLog)) {
-                // The record was created but positioning failed
-                $liveUid = $this->getLiveUid($table, $parentUid);
-                return $this->createJsonResult([
-                    'action' => 'create',
-                    'table' => $table,
-                    'uid' => $liveUid,
-                    'warning' => 'Record created but positioning failed: ' . implode(', ', $moveDataHandler->errorLog)
-                ]);
-            }
-        }
-        
         // Get the live UID for workspace transparency
         $liveUid = $this->getLiveUid($table, $parentUid);
         

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -314,37 +314,36 @@ class WriteTableTool extends AbstractRecordTool
             $sortingField = $this->tableAccessService->getSortingFieldName($table);
 
             if ($sortingField !== null) {
-                // Look up the reference record to get its page and sorting value
-                $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-                    ->getQueryBuilderForTable($table);
-                $queryBuilder->getRestrictions()->removeAll()
-                    ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-
-                $refRecord = $queryBuilder
-                    ->select('uid', 'pid', $sortingField)
-                    ->from($table)
-                    ->where(
-                        $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($referenceUid, ParameterType::INTEGER))
-                    )
-                    ->executeQuery()
-                    ->fetchAssociative();
+                // Workspace-aware lookup: resolve to workspace version for correct pid/sorting
+                $refRecord = BackendUtility::getRecord($table, $referenceUid);
+                if ($refRecord) {
+                    BackendUtility::workspaceOL($table, $refRecord);
+                }
 
                 if ($refRecord) {
                     $refPid = (int)$refRecord['pid'];
                     $refSorting = (int)$refRecord[$sortingField];
+                    $refUid = (int)$refRecord['uid'];
 
-                    // Find the record immediately before the reference in sorting order
+                    // Find the predecessor: workspace-aware, with UID tiebreak for equal sorting
                     $qb2 = GeneralUtility::makeInstance(ConnectionPool::class)
                         ->getQueryBuilderForTable($table);
                     $qb2->getRestrictions()->removeAll()
-                        ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+                        ->add(GeneralUtility::makeInstance(DeletedRestriction::class))
+                        ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, $GLOBALS['BE_USER']->workspace ?? 0));
 
                     $predecessorRecord = $qb2
                         ->select('uid')
                         ->from($table)
                         ->where(
                             $qb2->expr()->eq('pid', $qb2->createNamedParameter($refPid, ParameterType::INTEGER)),
-                            $qb2->expr()->lt($sortingField, $qb2->createNamedParameter($refSorting, ParameterType::INTEGER))
+                            $qb2->expr()->or(
+                                $qb2->expr()->lt($sortingField, $qb2->createNamedParameter($refSorting, ParameterType::INTEGER)),
+                                $qb2->expr()->and(
+                                    $qb2->expr()->eq($sortingField, $qb2->createNamedParameter($refSorting, ParameterType::INTEGER)),
+                                    $qb2->expr()->lt('uid', $qb2->createNamedParameter($refUid, ParameterType::INTEGER))
+                                )
+                            )
                         )
                         ->orderBy($sortingField, 'DESC')
                         ->addOrderBy('uid', 'DESC')
@@ -353,9 +352,8 @@ class WriteTableTool extends AbstractRecordTool
                         ->fetchAssociative();
 
                     if ($predecessorRecord) {
-                        // Insert after the predecessor = before the reference
-                        $wsUid = $this->resolveToWorkspaceUid($table, (int)$predecessorRecord['uid']);
-                        $newRecordData['pid'] = -$wsUid;
+                        // WorkspaceRestriction already returns the correct UID for the context
+                        $newRecordData['pid'] = -(int)$predecessorRecord['uid'];
                     } else {
                         // Reference is the first record on its page — insert at top
                         $newRecordData['pid'] = $refPid;

--- a/Tests/Functional/MCP/Tool/WriteTableToolTest.php
+++ b/Tests/Functional/MCP/Tool/WriteTableToolTest.php
@@ -538,7 +538,15 @@ class WriteTableToolTest extends AbstractFunctionalTest
     }
 
     /**
-     * Test creating content at bottom position
+     * Test creating content at the bottom of a page.
+     *
+     * Fixture data on page 1:
+     *   uid 100, sorting 256
+     *   uid 101, sorting 512
+     *   uid 104, sorting 768 (hidden=1 — still counts for sorting)
+     *
+     * Inserting with position=bottom must place the record on pid 1 with
+     * sorting greater than every existing record on the page.
      */
     public function testCreateContentAtBottom(): void
     {
@@ -556,27 +564,49 @@ class WriteTableToolTest extends AbstractFunctionalTest
             ]
         ]);
 
-        $this->assertFalse($result->isError, json_encode($result->content));
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
 
         $data = json_decode($result->content[0]->text, true);
         $newUid = $data['uid'];
 
-        // Verify it's created with high sorting value
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('tt_content');
+        $readRecord = function (int $uid): array {
+            $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getQueryBuilderForTable('tt_content');
+            $qb->getRestrictions()->removeAll()
+                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+            $row = $qb->select('pid', 'sorting')
+                ->from('tt_content')
+                ->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid, ParameterType::INTEGER)))
+                ->executeQuery()
+                ->fetchAssociative();
+            $this->assertIsArray($row, "Record $uid must exist");
+            return $row;
+        };
 
-        $record = $queryBuilder->select('sorting')
+        $newRecord = $readRecord($newUid);
+
+        $this->assertEquals(1, (int)$newRecord['pid'],
+            'Record created with position=bottom must be on the provided pid');
+
+        // Sorting must be greater than the highest existing sorting on page 1.
+        // Fixture: uid 104 has sorting 768 (highest), hidden but still counts.
+        $qbMax = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('tt_content');
+        $qbMax->getRestrictions()->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $maxSorting = (int)$qbMax->select('sorting')
             ->from('tt_content')
             ->where(
-                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($newUid, ParameterType::INTEGER))
+                $qbMax->expr()->eq('pid', $qbMax->createNamedParameter(1, ParameterType::INTEGER)),
+                $qbMax->expr()->neq('uid', $qbMax->createNamedParameter($newUid, ParameterType::INTEGER))
             )
+            ->orderBy('sorting', 'DESC')
+            ->setMaxResults(1)
             ->executeQuery()
-            ->fetchAssociative();
+            ->fetchOne();
 
-        $this->assertIsArray($record);
-        // The record should have a sorting value
-        $this->assertArrayHasKey('sorting', $record);
-        $this->assertIsInt($record['sorting']);
+        $this->assertGreaterThan($maxSorting, (int)$newRecord['sorting'],
+            'Record created with position=bottom must have sorting greater than all existing records on the page');
     }
 
     /**
@@ -617,12 +647,21 @@ class WriteTableToolTest extends AbstractFunctionalTest
     }
 
     /**
-     * Test creating content after a specific element
+     * Test that after:UID positions the record between the reference element
+     * and the next element in sorting order.
+     *
+     * Fixture data on page 1 (colPos 0):
+     *   uid 100, sorting 256 (reference)
+     *   uid 101, sorting 512 (next)
+     *
+     * Inserting after:100 must place the new record:
+     *   - On pid 1
+     *   - With sorting BETWEEN uid 100 (256) and uid 101 (512)
      */
     public function testCreateContentAfterElement(): void
     {
         $tool = new WriteTableTool();
-        
+
         $result = $tool->execute([
             'action' => 'create',
             'table' => 'tt_content',
@@ -634,31 +673,103 @@ class WriteTableToolTest extends AbstractFunctionalTest
                 'colPos' => 0
             ]
         ]);
-        
-        $this->assertFalse($result->isError, json_encode($result->content));
-        
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
         $data = json_decode($result->content[0]->text, true);
         $this->assertIsArray($data);
         $this->assertEquals('create', $data['action']);
         $this->assertIsInt($data['uid']);
-        
-        // Verify the sorting is set (positioning might not work perfectly in test env)
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('tt_content');
-        
-        $record = $queryBuilder->select('sorting')
-            ->from('tt_content')
-            ->where(
-                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($data['uid'], ParameterType::INTEGER))
-            )
-            ->executeQuery()
-            ->fetchAssociative();
-        
-        $this->assertIsArray($record);
-        $this->assertArrayHasKey('sorting', $record);
-        // The sorting should be set, even if positioning didn't work perfectly
-        $this->assertIsInt($record['sorting']);
-        $this->assertGreaterThan(0, $record['sorting']);
+
+        $newUid = $data['uid'];
+
+        $readRecord = function (int $uid): array {
+            $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getQueryBuilderForTable('tt_content');
+            $qb->getRestrictions()->removeAll()
+                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+            $row = $qb->select('pid', 'sorting')
+                ->from('tt_content')
+                ->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid, ParameterType::INTEGER)))
+                ->executeQuery()
+                ->fetchAssociative();
+            $this->assertIsArray($row, "Record $uid must exist");
+            return $row;
+        };
+
+        $newRecord = $readRecord($newUid);
+        $refRecord = $readRecord(100);
+        $nextRecord = $readRecord(101);
+
+        $this->assertEquals(1, (int)$newRecord['pid'],
+            'Record created with after:100 must be on pid 1');
+
+        $this->assertGreaterThan(
+            (int)$refRecord['sorting'],
+            (int)$newRecord['sorting'],
+            'New record sorting must be greater than the reference record (uid 100)'
+        );
+        $this->assertLessThan(
+            (int)$nextRecord['sorting'],
+            (int)$newRecord['sorting'],
+            'New record sorting must be less than the next record (uid 101)'
+        );
+    }
+
+    /**
+     * Test creating content after the last element on a page.
+     *
+     * Fixture data on page 2 (colPos 0):
+     *   uid 102, sorting 256
+     *   uid 103, sorting 512 (last)
+     *
+     * Inserting after:103 must place the record on pid 2 with sorting > 512.
+     */
+    public function testCreateContentAfterLastElement(): void
+    {
+        $tool = new WriteTableTool();
+
+        $result = $tool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 2,
+            'position' => 'after:103',
+            'data' => [
+                'CType' => 'textmedia',
+                'header' => 'After Last Element',
+                'colPos' => 0
+            ]
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $data = json_decode($result->content[0]->text, true);
+        $newUid = $data['uid'];
+
+        $readRecord = function (int $uid): array {
+            $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getQueryBuilderForTable('tt_content');
+            $qb->getRestrictions()->removeAll()
+                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+            $row = $qb->select('pid', 'sorting')
+                ->from('tt_content')
+                ->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid, ParameterType::INTEGER)))
+                ->executeQuery()
+                ->fetchAssociative();
+            $this->assertIsArray($row, "Record $uid must exist");
+            return $row;
+        };
+
+        $newRecord = $readRecord($newUid);
+        $refRecord = $readRecord(103);
+
+        $this->assertEquals(2, (int)$newRecord['pid'],
+            'Record created with after:103 must be on pid 2');
+        $this->assertGreaterThan(
+            (int)$refRecord['sorting'],
+            (int)$newRecord['sorting'],
+            'Record created with after:103 (last element) must have sorting greater than record 103'
+        );
     }
 
     /**
@@ -798,12 +909,18 @@ class WriteTableToolTest extends AbstractFunctionalTest
     }
 
     /**
-     * Test creating content at top position
+     * Test creating content at the top of a page.
+     *
+     * Fixture data on page 1 (colPos 0):
+     *   uid 100, sorting 256 (first)
+     *
+     * Inserting with position=top must place the record on pid 1 with
+     * sorting lower than every existing record on the page.
      */
     public function testCreateContentAtTop(): void
     {
         $tool = new WriteTableTool();
-        
+
         $result = $tool->execute([
             'action' => 'create',
             'table' => 'tt_content',
@@ -815,11 +932,95 @@ class WriteTableToolTest extends AbstractFunctionalTest
                 'colPos' => 0
             ]
         ]);
-        
-        $this->assertFalse($result->isError, json_encode($result->content));
-        
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
         $data = json_decode($result->content[0]->text, true);
         $this->assertIsInt($data['uid']);
+        $newUid = $data['uid'];
+
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('tt_content');
+        $qb->getRestrictions()->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $newRecord = $qb->select('pid', 'sorting')
+            ->from('tt_content')
+            ->where($qb->expr()->eq('uid', $qb->createNamedParameter($newUid, ParameterType::INTEGER)))
+            ->executeQuery()
+            ->fetchAssociative();
+
+        $this->assertIsArray($newRecord);
+        $this->assertEquals(1, (int)$newRecord['pid'],
+            'Record created with position=top must be on the provided pid');
+
+        // Sorting must be less than the minimum existing sorting on page 1.
+        $qbMin = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('tt_content');
+        $qbMin->getRestrictions()->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $minSorting = (int)$qbMin->select('sorting')
+            ->from('tt_content')
+            ->where(
+                $qbMin->expr()->eq('pid', $qbMin->createNamedParameter(1, ParameterType::INTEGER)),
+                $qbMin->expr()->neq('uid', $qbMin->createNamedParameter($newUid, ParameterType::INTEGER))
+            )
+            ->orderBy('sorting', 'ASC')
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchOne();
+
+        $this->assertLessThan($minSorting, (int)$newRecord['sorting'],
+            'Record created with position=top must have sorting less than all existing records on the page');
+    }
+
+    /**
+     * Test that before:UID follows the reference record's page when the
+     * user-provided pid points to a different page.
+     *
+     * This is the scenario from issue #50: user provides pid=1 but
+     * references a UID on page 2. The positional reference must win —
+     * the record must NOT land on pid 0 or pid 1.
+     *
+     * Fixture data on page 2 (colPos 0):
+     *   uid 102, sorting 256 (first element on page 2)
+     *   uid 103, sorting 512
+     */
+    public function testCreateContentBeforeElementOnDifferentPage(): void
+    {
+        $tool = new WriteTableTool();
+
+        $result = $tool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1, // deliberately different from reference's actual page
+            'position' => 'before:102',
+            'data' => [
+                'CType' => 'textmedia',
+                'header' => 'Before element on another page',
+                'colPos' => 0
+            ]
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $data = json_decode($result->content[0]->text, true);
+        $newUid = $data['uid'];
+
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('tt_content');
+        $qb->getRestrictions()->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $newRecord = $qb->select('pid', 'sorting')
+            ->from('tt_content')
+            ->where($qb->expr()->eq('uid', $qb->createNamedParameter($newUid, ParameterType::INTEGER)))
+            ->executeQuery()
+            ->fetchAssociative();
+
+        $this->assertIsArray($newRecord);
+        $this->assertEquals(2, (int)$newRecord['pid'],
+            'Record must land on the reference element\'s page (2), not the user-provided pid (1) or pid 0');
+        $this->assertLessThan(256, (int)$newRecord['sorting'],
+            'Record must have sorting less than reference record 102 (sorting 256)');
     }
 
     /**

--- a/Tests/Functional/MCP/Tool/WriteTableToolTest.php
+++ b/Tests/Functional/MCP/Tool/WriteTableToolTest.php
@@ -662,12 +662,23 @@ class WriteTableToolTest extends AbstractFunctionalTest
     }
 
     /**
-     * Test creating content before a specific element
+     * Test that before:UID positions the record between the preceding element
+     * and the reference element — not at the top of the page.
+     *
+     * Fixture data on page 1 (colPos 0):
+     *   uid 100, sorting 256 (Welcome Header)
+     *   uid 101, sorting 512 (About Section)
+     *   uid 104, sorting 768 (Hidden Content, hidden=1)
+     *
+     * Inserting before:101 must place the new record:
+     *   - On pid 1 (not pid 0)
+     *   - With sorting BETWEEN uid 100 (256) and uid 101 (512)
+     *     i.e. sorting > 256 AND sorting < 512
      */
     public function testCreateContentBeforeElement(): void
     {
         $tool = new WriteTableTool();
-        
+
         $result = $tool->execute([
             'action' => 'create',
             'table' => 'tt_content',
@@ -679,31 +690,111 @@ class WriteTableToolTest extends AbstractFunctionalTest
                 'colPos' => 0
             ]
         ]);
-        
-        $this->assertFalse($result->isError, json_encode($result->content));
-        
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
         $data = json_decode($result->content[0]->text, true);
         $this->assertIsArray($data);
         $this->assertEquals('create', $data['action']);
         $this->assertIsInt($data['uid']);
-        
-        // Verify the sorting is set (positioning might not work perfectly in test env)
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('tt_content');
-        
-        $record = $queryBuilder->select('sorting')
-            ->from('tt_content')
-            ->where(
-                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($data['uid'], ParameterType::INTEGER))
-            )
-            ->executeQuery()
-            ->fetchAssociative();
-        
-        $this->assertIsArray($record);
-        $this->assertArrayHasKey('sorting', $record);
-        // The sorting should be set, even if positioning didn't work perfectly
-        $this->assertIsInt($record['sorting']);
-        $this->assertGreaterThan(0, $record['sorting']);
+
+        $newUid = $data['uid'];
+
+        // Helper: read a single record's pid+sorting (ignoring workspace restrictions)
+        $readRecord = function (int $uid): array {
+            $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getQueryBuilderForTable('tt_content');
+            $qb->getRestrictions()->removeAll()
+                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+            $row = $qb->select('pid', 'sorting')
+                ->from('tt_content')
+                ->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid, ParameterType::INTEGER)))
+                ->executeQuery()
+                ->fetchAssociative();
+            $this->assertIsArray($row, "Record $uid must exist");
+            return $row;
+        };
+
+        $newRecord = $readRecord($newUid);
+        $prevRecord = $readRecord(100);  // element before the reference
+        $refRecord  = $readRecord(101);  // the reference element
+
+        // Critical: PID must be 1, not 0
+        $this->assertEquals(1, (int)$newRecord['pid'],
+            'Record created with before:101 must be on pid 1, not pid ' . $newRecord['pid']);
+
+        // The new record must sit between uid 100 and uid 101 in sorting order.
+        $this->assertGreaterThan(
+            (int)$prevRecord['sorting'],
+            (int)$newRecord['sorting'],
+            'New record sorting (' . $newRecord['sorting'] . ') must be greater than '
+            . 'record 100 sorting (' . $prevRecord['sorting'] . ') — it should be between 100 and 101, not at the top'
+        );
+        $this->assertLessThan(
+            (int)$refRecord['sorting'],
+            (int)$newRecord['sorting'],
+            'New record sorting (' . $newRecord['sorting'] . ') must be less than '
+            . 'record 101 sorting (' . $refRecord['sorting'] . ')'
+        );
+    }
+
+    /**
+     * Test creating content before the first element on a page.
+     *
+     * Fixture data on page 1 (colPos 0):
+     *   uid 100, sorting 256 (Welcome Header) — first element
+     *
+     * Inserting before:100 must place the record on pid 1 with sorting < 256.
+     */
+    public function testCreateContentBeforeFirstElement(): void
+    {
+        $tool = new WriteTableTool();
+
+        $result = $tool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'position' => 'before:100',
+            'data' => [
+                'CType' => 'textmedia',
+                'header' => 'Before First Element',
+                'colPos' => 0
+            ]
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $data = json_decode($result->content[0]->text, true);
+        $this->assertIsArray($data);
+        $newUid = $data['uid'];
+
+        // Read the new record and the reference record
+        $readRecord = function (int $uid): array {
+            $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getQueryBuilderForTable('tt_content');
+            $qb->getRestrictions()->removeAll()
+                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+            $row = $qb->select('pid', 'sorting')
+                ->from('tt_content')
+                ->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid, ParameterType::INTEGER)))
+                ->executeQuery()
+                ->fetchAssociative();
+            $this->assertIsArray($row, "Record $uid must exist");
+            return $row;
+        };
+
+        $newRecord = $readRecord($newUid);
+        $refRecord = $readRecord(100);
+
+        $this->assertEquals(1, (int)$newRecord['pid'],
+            'Record created with before:100 must be on pid 1');
+
+        // The new record must have lower sorting than the first element
+        $this->assertLessThan(
+            (int)$refRecord['sorting'],
+            (int)$newRecord['sorting'],
+            'Record created with before:100 must have lower sorting than record 100'
+        );
     }
 
     /**

--- a/Tests/Functional/MCP/Tool/WriteTableToolTest.php
+++ b/Tests/Functional/MCP/Tool/WriteTableToolTest.php
@@ -569,21 +569,11 @@ class WriteTableToolTest extends AbstractFunctionalTest
         $data = json_decode($result->content[0]->text, true);
         $newUid = $data['uid'];
 
-        $readRecord = function (int $uid): array {
-            $qb = GeneralUtility::makeInstance(ConnectionPool::class)
-                ->getQueryBuilderForTable('tt_content');
-            $qb->getRestrictions()->removeAll()
-                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-            $row = $qb->select('pid', 'sorting')
-                ->from('tt_content')
-                ->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid, ParameterType::INTEGER)))
-                ->executeQuery()
-                ->fetchAssociative();
-            $this->assertIsArray($row, "Record $uid must exist");
-            return $row;
-        };
-
-        $newRecord = $readRecord($newUid);
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tt_content');
+        $newRecord = $connection->select(['pid', 'sorting'], 'tt_content', ['uid' => $newUid])
+            ->fetchAssociative();
+        $this->assertIsArray($newRecord, "New record $newUid must exist");
 
         $this->assertEquals(1, (int)$newRecord['pid'],
             'Record created with position=bottom must be on the provided pid');
@@ -683,23 +673,15 @@ class WriteTableToolTest extends AbstractFunctionalTest
 
         $newUid = $data['uid'];
 
-        $readRecord = function (int $uid): array {
-            $qb = GeneralUtility::makeInstance(ConnectionPool::class)
-                ->getQueryBuilderForTable('tt_content');
-            $qb->getRestrictions()->removeAll()
-                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-            $row = $qb->select('pid', 'sorting')
-                ->from('tt_content')
-                ->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid, ParameterType::INTEGER)))
-                ->executeQuery()
-                ->fetchAssociative();
-            $this->assertIsArray($row, "Record $uid must exist");
-            return $row;
-        };
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tt_content');
+        $newRecord = $connection->select(['pid', 'sorting'], 'tt_content', ['uid' => $newUid])->fetchAssociative();
+        $refRecord = $connection->select(['pid', 'sorting'], 'tt_content', ['uid' => 100])->fetchAssociative();
+        $nextRecord = $connection->select(['pid', 'sorting'], 'tt_content', ['uid' => 101])->fetchAssociative();
 
-        $newRecord = $readRecord($newUid);
-        $refRecord = $readRecord(100);
-        $nextRecord = $readRecord(101);
+        $this->assertIsArray($newRecord);
+        $this->assertIsArray($refRecord);
+        $this->assertIsArray($nextRecord);
 
         $this->assertEquals(1, (int)$newRecord['pid'],
             'Record created with after:100 must be on pid 1');
@@ -746,22 +728,13 @@ class WriteTableToolTest extends AbstractFunctionalTest
         $data = json_decode($result->content[0]->text, true);
         $newUid = $data['uid'];
 
-        $readRecord = function (int $uid): array {
-            $qb = GeneralUtility::makeInstance(ConnectionPool::class)
-                ->getQueryBuilderForTable('tt_content');
-            $qb->getRestrictions()->removeAll()
-                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-            $row = $qb->select('pid', 'sorting')
-                ->from('tt_content')
-                ->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid, ParameterType::INTEGER)))
-                ->executeQuery()
-                ->fetchAssociative();
-            $this->assertIsArray($row, "Record $uid must exist");
-            return $row;
-        };
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tt_content');
+        $newRecord = $connection->select(['pid', 'sorting'], 'tt_content', ['uid' => $newUid])->fetchAssociative();
+        $refRecord = $connection->select(['pid', 'sorting'], 'tt_content', ['uid' => 103])->fetchAssociative();
 
-        $newRecord = $readRecord($newUid);
-        $refRecord = $readRecord(103);
+        $this->assertIsArray($newRecord);
+        $this->assertIsArray($refRecord);
 
         $this->assertEquals(2, (int)$newRecord['pid'],
             'Record created with after:103 must be on pid 2');
@@ -811,24 +784,15 @@ class WriteTableToolTest extends AbstractFunctionalTest
 
         $newUid = $data['uid'];
 
-        // Helper: read a single record's pid+sorting (ignoring workspace restrictions)
-        $readRecord = function (int $uid): array {
-            $qb = GeneralUtility::makeInstance(ConnectionPool::class)
-                ->getQueryBuilderForTable('tt_content');
-            $qb->getRestrictions()->removeAll()
-                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-            $row = $qb->select('pid', 'sorting')
-                ->from('tt_content')
-                ->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid, ParameterType::INTEGER)))
-                ->executeQuery()
-                ->fetchAssociative();
-            $this->assertIsArray($row, "Record $uid must exist");
-            return $row;
-        };
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tt_content');
+        $newRecord  = $connection->select(['pid', 'sorting'], 'tt_content', ['uid' => $newUid])->fetchAssociative();
+        $prevRecord = $connection->select(['pid', 'sorting'], 'tt_content', ['uid' => 100])->fetchAssociative();
+        $refRecord  = $connection->select(['pid', 'sorting'], 'tt_content', ['uid' => 101])->fetchAssociative();
 
-        $newRecord = $readRecord($newUid);
-        $prevRecord = $readRecord(100);  // element before the reference
-        $refRecord  = $readRecord(101);  // the reference element
+        $this->assertIsArray($newRecord);
+        $this->assertIsArray($prevRecord);
+        $this->assertIsArray($refRecord);
 
         // Critical: PID must be 1, not 0
         $this->assertEquals(1, (int)$newRecord['pid'],
@@ -879,23 +843,13 @@ class WriteTableToolTest extends AbstractFunctionalTest
         $this->assertIsArray($data);
         $newUid = $data['uid'];
 
-        // Read the new record and the reference record
-        $readRecord = function (int $uid): array {
-            $qb = GeneralUtility::makeInstance(ConnectionPool::class)
-                ->getQueryBuilderForTable('tt_content');
-            $qb->getRestrictions()->removeAll()
-                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-            $row = $qb->select('pid', 'sorting')
-                ->from('tt_content')
-                ->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid, ParameterType::INTEGER)))
-                ->executeQuery()
-                ->fetchAssociative();
-            $this->assertIsArray($row, "Record $uid must exist");
-            return $row;
-        };
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tt_content');
+        $newRecord = $connection->select(['pid', 'sorting'], 'tt_content', ['uid' => $newUid])->fetchAssociative();
+        $refRecord = $connection->select(['pid', 'sorting'], 'tt_content', ['uid' => 100])->fetchAssociative();
 
-        $newRecord = $readRecord($newUid);
-        $refRecord = $readRecord(100);
+        $this->assertIsArray($newRecord);
+        $this->assertIsArray($refRecord);
 
         $this->assertEquals(1, (int)$newRecord['pid'],
             'Record created with before:100 must be on pid 1');
@@ -939,14 +893,9 @@ class WriteTableToolTest extends AbstractFunctionalTest
         $this->assertIsInt($data['uid']);
         $newUid = $data['uid'];
 
-        $qb = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('tt_content');
-        $qb->getRestrictions()->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-        $newRecord = $qb->select('pid', 'sorting')
-            ->from('tt_content')
-            ->where($qb->expr()->eq('uid', $qb->createNamedParameter($newUid, ParameterType::INTEGER)))
-            ->executeQuery()
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tt_content');
+        $newRecord = $connection->select(['pid', 'sorting'], 'tt_content', ['uid' => $newUid])
             ->fetchAssociative();
 
         $this->assertIsArray($newRecord);
@@ -1006,14 +955,9 @@ class WriteTableToolTest extends AbstractFunctionalTest
         $data = json_decode($result->content[0]->text, true);
         $newUid = $data['uid'];
 
-        $qb = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('tt_content');
-        $qb->getRestrictions()->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-        $newRecord = $qb->select('pid', 'sorting')
-            ->from('tt_content')
-            ->where($qb->expr()->eq('uid', $qb->createNamedParameter($newUid, ParameterType::INTEGER)))
-            ->executeQuery()
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tt_content');
+        $newRecord = $connection->select(['pid', 'sorting'], 'tt_content', ['uid' => $newUid])
             ->fetchAssociative();
 
         $this->assertIsArray($newRecord);


### PR DESCRIPTION
## Summary
This PR significantly improves the positioning logic for creating content elements before and after reference elements in TYPO3. It replaces the post-creation move command approach with pre-creation pid calculation, adds comprehensive test coverage for edge cases, and fixes a critical bug where records could land on the wrong page.

## Key Changes

- **Refactored `before:` positioning logic**: Moved from post-creation move command to pre-creation pid calculation by finding the predecessor record and using negative pid to insert after it. This is more reliable and consistent with the existing `after:` implementation.

- **Fixed page assignment bug**: Records positioned relative to a reference element now correctly land on the reference element's page, not the user-provided pid. This fixes issue #50 where `before:102` with `pid=1` would incorrectly place the record on pid 1 instead of pid 2.

- **Enhanced test coverage**: 
  - Expanded existing positioning tests with detailed fixture documentation and comprehensive assertions
  - Added `testCreateContentAfterLastElement()` to verify positioning after the last element on a page
  - Added `testCreateContentBeforeFirstElement()` to verify positioning before the first element on a page
  - Added `testCreateContentBeforeElementOnDifferentPage()` to verify the page assignment fix
  - Improved all positioning tests to verify both pid and sorting values are correct

- **Improved test assertions**: Updated error messages to use `json_encode($result->jsonSerialize())` for better debugging and added detailed comments explaining fixture data and expected behavior.

- **Removed post-creation move logic**: Eliminated the DataHandler move command approach for `before:` positioning, simplifying the code and reducing potential error paths.

## Implementation Details

The `before:` positioning now:
1. Looks up the reference record to get its page (pid) and sorting value
2. Finds the predecessor record (highest sorting value less than reference)
3. If predecessor exists: uses negative pid of predecessor (inserts after it)
4. If no predecessor: uses the reference record's pid directly (inserts at top of page)
5. Falls back to user-provided pid if reference record not found or table has no sorting field

This approach ensures records are always positioned on the correct page and in the correct order relative to existing elements.

https://claude.ai/code/session_01TtVZnWgAMqQfnM9MhzouLw