### PR TITLE
Refactor record access control to event-driven architecture

### DIFF
--- a/Classes/Event/AfterRecordReadEvent.php
+++ b/Classes/Event/AfterRecordReadEvent.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Event;
+
+/**
+ * PSR-14 event dispatched after ReadTableTool has loaded a batch of records.
+ *
+ * Listeners can mutate the record array to enrich or redact fields — for
+ * example, attaching file metadata to sys_file_reference rows, resolving
+ * public URLs, or stripping sensitive columns before the result is handed
+ * to the LLM.
+ *
+ * Records are passed as a batch per table so that listeners can perform
+ * efficient single-query lookups (no N+1).
+ */
+final class AfterRecordReadEvent
+{
+    /**
+     * @param string $table The table the records come from
+     * @param array<int, array<string, mixed>> $records Mutable records array
+     * @param string $context 'top' for directly queried records, 'inline' for inline relation children
+     */
+    public function __construct(
+        private readonly string $table,
+        private array $records,
+        private readonly string $context,
+    ) {}
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getRecords(): array
+    {
+        return $this->records;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $records
+     */
+    public function setRecords(array $records): void
+    {
+        $this->records = $records;
+    }
+
+    public function getContext(): string
+    {
+        return $this->context;
+    }
+}

--- a/Classes/Event/AfterRecordWriteEvent.php
+++ b/Classes/Event/AfterRecordWriteEvent.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Event;
+
+/**
+ * PSR-14 event dispatched after WriteTableTool successfully creates or updates a record.
+ *
+ * This event is read-only — the operation has already completed. Use it for:
+ * - Audit logging of AI-initiated writes
+ * - Triggering side effects (cache clearing, webhook notifications)
+ * - Analytics and tracking of MCP operations
+ *
+ * Not dispatched on errors or vetoed operations.
+ */
+final class AfterRecordWriteEvent
+{
+    /**
+     * @param string $table The target table
+     * @param string $action The action that was performed: 'create', 'update', or 'delete'
+     * @param int $uid The record UID (live UID for workspace transparency)
+     * @param array $data The record data that was written (empty for delete)
+     * @param int|null $pid Page ID (only for create)
+     */
+    public function __construct(
+        private readonly string $table,
+        private readonly string $action,
+        private readonly int $uid,
+        private readonly array $data,
+        private readonly ?int $pid,
+    ) {}
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getAction(): string
+    {
+        return $this->action;
+    }
+
+    public function getUid(): int
+    {
+        return $this->uid;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function getPid(): ?int
+    {
+        return $this->pid;
+    }
+}

--- a/Classes/Event/BeforeRecordReadEvent.php
+++ b/Classes/Event/BeforeRecordReadEvent.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Event;
+
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+
+/**
+ * PSR-14 event dispatched before ReadTableTool executes a database query.
+ *
+ * Listeners receive a mutable QueryBuilder and can attach additional WHERE
+ * conditions to restrict what records the user is allowed to see. The event
+ * is dispatched for each top-level SELECT and for inline-relation child
+ * lookups — so any restriction applied here also filters embedded relations.
+ *
+ * Typical uses:
+ * - Filter sys_file rows to the user's file mounts
+ * - Filter a tenant-scoped table to the user's tenant id
+ * - Hide records based on workflow state
+ *
+ * Not dispatched on internal integrity queries from WriteTableTool (duplicate
+ * checks, child lookups during save), since those must see all rows to
+ * prevent corrupt writes.
+ */
+final class BeforeRecordReadEvent
+{
+    /**
+     * @param string $table The table being queried
+     * @param QueryBuilder $queryBuilder Mutable query builder — listeners may call andWhere()
+     * @param string $queryType 'select' for the result query, 'count' for the total-count query
+     */
+    public function __construct(
+        private readonly string $table,
+        private readonly QueryBuilder $queryBuilder,
+        private readonly string $queryType,
+    ) {}
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getQueryBuilder(): QueryBuilder
+    {
+        return $this->queryBuilder;
+    }
+
+    public function getQueryType(): string
+    {
+        return $this->queryType;
+    }
+}

--- a/Classes/Event/BeforeRecordWriteEvent.php
+++ b/Classes/Event/BeforeRecordWriteEvent.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Event;
+
+/**
+ * PSR-14 event dispatched before WriteTableTool processes a write or move operation.
+ *
+ * Dispatched after parameter validation and ISO code conversion, but before
+ * validateRecordData() and DataHandler execution. This allows listeners to:
+ * - Modify data before validation and storage (auto-populate fields, normalize values)
+ * - Veto the operation with a reason (custom access control, policy enforcement)
+ * - Distinguish AI-originated writes from human-originated writes
+ */
+final class BeforeRecordWriteEvent
+{
+    private bool $vetoed = false;
+    private ?string $vetoReason = null;
+
+    /**
+     * @param string $table The target table
+     * @param string $action The action: 'create', 'update', 'delete', 'translate', or 'move'
+     * @param array $data The record data (mutable)
+     * @param int|null $uid Record UID (null for create)
+     * @param int|null $pid Page ID (null for update/delete)
+     */
+    public function __construct(
+        private readonly string $table,
+        private readonly string $action,
+        private array $data,
+        private readonly ?int $uid,
+        private readonly ?int $pid,
+    ) {}
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getAction(): string
+    {
+        return $this->action;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function setData(array $data): void
+    {
+        $this->data = $data;
+    }
+
+    public function getUid(): ?int
+    {
+        return $this->uid;
+    }
+
+    public function getPid(): ?int
+    {
+        return $this->pid;
+    }
+
+    public function veto(string $reason): void
+    {
+        $this->vetoed = true;
+        $this->vetoReason = $reason;
+    }
+
+    public function isVetoed(): bool
+    {
+        return $this->vetoed;
+    }
+
+    public function getVetoReason(): ?string
+    {
+        return $this->vetoReason;
+    }
+}

--- a/Classes/Event/ModifyAvailableFieldsEvent.php
+++ b/Classes/Event/ModifyAvailableFieldsEvent.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Event;
+
+/**
+ * PSR-14 event dispatched after TableAccessService discovers available fields for a table.
+ *
+ * Listeners can add, remove, or modify fields to control what the MCP tools expose.
+ * This event propagates through all tools (ReadTable, WriteTable, GetTableSchema, SearchTool)
+ * since they all use TableAccessService::getAvailableFields() as single source of truth.
+ */
+final class ModifyAvailableFieldsEvent
+{
+    /**
+     * @param string $table The table name
+     * @param string $type The record type (e.g. CType value, empty for default)
+     * @param array<string, array> $fields Field name => TCA config array
+     */
+    public function __construct(
+        private readonly string $table,
+        private readonly string $type,
+        private array $fields,
+    ) {}
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return array<string, array>
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @param array<string, array> $fields
+     */
+    public function setFields(array $fields): void
+    {
+        $this->fields = $fields;
+    }
+
+    public function removeField(string $fieldName): void
+    {
+        unset($this->fields[$fieldName]);
+    }
+
+    public function addField(string $fieldName, array $configuration): void
+    {
+        $this->fields[$fieldName] = $configuration;
+    }
+
+    public function hasField(string $fieldName): bool
+    {
+        return isset($this->fields[$fieldName]);
+    }
+}

--- a/Classes/EventListener/SysFileMountRestrictionListener.php
+++ b/Classes/EventListener/SysFileMountRestrictionListener.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\EventListener;
+
+use Doctrine\DBAL\ParameterType;
+use Hn\McpServer\Event\BeforeRecordReadEvent;
+use Hn\McpServer\Service\TableAccessService;
+use TYPO3\CMS\Core\Database\Query\Expression\CompositeExpression;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Restricts sys_file reads to the file mounts the current backend user can
+ * actually access. Non-admin users with no file mounts see no files at all.
+ */
+final class SysFileMountRestrictionListener
+{
+    public function __invoke(BeforeRecordReadEvent $event): void
+    {
+        if ($event->getTable() !== 'sys_file') {
+            return;
+        }
+
+        $queryBuilder = $event->getQueryBuilder();
+        $restriction = $this->buildFileMountRestriction($queryBuilder);
+        if ($restriction !== null) {
+            $queryBuilder->andWhere($restriction);
+        }
+    }
+
+    /**
+     * Build a WHERE expression restricting a sys_file query to files within
+     * the current user's accessible file mounts. Returns null when no
+     * restriction applies (admin user). Returns an always-false expression
+     * when the user has no mounts at all.
+     */
+    private function buildFileMountRestriction(QueryBuilder $queryBuilder): ?CompositeExpression
+    {
+        $tableAccessService = GeneralUtility::makeInstance(TableAccessService::class);
+        $isAdmin = false;
+        $mounts = $tableAccessService->getAccessibleFileMounts($isAdmin);
+        if ($isAdmin) {
+            return null;
+        }
+        if (empty($mounts)) {
+            return $queryBuilder->expr()->and('1 = 0');
+        }
+
+        $perStorage = [];
+        foreach ($mounts as $mount) {
+            $perStorage[$mount['storage']][] = $mount['path'];
+        }
+
+        $storageExpressions = [];
+        foreach ($perStorage as $storageUid => $paths) {
+            $pathExpressions = [];
+            foreach ($paths as $path) {
+                $normalized = rtrim($path, '/') . '/';
+                $pathExpressions[] = $queryBuilder->expr()->like(
+                    'identifier',
+                    $queryBuilder->createNamedParameter(
+                        $queryBuilder->escapeLikeWildcards($normalized) . '%'
+                    )
+                );
+            }
+
+            $storageExpressions[] = $queryBuilder->expr()->and(
+                $queryBuilder->expr()->eq(
+                    'storage',
+                    $queryBuilder->createNamedParameter($storageUid, ParameterType::INTEGER)
+                ),
+                $queryBuilder->expr()->or(...$pathExpressions)
+            );
+        }
+
+        return $queryBuilder->expr()->or(...$storageExpressions);
+    }
+}

--- a/Classes/EventListener/SysFileReferenceEnrichmentListener.php
+++ b/Classes/EventListener/SysFileReferenceEnrichmentListener.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\EventListener;
+
+use Hn\McpServer\Event\AfterRecordReadEvent;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Enriches sys_file_reference rows with a minimal sys_file summary so the LLM
+ * knows which file each reference points at without having to do a follow-up
+ * read on sys_file.
+ */
+final class SysFileReferenceEnrichmentListener
+{
+    public function __invoke(AfterRecordReadEvent $event): void
+    {
+        if ($event->getTable() !== 'sys_file_reference') {
+            return;
+        }
+
+        $records = $event->getRecords();
+        if (empty($records)) {
+            return;
+        }
+
+        $fileUids = [];
+        foreach ($records as $record) {
+            $fileUid = (int)($record['uid_local'] ?? 0);
+            if ($fileUid > 0) {
+                $fileUids[$fileUid] = true;
+            }
+        }
+        if (empty($fileUids)) {
+            return;
+        }
+
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('sys_file');
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $fileRecords = $queryBuilder
+            ->select('uid', 'name', 'identifier', 'storage', 'type', 'mime_type', 'size')
+            ->from('sys_file')
+            ->where(
+                $queryBuilder->expr()->in(
+                    'uid',
+                    $queryBuilder->createNamedParameter(array_keys($fileUids), Connection::PARAM_INT_ARRAY)
+                )
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $fileMap = [];
+        foreach ($fileRecords as $fileRecord) {
+            $fileMap[(int)$fileRecord['uid']] = $fileRecord;
+        }
+
+        $resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
+
+        foreach ($records as &$record) {
+            $fileUid = (int)($record['uid_local'] ?? 0);
+            if ($fileUid > 0 && isset($fileMap[$fileUid])) {
+                $file = $fileMap[$fileUid];
+                $record['file_name'] = $file['name'];
+                $record['file_identifier'] = $file['identifier'];
+                $record['file_mime_type'] = $file['mime_type'];
+                $record['file_size'] = (int)$file['size'];
+
+                try {
+                    $record['public_url'] = $resourceFactory->getFileObject($fileUid)->getPublicUrl();
+                } catch (\Exception $e) {
+                    $record['public_url'] = null;
+                }
+            }
+        }
+        unset($record);
+
+        $event->setRecords($records);
+    }
+}

--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Hn\McpServer\MCP\Tool\Record;
 
 use Doctrine\DBAL\ParameterType;
+use Hn\McpServer\Event\AfterRecordReadEvent;
+use Hn\McpServer\Event\BeforeRecordReadEvent;
 use Hn\McpServer\Exception\DatabaseException;
 use Hn\McpServer\Exception\ValidationException;
 use Mcp\Types\CallToolResult;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -273,14 +276,6 @@ class ReadTableTool extends AbstractRecordTool
             $queryBuilder->andWhere($condition);
         }
 
-        // Apply file-mount restriction for non-admin users when reading sys_file
-        if ($table === 'sys_file') {
-            $mountRestriction = $this->tableAccessService->buildFileMountRestriction($queryBuilder);
-            if ($mountRestriction !== null) {
-                $queryBuilder->andWhere($mountRestriction);
-            }
-        }
-
         // Apply default sorting from TCA
         $this->applyDefaultSorting($queryBuilder, $table);
 
@@ -345,13 +340,10 @@ class ReadTableTool extends AbstractRecordTool
             $countQueryBuilder->andWhere($condition);
         }
 
-        // Apply file-mount restriction for non-admin users when counting sys_file
-        if ($table === 'sys_file') {
-            $countMountRestriction = $this->tableAccessService->buildFileMountRestriction($countQueryBuilder);
-            if ($countMountRestriction !== null) {
-                $countQueryBuilder->andWhere($countMountRestriction);
-            }
-        }
+        // Allow listeners to add restrictions (e.g. file mounts, tenant scopes)
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $eventDispatcher->dispatch(new BeforeRecordReadEvent($table, $countQueryBuilder, 'count'));
+        $eventDispatcher->dispatch(new BeforeRecordReadEvent($table, $queryBuilder, 'select'));
 
         try {
             $totalCount = $countQueryBuilder->executeQuery()->fetchOne();
@@ -365,6 +357,11 @@ class ReadTableTool extends AbstractRecordTool
         } catch (\Doctrine\DBAL\Exception $e) {
             throw new DatabaseException('select', $table, $e);
         }
+
+        // Allow listeners to enrich or redact rows before post-processing
+        $afterEvent = new AfterRecordReadEvent($table, $records, 'top');
+        $eventDispatcher->dispatch($afterEvent);
+        $records = $afterEvent->getRecords();
 
         // Process records to handle binary data, convert types, and filter default values
         $processedRecords = [];
@@ -833,9 +830,12 @@ class ReadTableTool extends AbstractRecordTool
         $foreignMatchFields = $fieldConfig['config']['foreign_match_fields'] ?? [];
         $relatedRecords = $this->getInlineRelatedRecords($foreignTable, $foreignField, $recordUids, $foreignSortBy, $foreignMatchFields);
 
-        // For sys_file_reference, enrich with file metadata so LLMs know what file is referenced
-        if ($foreignTable === 'sys_file_reference' && !empty($relatedRecords)) {
-            $relatedRecords = $this->enrichFileReferences($relatedRecords);
+        // Allow listeners to enrich or redact inline children (e.g. attach file metadata)
+        if (!empty($relatedRecords)) {
+            $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+            $afterEvent = new AfterRecordReadEvent($foreignTable, $relatedRecords, 'inline');
+            $eventDispatcher->dispatch($afterEvent);
+            $relatedRecords = $afterEvent->getRecords();
         }
 
         // Group related records by parent record
@@ -870,75 +870,6 @@ class ReadTableTool extends AbstractRecordTool
                 }
             }
         }
-    }
-
-    /**
-     * Enrich sys_file_reference records with file metadata from sys_file.
-     * Adds file_name, file_identifier, and public_url so LLMs know what file is referenced.
-     */
-    protected function enrichFileReferences(array $records): array
-    {
-        // Collect unique sys_file UIDs from uid_local
-        $fileUids = [];
-        foreach ($records as $record) {
-            $fileUid = (int)($record['uid_local'] ?? 0);
-            if ($fileUid > 0) {
-                $fileUids[$fileUid] = true;
-            }
-        }
-
-        if (empty($fileUids)) {
-            return $records;
-        }
-
-        // Fetch file metadata in a single query
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('sys_file');
-        $queryBuilder->getRestrictions()->removeAll();
-
-        $fileRecords = $queryBuilder
-            ->select('uid', 'name', 'identifier', 'storage', 'type', 'mime_type', 'size')
-            ->from('sys_file')
-            ->where(
-                $queryBuilder->expr()->in(
-                    'uid',
-                    $queryBuilder->createNamedParameter(array_keys($fileUids), Connection::PARAM_INT_ARRAY)
-                )
-            )
-            ->executeQuery()
-            ->fetchAllAssociative();
-
-        // Index by uid
-        $fileMap = [];
-        foreach ($fileRecords as $fileRecord) {
-            $fileMap[(int)$fileRecord['uid']] = $fileRecord;
-        }
-
-        // Resolve public URLs via ResourceFactory
-        $resourceFactory = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\ResourceFactory::class);
-
-        // Enrich each file reference record
-        foreach ($records as &$record) {
-            $fileUid = (int)($record['uid_local'] ?? 0);
-            if ($fileUid > 0 && isset($fileMap[$fileUid])) {
-                $file = $fileMap[$fileUid];
-                $record['file_name'] = $file['name'];
-                $record['file_identifier'] = $file['identifier'];
-                $record['file_mime_type'] = $file['mime_type'];
-                $record['file_size'] = (int)$file['size'];
-
-                // Try to resolve public URL
-                try {
-                    $fileObject = $resourceFactory->getFileObject($fileUid);
-                    $record['public_url'] = $fileObject->getPublicUrl();
-                } catch (\Exception $e) {
-                    // File might not be accessible
-                    $record['public_url'] = null;
-                }
-            }
-        }
-
-        return $records;
     }
 
     /**
@@ -988,9 +919,11 @@ class ReadTableTool extends AbstractRecordTool
             );
         }
 
+        // Allow listeners to add restrictions to inline-child lookups too
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $eventDispatcher->dispatch(new BeforeRecordReadEvent($table, $queryBuilder, 'select'));
+
         $records = $queryBuilder->executeQuery()->fetchAllAssociative();
-
-
 
         // Process records for workspace transparency
         $processedRecords = [];

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Hn\McpServer\MCP\Tool\Record;
 
 use Doctrine\DBAL\ParameterType;
+use Hn\McpServer\Event\AfterRecordWriteEvent;
+use Hn\McpServer\Event\BeforeRecordWriteEvent;
 use Hn\McpServer\Exception\DatabaseException;
 use Hn\McpServer\Exception\ValidationException;
 use Hn\McpServer\Service\LanguageService;
 use Mcp\Types\CallToolResult;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -229,7 +232,16 @@ class WriteTableTool extends AbstractRecordTool
             default:
                 throw new ValidationException(['Invalid action: ' . $action . '. Valid actions are: create, update, translate, delete']);
         }
-        
+
+        // Allow listeners to modify data or veto the operation
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $beforeEvent = new BeforeRecordWriteEvent($table, $action, $data, $uid, $pid);
+        $eventDispatcher->dispatch($beforeEvent);
+        if ($beforeEvent->isVetoed()) {
+            return $this->createErrorResult('Operation vetoed: ' . ($beforeEvent->getVetoReason() ?? 'No reason given'));
+        }
+        $data = $beforeEvent->getData();
+
         // Execute the action
         switch ($action) {
             case 'create':
@@ -491,7 +503,10 @@ class WriteTableTool extends AbstractRecordTool
 
         // Get the live UID for workspace transparency
         $liveUid = $this->getLiveUid($table, $parentUid);
-        
+
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $eventDispatcher->dispatch(new AfterRecordWriteEvent($table, 'create', $liveUid, $data, $pid));
+
         // Return the result with live UID
         return $this->createJsonResult([
             'action' => 'create',
@@ -610,6 +625,9 @@ class WriteTableTool extends AbstractRecordTool
             }
         }
 
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $eventDispatcher->dispatch(new AfterRecordWriteEvent($table, 'update', $uid, $data, null));
+
         // Return the result with the original live UID
         return $this->createJsonResult([
             'action' => 'update',
@@ -637,6 +655,9 @@ class WriteTableTool extends AbstractRecordTool
             return $this->createErrorResult('Error deleting record: ' . implode(', ', $dataHandler->errorLog));
         }
         
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $eventDispatcher->dispatch(new AfterRecordWriteEvent($table, 'delete', $uid, [], null));
+
         return $this->createJsonResult([
             'action' => 'delete',
             'table' => $table,
@@ -874,6 +895,11 @@ class WriteTableTool extends AbstractRecordTool
         }
 
         $targetIsoCode = $this->languageService->getIsoCodeFromUid($targetLanguageUid) ?? $targetLanguageUid;
+
+        if ($newTranslationUid) {
+            $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+            $eventDispatcher->dispatch(new AfterRecordWriteEvent($table, 'translate', (int)$newTranslationUid, [], null));
+        }
 
         return $this->createJsonResult([
             'action' => 'translate',

--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Hn\McpServer\Service;
 
 use Doctrine\DBAL\ArrayParameterType;
+use Hn\McpServer\Event\ModifyAvailableFieldsEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Core\Database\Query\Expression\CompositeExpression;
-use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -298,8 +298,11 @@ class TableAccessService implements SingletonInterface
                 unset($fields[$fieldName]);
             }
         }
-        
-        return $fields;
+
+        // Allow extensions to add, remove, or reconfigure fields
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $event = $eventDispatcher->dispatch(new ModifyAvailableFieldsEvent($table, $type, $fields));
+        return $event->getFields();
     }
     
     /**
@@ -433,55 +436,6 @@ class TableAccessService implements SingletonInterface
             $mounts[] = ['storage' => $storageUid, 'path' => $path];
         }
         return $mounts;
-    }
-
-    /**
-     * Build a WHERE expression to restrict a sys_file query to files within the current user's
-     * accessible file mounts. Returns null when no restriction applies (admin user).
-     * Returns an always-false expression when user has no mounts at all.
-     */
-    public function buildFileMountRestriction(QueryBuilder $queryBuilder): ?CompositeExpression
-    {
-        $isAdmin = false;
-        $mounts = $this->getAccessibleFileMounts($isAdmin);
-        if ($isAdmin) {
-            return null;
-        }
-        if (empty($mounts)) {
-            // No mounts → user cannot see any files
-            return $queryBuilder->expr()->and('1 = 0');
-        }
-
-        // Group mount paths by storage for a cleaner query structure
-        $perStorage = [];
-        foreach ($mounts as $mount) {
-            $perStorage[$mount['storage']][] = $mount['path'];
-        }
-
-        $storageExpressions = [];
-        foreach ($perStorage as $storageUid => $paths) {
-            $pathExpressions = [];
-            foreach ($paths as $path) {
-                $normalized = rtrim($path, '/') . '/';
-                // Match files whose identifier begins with this mount path (including subfolders)
-                $pathExpressions[] = $queryBuilder->expr()->like(
-                    'identifier',
-                    $queryBuilder->createNamedParameter(
-                        $queryBuilder->escapeLikeWildcards($normalized) . '%'
-                    )
-                );
-            }
-
-            $storageExpressions[] = $queryBuilder->expr()->and(
-                $queryBuilder->expr()->eq(
-                    'storage',
-                    $queryBuilder->createNamedParameter($storageUid, \Doctrine\DBAL\ParameterType::INTEGER)
-                ),
-                $queryBuilder->expr()->or(...$pathExpressions)
-            );
-        }
-
-        return $queryBuilder->expr()->or(...$storageExpressions);
     }
 
     /**

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -51,6 +51,19 @@ services:
   Hn\McpServer\Server\SiteInstructionsService:
     public: true
     
+  # Event listeners
+  Hn\McpServer\EventListener\SysFileReferenceEnrichmentListener:
+    tags:
+      - name: event.listener
+        event: Hn\McpServer\Event\AfterRecordReadEvent
+        identifier: 'mcp-server/sys-file-reference-enrichment'
+
+  Hn\McpServer\EventListener\SysFileMountRestrictionListener:
+    tags:
+      - name: event.listener
+        event: Hn\McpServer\Event\BeforeRecordReadEvent
+        identifier: 'mcp-server/sys-file-mount-restriction'
+
   # Explicitly configure the module controller
   Hn\McpServer\Controller\McpServerModuleController:
     public: true


### PR DESCRIPTION
## Summary

This PR refactors the MCP server's record access control and enrichment logic from hard-coded implementations to a flexible, event-driven PSR-14 architecture. This enables extensions to hook into read/write operations without modifying core code.

## Key Changes

- **New PSR-14 Events**: Introduced four new event classes for extensibility:
  - `BeforeRecordReadEvent`: Fired before SELECT queries, allows listeners to add WHERE restrictions (e.g., file mounts, tenant scoping)
  - `AfterRecordReadEvent`: Fired after records are loaded, allows enrichment or redaction of fields
  - `BeforeRecordWriteEvent`: Fired before write operations, allows data modification or veto with reason
  - `AfterRecordWriteEvent`: Fired after successful writes, for audit logging and side effects
  - `ModifyAvailableFieldsEvent`: Fired when discovering available fields, allows add/remove/reconfigure

- **Event Listeners**: Extracted hard-coded logic into dedicated listeners:
  - `SysFileMountRestrictionListener`: Restricts sys_file reads to user's accessible file mounts (moved from `TableAccessService.buildFileMountRestriction()`)
  - `SysFileReferenceEnrichmentListener`: Enriches sys_file_reference rows with file metadata (moved from `ReadTableTool.enrichFileReferences()`)

- **ReadTableTool Refactoring**:
  - Removed hard-coded sys_file mount restriction logic
  - Removed `enrichFileReferences()` method
  - Added `BeforeRecordReadEvent` dispatch before SELECT and COUNT queries
  - Added `AfterRecordReadEvent` dispatch after loading top-level records and inline children
  - Inline relation enrichment now uses event system instead of table-specific logic

- **WriteTableTool Refactoring**:
  - Added `BeforeRecordWriteEvent` dispatch before validation/execution, allowing data modification and operation veto
  - Added `AfterRecordWriteEvent` dispatch after successful create/update operations

- **TableAccessService Refactoring**:
  - Removed `buildFileMountRestriction()` method (moved to listener)
  - Added `ModifyAvailableFieldsEvent` dispatch in `getAvailableFields()` to allow field customization

- **Service Configuration**: Registered new event listeners in `Services.yaml` with appropriate event tags

## Implementation Details

- Events are dispatched at strategic points: before queries (for restrictions), after data loads (for enrichment), and around write operations (for validation/audit)
- The `BeforeRecordReadEvent` is dispatched for both top-level SELECT queries and inline-relation child lookups, ensuring restrictions apply consistently
- `AfterRecordReadEvent` includes a `context` parameter ('top' or 'inline') to distinguish between directly queried records and embedded relations
- `BeforeRecordWriteEvent` allows listeners to veto operations with a reason, which is returned to the user
- All hard-coded table-specific logic (sys_file mounts, sys_file_reference enrichment) is now in listeners, making the core tools table-agnostic

https://claude.ai/code/session_01GtPiYwRM1VkqdfjLkdfT7Q