### PR TITLE
feat(WriteTableTool): accept colPos=-1 for Gridelements container children

### DIFF
--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -719,7 +719,7 @@ class WriteTableTool extends AbstractRecordTool
 
     /**
      * Validate record data against TCA
-     * 
+     *
      * @param int|null $uid Record UID (required for update actions)
      * @return true|string True if valid, error message if invalid
      */
@@ -727,7 +727,7 @@ class WriteTableTool extends AbstractRecordTool
     {
         // Table access has already been validated by ensureTableAccess() before this method is called
         // No need to re-check table existence here
-        
+
         // Special handling for uid and pid
         if (isset($data['uid'])) {
             return "Field 'uid' cannot be modified directly";
@@ -735,7 +735,16 @@ class WriteTableTool extends AbstractRecordTool
         if (isset($data['pid']) && $action !== 'create') {
             return "Field 'pid' can only be set during record creation";
         }
-        
+
+        // Gridelements: records linked to a Gridelements container live outside page columns
+        // and must carry colPos = -1 (a magic value Gridelements sets implicitly but that is not
+        // declared in TCA select items). Normalise colPos here so callers do not have to know
+        // the magic value, and so the TCA-select validation below accepts it.
+        $isGridelementsChild = $this->isGridelementsContainerChild($table, $data, $action, $uid);
+        if ($isGridelementsChild) {
+            $data['colPos'] = -1;
+        }
+
         // Validate and convert field values
         foreach ($data as $fieldName => $value) {
             $fieldConfig = $this->tableAccessService->getFieldConfig($table, $fieldName);
@@ -750,6 +759,12 @@ class WriteTableTool extends AbstractRecordTool
                     return "Field '{$fieldName}': File fields are not supported. Please use TYPO3 backend for file operations.";
                 }
                 return "Field '{$fieldName}' is not accessible";
+            }
+
+            // Gridelements container children carry colPos = -1 (see isGridelementsContainerChild).
+            // That value is not in the TCA select items, so skip the value check for this case.
+            if ($isGridelementsChild && $fieldName === 'colPos' && (int)$value === -1) {
+                continue;
             }
 
             // Validate field value
@@ -847,8 +862,15 @@ class WriteTableTool extends AbstractRecordTool
                     // Example: tx_news_related_news stores the foreign key for inline relations
                     continue;
                 }
-                
-                
+
+                // Gridelements manages tx_gridelements_container / tx_gridelements_columns behind
+                // the scenes (no showitem entry on standard CTypes), but they are valid TCA columns
+                // that must be writable to attach a record to a container.
+                if ($table === 'tt_content' && in_array($fieldName, ['tx_gridelements_container', 'tx_gridelements_columns'], true)) {
+                    continue;
+                }
+
+
                 // If we have available fields configured and this field is not in the list
                 if (!empty($availableFields) && !isset($availableFields[$fieldName])) {
                     return "Field '{$fieldName}' is not available for this record type";
@@ -858,8 +880,43 @@ class WriteTableTool extends AbstractRecordTool
         
         return true;
     }
-    
-    
+
+    /**
+     * Determine whether a tt_content record is (or is becoming) a child of a
+     * Gridelements container. Children live outside page columns and are linked
+     * to their parent via tx_gridelements_container; TYPO3 represents that state
+     * as colPos = -1, a value not declared in TCA select items and therefore
+     * rejected by the standard field validator.
+     *
+     * Returns false when Gridelements is not installed (column absent from TCA)
+     * so the method is inert in projects that do not use it.
+     */
+    protected function isGridelementsContainerChild(string $table, array $data, string $action, ?int $uid): bool
+    {
+        if ($table !== 'tt_content') {
+            return false;
+        }
+        if (!isset($GLOBALS['TCA'][$table]['columns']['tx_gridelements_container'])) {
+            return false;
+        }
+
+        // If the caller explicitly sets the container link in this operation, trust it.
+        if (array_key_exists('tx_gridelements_container', $data)) {
+            return (int)$data['tx_gridelements_container'] > 0;
+        }
+
+        // For updates without the field in data, fall back to the existing record.
+        if ($action === 'update' && $uid !== null) {
+            $current = BackendUtility::getRecord($table, $uid, 'tx_gridelements_container');
+            if ($current && (int)($current['tx_gridelements_container'] ?? 0) > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
     /**
      * Extract inline relations from data array
      */

--- a/Tests/Functional/Fixtures/Extensions/gridelements_stub/Configuration/TCA/Overrides/tt_content.php
+++ b/Tests/Functional/Fixtures/Extensions/gridelements_stub/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,42 @@
+<?php
+
+defined('TYPO3') or die();
+
+// Minimal TCA stub that mirrors the shape of the real GridElementsTeam/gridelements
+// extension for the two columns the MCP server cares about. Only the details that
+// affect WriteTableTool validation are modelled:
+//   - tx_gridelements_container is a "select" with foreign_table (no static items),
+//     flagged as exclude=1 just like the real extension.
+//   - tx_gridelements_columns is a "select" with static items.
+// Neither field is added to any type's showitem — that is intentional and matches
+// the real extension, which manages the columns behind the scenes via drag&drop.
+
+$GLOBALS['TCA']['tt_content']['columns']['tx_gridelements_container'] = [
+    'exclude' => 1,
+    'label' => 'Gridelements container',
+    'config' => [
+        'type' => 'select',
+        'renderType' => 'selectSingle',
+        'foreign_table' => 'tt_content',
+        'items' => [
+            ['label' => '', 'value' => 0],
+        ],
+        'default' => 0,
+    ],
+];
+
+$GLOBALS['TCA']['tt_content']['columns']['tx_gridelements_columns'] = [
+    'exclude' => 1,
+    'label' => 'Gridelements column index',
+    'config' => [
+        'type' => 'select',
+        'renderType' => 'selectSingle',
+        'items' => [
+            ['label' => 'column 0', 'value' => 0],
+            ['label' => 'column 1', 'value' => 1],
+            ['label' => 'column 2', 'value' => 2],
+            ['label' => 'column 3', 'value' => 3],
+        ],
+        'default' => 0,
+    ],
+];

--- a/Tests/Functional/Fixtures/Extensions/gridelements_stub/ext_emconf.php
+++ b/Tests/Functional/Fixtures/Extensions/gridelements_stub/ext_emconf.php
@@ -1,0 +1,16 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Gridelements stub (test fixture)',
+    'description' => 'Adds the tx_gridelements_container / tx_gridelements_columns columns to tt_content so MCP behaviour around Gridelements container children can be tested without depending on the real GridElementsTeam/gridelements extension.',
+    'category' => 'tests',
+    'version' => '1.0.0',
+    'state' => 'stable',
+    'author' => 'Hn MCP Server Tests',
+    'author_email' => 'noreply@example.com',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '13.4.0-13.4.99',
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Extensions/gridelements_stub/ext_tables.sql
+++ b/Tests/Functional/Fixtures/Extensions/gridelements_stub/ext_tables.sql
@@ -1,0 +1,8 @@
+#
+# Stubbed schema additions matching the subset of GridElementsTeam/gridelements
+# that WriteTableTool validation depends on.
+#
+CREATE TABLE tt_content (
+	tx_gridelements_container int(11) DEFAULT '0' NOT NULL,
+	tx_gridelements_columns int(11) DEFAULT '0' NOT NULL
+);

--- a/Tests/Functional/MCP/Tool/GridelementsContainerChildTest.php
+++ b/Tests/Functional/MCP/Tool/GridelementsContainerChildTest.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Gridelements container children carry colPos = -1. That value is a Gridelements magic
+ * value and is not declared in TCA select items, so the default TCA validator rejects it.
+ * WriteTableTool recognises the container-child case (via tx_gridelements_container) and
+ * bypasses the select validation; these tests exercise that behaviour.
+ *
+ * The real GridElementsTeam/gridelements extension is not loaded in tests — instead the
+ * fixture extension at Tests/Functional/Fixtures/Extensions/gridelements_stub adds just
+ * the two columns the MCP server inspects (tx_gridelements_container, tx_gridelements_columns).
+ */
+class GridelementsContainerChildTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+        'frontend',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'mcp_server',
+    ];
+
+    protected function setUp(): void
+    {
+        // Register fixture extension via absolute path so that its TCA overrides are applied
+        // and the matching columns are created in tt_content. The path cannot live in the
+        // class-property default (no __DIR__ there), so it is injected here.
+        $this->testExtensionsToLoad[] = __DIR__ . '/../../Fixtures/Extensions/gridelements_stub';
+
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/pages.csv');
+        $this->setUpBackendUser(1);
+    }
+
+    /**
+     * The minimal happy path: a parent "container" record exists on a page and a child
+     * record points at it via tx_gridelements_container. colPos is not given by the
+     * caller — the MCP should fill in -1 automatically.
+     */
+    public function testContainerChildCreatedWithoutColPosAutoFillsMinusOne(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+
+        $containerResult = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Container placeholder',
+                'colPos' => 0,
+            ],
+        ]);
+        $this->assertFalse($containerResult->isError, $this->errorText($containerResult));
+        $containerUid = (int)json_decode($containerResult->content[0]->text, true)['uid'];
+
+        $childResult = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Child in column 0',
+                'bodytext' => 'text inside the container',
+                'tx_gridelements_container' => $containerUid,
+                'tx_gridelements_columns' => 0,
+            ],
+        ]);
+        $this->assertFalse($childResult->isError, $this->errorText($childResult));
+        $childUid = (int)json_decode($childResult->content[0]->text, true)['uid'];
+
+        $this->assertSame(-1, $this->fetchColPos($childUid));
+        $this->assertSame($containerUid, $this->fetchGridContainer($childUid));
+    }
+
+    /**
+     * Caller explicitly sets colPos = -1 together with the container linkage. Both are
+     * valid, so the write must succeed without the TCA select validator rejecting -1.
+     */
+    public function testExplicitMinusOneColPosWithContainerLinkageIsAccepted(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+
+        $containerResult = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => ['CType' => 'text', 'header' => 'Container', 'colPos' => 0],
+        ]);
+        $this->assertFalse($containerResult->isError, $this->errorText($containerResult));
+        $containerUid = (int)json_decode($containerResult->content[0]->text, true)['uid'];
+
+        $childResult = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Child',
+                'colPos' => -1,
+                'tx_gridelements_container' => $containerUid,
+                'tx_gridelements_columns' => 1,
+            ],
+        ]);
+        $this->assertFalse($childResult->isError, $this->errorText($childResult));
+        $childUid = (int)json_decode($childResult->content[0]->text, true)['uid'];
+
+        $this->assertSame(-1, $this->fetchColPos($childUid));
+    }
+
+    /**
+     * colPos = -1 without any container linkage is meaningless and must still be rejected —
+     * the bypass only kicks in for genuine container children. Guarding this case keeps the
+     * TCA validator honest for normal records.
+     */
+    public function testOrphanColPosMinusOneWithoutContainerIsRejected(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+
+        $result = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Orphan',
+                'colPos' => -1,
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'colPos=-1 must be rejected when no container linkage is provided');
+    }
+
+    /**
+     * When an existing record already lives inside a container, the caller must be able to
+     * touch unrelated fields (e.g. bodytext) via update without having to repeat the
+     * container linkage or the magic colPos value.
+     */
+    public function testUpdateOfExistingChildWithoutContainerInDataKeepsMinusOne(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+
+        $containerResult = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => ['CType' => 'text', 'header' => 'Container', 'colPos' => 0],
+        ]);
+        $containerUid = (int)json_decode($containerResult->content[0]->text, true)['uid'];
+
+        $childResult = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Child',
+                'bodytext' => 'initial',
+                'tx_gridelements_container' => $containerUid,
+                'tx_gridelements_columns' => 0,
+            ],
+        ]);
+        $childUid = (int)json_decode($childResult->content[0]->text, true)['uid'];
+        $this->assertSame(-1, $this->fetchColPos($childUid));
+
+        $updateResult = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'update',
+            'uid' => $childUid,
+            'data' => [
+                'bodytext' => 'edited text',
+            ],
+        ]);
+        $this->assertFalse($updateResult->isError, $this->errorText($updateResult));
+
+        $this->assertSame(-1, $this->fetchColPos($childUid));
+        $this->assertSame($containerUid, $this->fetchGridContainer($childUid));
+    }
+
+    /**
+     * Moving a record INTO a container via update: caller sets tx_gridelements_container
+     * to a non-zero value, MCP must auto-fix colPos from 0 to -1 so the record no longer
+     * double-renders at the page level.
+     */
+    public function testUpdateThatAttachesRecordToContainerForcesColPosMinusOne(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+
+        $containerResult = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => ['CType' => 'text', 'header' => 'Container', 'colPos' => 0],
+        ]);
+        $containerUid = (int)json_decode($containerResult->content[0]->text, true)['uid'];
+
+        $topLevelResult = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Top-level element',
+                'colPos' => 0,
+            ],
+        ]);
+        $topLevelUid = (int)json_decode($topLevelResult->content[0]->text, true)['uid'];
+        $this->assertSame(0, $this->fetchColPos($topLevelUid));
+
+        $moveResult = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'update',
+            'uid' => $topLevelUid,
+            'data' => [
+                'tx_gridelements_container' => $containerUid,
+                'tx_gridelements_columns' => 0,
+            ],
+        ]);
+        $this->assertFalse($moveResult->isError, $this->errorText($moveResult));
+
+        $this->assertSame(-1, $this->fetchColPos($topLevelUid));
+    }
+
+    /**
+     * Moving a record OUT of a container: caller clears tx_gridelements_container to 0.
+     * MCP must NOT force colPos = -1 in this case — the record goes back to being a
+     * top-level element, and the caller is free to assign a real page colPos.
+     */
+    public function testUpdateThatDetachesRecordFromContainerAllowsNormalColPos(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+
+        $containerResult = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => ['CType' => 'text', 'header' => 'Container', 'colPos' => 0],
+        ]);
+        $containerUid = (int)json_decode($containerResult->content[0]->text, true)['uid'];
+
+        $childResult = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Child',
+                'tx_gridelements_container' => $containerUid,
+                'tx_gridelements_columns' => 0,
+            ],
+        ]);
+        $childUid = (int)json_decode($childResult->content[0]->text, true)['uid'];
+        $this->assertSame(-1, $this->fetchColPos($childUid));
+
+        $detachResult = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'update',
+            'uid' => $childUid,
+            'data' => [
+                'tx_gridelements_container' => 0,
+                'colPos' => 0,
+            ],
+        ]);
+        $this->assertFalse($detachResult->isError, $this->errorText($detachResult));
+
+        $this->assertSame(0, $this->fetchColPos($childUid));
+        $this->assertSame(0, $this->fetchGridContainer($childUid));
+    }
+
+    private function fetchColPos(int $uid): int
+    {
+        $row = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tt_content')
+            ->select(['colPos'], 'tt_content', ['uid' => $uid])
+            ->fetchAssociative();
+        $this->assertIsArray($row, "tt_content record {$uid} not found");
+        return (int)$row['colPos'];
+    }
+
+    private function fetchGridContainer(int $uid): int
+    {
+        $row = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tt_content')
+            ->select(['tx_gridelements_container'], 'tt_content', ['uid' => $uid])
+            ->fetchAssociative();
+        $this->assertIsArray($row, "tt_content record {$uid} not found");
+        return (int)$row['tx_gridelements_container'];
+    }
+
+    private function errorText($result): string
+    {
+        return json_encode($result->jsonSerialize());
+    }
+}


### PR DESCRIPTION
# Accept `colPos = -1` for Gridelements container children

## Problem

Trying to create or update a `tt_content` record that sits inside a Gridelements
container currently fails with

```
Validation error: Field 'colPos' value '-1' must be one of: '0', '2', '3'
```

Gridelements links children to their parent via `tx_gridelements_container` and
stores them with `colPos = -1`. That `-1` is a magic value: Gridelements itself
sets it implicitly from its TCEmain hooks and from the backend drag-and-drop UI,
and it is deliberately not declared in the TCA select items for `colPos`.

`WriteTableTool` validates every field strictly against the TCA select items
before letting the DataHandler see it, so `-1` is refused before it ever
reaches Gridelements' own logic. The LLM / MCP client therefore cannot build
container layouts (columns, accordion, tabs, ...) from scratch or move records
into an existing container — a common authoring workflow.

A secondary issue: `tx_gridelements_container` and `tx_gridelements_columns`
are not listed in any type's `showitem`, so the availability check near the end
of `validateRecordData()` rejects them as "not available for this record type"
even though they are valid TCA columns.

## Fix

`validateRecordData()` now:

1. Detects whether the record is, or is becoming, a Gridelements container
   child — either because `tx_gridelements_container` is set to a non-zero
   value in the current payload, or because the existing record already has
   it set (update case). The check returns `false` and stays inert when
   Gridelements is not installed (column absent from TCA).
2. For container children, normalises `colPos` to `-1` up-front, so callers
   don't need to know the magic value: passing a container link is enough.
3. Skips the TCA select validation for `colPos = -1` in that case.
4. Whitelists `tx_gridelements_container` and `tx_gridelements_columns` in the
   per-type availability check.

The guardrail for "orphan" `colPos = -1` without a container link is
preserved: the bypass only activates when a container linkage is actually
present, so a bare `colPos = -1` still gets rejected by the standard
validator.

## Tests

`Tests/Functional/MCP/Tool/GridelementsContainerChildTest.php` covers:

- child created without `colPos` → MCP auto-fills `-1`
- child created with explicit `colPos = -1` + container link → accepted
- orphan `colPos = -1` without container link → still rejected
- update of an existing child without repeating the container link → keeps `-1`
- update that attaches a top-level record to a container → forces `colPos` to `-1`
- update that detaches a child from its container → allows a normal `colPos`

The tests use a minimal fixture extension at
`Tests/Functional/Fixtures/Extensions/gridelements_stub/` that registers the
two TCA columns the validator inspects, so the suite does not depend on the
real GridElementsTeam/gridelements extension. This mirrors the stub-extension
pattern used in the TYPO3 core test suite.

## Compatibility

- No breaking changes. Existing calls without `tx_gridelements_container`
  behave exactly as before.
- No new dependencies (runtime or dev).
- Inert on installs without Gridelements (detected via TCA column presence).
