### PR TITLE
fix: init anonymous user session so DataHandler UPDATE does not crash

### DIFF
--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -252,6 +252,14 @@ class McpEndpoint
             $beUser->user = $userData;
             $GLOBALS['BE_USER'] = $beUser;
 
+            // CRITICAL: Initialize an (anonymous) user session.
+            // Normal TYPO3 requests go through BackendUserAuthenticator middleware which wires
+            // up a real UserSession. Token auth bypasses that, so DataHandler write paths
+            // that touch $beUser->setAndSaveSessionData() (FlashMessageQueue, BackendFormProtection)
+            // crash with "Call to a member function set() on null" on UPDATE operations.
+            // An anonymous in-memory session is discarded at request end — sufficient for stateless MCP.
+            $beUser->initializeUserSessionManager();
+
             // CRITICAL: Fetch group data to populate permissions
             // This computes tables_select, tables_modify, non_exclude_fields, webmounts, etc.
             // Without this, non-admin users have no permissions computed from their groups


### PR DESCRIPTION
Token-authenticated MCP requests bypass BackendUserAuthenticator middleware, so $beUser->userSession stays null. Any DataHandler UPDATE path that ends up calling setAndSaveSessionData() (e.g. FlashMessageQueue, BackendFormProtection) then fatals with "Call to a member function set() on null".

Calling initializeUserSessionManager() after assigning $beUser->user creates an anonymous in-memory session that is discarded at request end — sufficient for stateless MCP calls and fixes the crash without introducing persistence.

Affects: every UPDATE operation via WriteTable tool.