### PR TITLE
fix(WriteTable): patch existing embedded inline relation by uid

### DIFF
--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -81,6 +81,10 @@ class WriteTableTool extends AbstractRecordTool
                             'Uses the same field syntax as ReadTable output.' .
                             ($hasMultipleLanguages ? ' Language fields (sys_language_uid) accept ISO codes like "de", "fr" instead of numeric IDs.' : '') . ' ' .
                             'Inline relations can be specified as arrays - UIDs for independent tables, record data for embedded tables. ' .
+                            'For embedded tables (e.g. file references), the array fully replaces the existing list: ' .
+                            'children present in the previous record but missing from the new array are deleted. ' .
+                            'To keep an existing child include it as {"uid": <existing>, ...}; only the fields you set are patched. ' .
+                            'Array order drives display order. ' .
                             'For text fields in update actions, instead of providing the full text, you can provide an array of search-and-replace operations: ' .
                             '[{"search": "old text", "replace": "new text"}]. Each operation can optionally include "replaceAll": true. ' .
                             'Operations are applied sequentially. Each search string must match exactly once unless replaceAll is true.',
@@ -1188,21 +1192,24 @@ class WriteTableTool extends AbstractRecordTool
                     }
                 }
 
-                // If we have a sorting field, set it
-                if (isset($config['foreign_sortby'])) {
-                    $recordData[$config['foreign_sortby']] = ($index + 1) * 256;
-                }
-
                 $key = 'NEW' . uniqid() . '_' . $index;
             } else {
                 // Update path: target the workspace version so DataHandler patches the existing
                 // reference instead of touching the live record outside the workspace overlay.
                 $key = $this->resolveToWorkspaceUid($foreignTable, $existingUid);
+            }
 
-                if (empty($recordData)) {
-                    // Caller only sent a uid with no field changes — nothing to patch.
-                    continue;
-                }
+            // Drive sort order from array position for both new and existing records.
+            // foreign_sortby is hidden from the schema (auto-managed), so reordering is
+            // only possible via the order in which the caller lists the children here.
+            if (isset($config['foreign_sortby'])) {
+                $recordData[$config['foreign_sortby']] = ($index + 1) * 256;
+            }
+
+            if ($existingUid !== null && empty($recordData)) {
+                // Caller only sent a uid with no field changes and the table has no
+                // foreign_sortby — nothing to patch.
+                continue;
             }
 
             // Add to data map

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -1124,12 +1124,42 @@ class WriteTableTool extends AbstractRecordTool
         array $config,
         ?int $liveUid = null
     ): void {
-        // If we're updating, handle existing relations
         $foreignMatchFields = $config['foreign_match_fields'] ?? [];
-        if ($liveUid !== null) {
-            $this->handleExistingEmbeddedRelations($foreignTable, $foreignField, $liveUid, $records, $foreignMatchFields);
+
+        // Existing children of this parent (live uids). Empty for the create path.
+        $existingChildUids = $liveUid !== null
+            ? $this->fetchEmbeddedRelationChildUids($foreignTable, $foreignField, $liveUid, $foreignMatchFields)
+            : [];
+
+        // Reject any uid that does not currently belong to this parent. Otherwise a caller
+        // could "steal" a child by sending another parent's child uid — combined with the
+        // orphan-deletion below this would silently delete this parent's real children and
+        // mutate an unrelated record.
+        foreach ($records as $index => $recordData) {
+            if (!is_array($recordData) || !isset($recordData['uid'])) {
+                continue;
+            }
+            if (!is_numeric($recordData['uid']) || (int)$recordData['uid'] <= 0) {
+                continue;
+            }
+            $childUid = (int)$recordData['uid'];
+            if (!in_array($childUid, $existingChildUids, true)) {
+                throw new ValidationException([
+                    sprintf(
+                        'Inline relation %s.%s at index %d references uid %d which does not belong to the current parent record. Embedded relations cannot be moved between parents.',
+                        $foreignTable,
+                        $foreignField,
+                        $index,
+                        $childUid
+                    )
+                ]);
+            }
         }
-        
+
+        if ($liveUid !== null) {
+            $this->deleteOrphanedEmbeddedRelations($foreignTable, $existingChildUids, $records);
+        }
+
         foreach ($records as $index => $recordData) {
             if (!is_array($recordData)) {
                 continue;
@@ -1263,16 +1293,19 @@ class WriteTableTool extends AbstractRecordTool
     }
     
     /**
-     * Handle existing embedded relations during updates
+     * Fetch the live uids of embedded children currently attached to a parent.
+     *
+     * Workspace overlays are folded onto their live uid (t3ver_oid) so the result
+     * matches the uids visible to the MCP client.
+     *
+     * @return int[]
      */
-    protected function handleExistingEmbeddedRelations(
+    protected function fetchEmbeddedRelationChildUids(
         string $foreignTable,
         string $foreignField,
         int $parentUid,
-        array $newRecords,
         array $foreignMatchFields = []
-    ): void {
-        // Get all existing child records for this parent
+    ): array {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable($foreignTable);
 
@@ -1282,7 +1315,7 @@ class WriteTableTool extends AbstractRecordTool
             ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, $GLOBALS['BE_USER']->workspace ?? 0));
 
         $queryBuilder
-            ->select('uid')
+            ->select('uid', 't3ver_oid')
             ->from($foreignTable)
             ->where(
                 $queryBuilder->expr()->eq($foreignField, $queryBuilder->createNamedParameter($parentUid, ParameterType::INTEGER))
@@ -1295,39 +1328,52 @@ class WriteTableTool extends AbstractRecordTool
             );
         }
 
-        $existingRecords = $queryBuilder->executeQuery()->fetchAllAssociative();
-        
-        if (!empty($existingRecords)) {
-            // Extract UIDs of new records that have UIDs (updates)
-            $keepUids = [];
-            foreach ($newRecords as $record) {
-                if (is_array($record) && isset($record['uid']) && is_numeric($record['uid'])) {
-                    $keepUids[] = (int)$record['uid'];
-                }
-            }
-            
-            // Delete records that are not in the new set
-            $deleteUids = [];
-            foreach ($existingRecords as $existingRecord) {
-                if (!in_array((int)$existingRecord['uid'], $keepUids, true)) {
-                    $deleteUids[] = (int)$existingRecord['uid'];
-                }
-            }
-            
-            if (!empty($deleteUids)) {
-                // Use DataHandler to delete records (respects workspaces)
-                $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
-                $dataHandler->BE_USER = $GLOBALS['BE_USER'];
-                
-                $cmdMap = [];
-                foreach ($deleteUids as $deleteUid) {
-                    $cmdMap[$foreignTable][$deleteUid]['delete'] = 1;
-                }
-                
-                $dataHandler->start([], $cmdMap);
-                $dataHandler->process_cmdmap();
+        $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+
+        $liveUids = [];
+        foreach ($rows as $row) {
+            $liveUids[] = (int)($row['t3ver_oid'] ?: $row['uid']);
+        }
+        return array_values(array_unique($liveUids));
+    }
+
+    /**
+     * Delete embedded children that the caller dropped from the new record list.
+     *
+     * @param int[] $existingChildUids live uids previously attached to the parent
+     * @param array $newRecords records as supplied by the caller
+     */
+    protected function deleteOrphanedEmbeddedRelations(
+        string $foreignTable,
+        array $existingChildUids,
+        array $newRecords
+    ): void {
+        if (empty($existingChildUids)) {
+            return;
+        }
+
+        $keepUids = [];
+        foreach ($newRecords as $record) {
+            if (is_array($record) && isset($record['uid']) && is_numeric($record['uid'])) {
+                $keepUids[] = (int)$record['uid'];
             }
         }
+
+        $deleteUids = array_values(array_diff($existingChildUids, $keepUids));
+        if (empty($deleteUids)) {
+            return;
+        }
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+
+        $cmdMap = [];
+        foreach ($deleteUids as $deleteUid) {
+            $cmdMap[$foreignTable][$deleteUid]['delete'] = 1;
+        }
+
+        $dataHandler->start([], $cmdMap);
+        $dataHandler->process_cmdmap();
     }
     
     /**

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -1108,32 +1108,52 @@ class WriteTableTool extends AbstractRecordTool
             if (!is_array($recordData)) {
                 continue;
             }
-            
-            // Create new ID for the inline record
-            $newId = 'NEW' . uniqid() . '_' . $index;
-            
+
+            // Existing record carries a numeric uid → update in place instead of inserting a new row.
+            // Without this, payloads like image: [{uid: 42, alternative: "..."}] silently created a
+            // broken sys_file_reference with uid_local=0 instead of patching the existing one.
+            $existingUid = (isset($recordData['uid']) && is_numeric($recordData['uid']) && (int)$recordData['uid'] > 0)
+                ? (int)$recordData['uid']
+                : null;
+            unset($recordData['uid']);
+
             // Don't set the foreign field here - it will be handled by RelationHandler
             // Remove it if it was accidentally included
             unset($recordData[$foreignField]);
-            $recordData['pid'] = $pid;
 
-            // Set foreign_match_fields (e.g., tablenames/fieldname for sys_file_reference)
-            if (!empty($config['foreign_match_fields'])) {
-                foreach ($config['foreign_match_fields'] as $matchField => $matchValue) {
-                    $recordData[$matchField] = $matchValue;
+            if ($existingUid === null) {
+                // New record: pid + foreign_match_fields are required for proper insertion
+                $recordData['pid'] = $pid;
+
+                // Set foreign_match_fields (e.g., tablenames/fieldname for sys_file_reference)
+                if (!empty($config['foreign_match_fields'])) {
+                    foreach ($config['foreign_match_fields'] as $matchField => $matchValue) {
+                        $recordData[$matchField] = $matchValue;
+                    }
                 }
-            }
 
-            // If we have a sorting field, set it
-            if (isset($config['foreign_sortby'])) {
-                $recordData[$config['foreign_sortby']] = ($index + 1) * 256;
+                // If we have a sorting field, set it
+                if (isset($config['foreign_sortby'])) {
+                    $recordData[$config['foreign_sortby']] = ($index + 1) * 256;
+                }
+
+                $key = 'NEW' . uniqid() . '_' . $index;
+            } else {
+                // Update path: target the workspace version so DataHandler patches the existing
+                // reference instead of touching the live record outside the workspace overlay.
+                $key = $this->resolveToWorkspaceUid($foreignTable, $existingUid);
+
+                if (empty($recordData)) {
+                    // Caller only sent a uid with no field changes — nothing to patch.
+                    continue;
+                }
             }
 
             // Add to data map
             if (!isset($dataMap[$foreignTable])) {
                 $dataMap[$foreignTable] = [];
             }
-            $dataMap[$foreignTable][$newId] = $recordData;
+            $dataMap[$foreignTable][$key] = $recordData;
         }
     }
     

--- a/Tests/Functional/MCP/Tool/InlineRelationWriteTest.php
+++ b/Tests/Functional/MCP/Tool/InlineRelationWriteTest.php
@@ -659,4 +659,151 @@ class InlineRelationWriteTest extends FunctionalTestCase
         $this->assertSame('patched', $record['assets'][0]['title']);
         $this->assertSame(1, (int)$record['assets'][0]['uid_local'], 'uid_local must not be wiped to 0');
     }
+
+    /**
+     * Embedded inline relations must not be stealable from another parent by uid.
+     *
+     * The update path that patches existing children by uid (testUpdateExistingEmbeddedRelationByUid)
+     * could otherwise be abused: passing parent B's child uid into parent A's update would mutate
+     * B's row and — through the orphan-deletion of children not in the new list — silently wipe
+     * parent A's real children too.
+     */
+    public function testCannotStealEmbeddedRelationFromAnotherParent(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+
+        $result = $writeTool->execute([
+            'table' => 'pages',
+            'action' => 'create',
+            'pid' => 0,
+            'data' => ['title' => 'Page for steal-test', 'doktype' => 1],
+        ]);
+        $pageUid = json_decode($result->content[0]->text, true)['uid'];
+
+        // Parent A with its own asset
+        $result = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => $pageUid,
+            'data' => [
+                'header' => 'Parent A',
+                'CType' => 'textmedia',
+                'assets' => [['uid_local' => 1, 'title' => 'A-original']],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $parentAUid = json_decode($result->content[0]->text, true)['uid'];
+
+        // Parent B with its own asset
+        $result = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => $pageUid,
+            'data' => [
+                'header' => 'Parent B',
+                'CType' => 'textmedia',
+                'assets' => [['uid_local' => 1, 'title' => 'B-original']],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $parentBUid = json_decode($result->content[0]->text, true)['uid'];
+
+        $aRef = (int)json_decode(
+            $readTool->execute(['table' => 'tt_content', 'uid' => $parentAUid])->content[0]->text,
+            true
+        )['records'][0]['assets'][0]['uid'];
+        $bRef = (int)json_decode(
+            $readTool->execute(['table' => 'tt_content', 'uid' => $parentBUid])->content[0]->text,
+            true
+        )['records'][0]['assets'][0]['uid'];
+        $this->assertNotSame($aRef, $bRef);
+
+        // Attempt to "steal" parent B's reference by patching it under parent A
+        $result = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'update',
+            'uid' => $parentAUid,
+            'data' => [
+                'assets' => [['uid' => $bRef, 'title' => 'stolen']],
+            ],
+        ]);
+        $this->assertTrue($result->isError, 'Stealing a child uid from another parent must be rejected');
+        $this->assertStringContainsString('does not belong to the current parent', $result->jsonSerialize()['content'][0]->text);
+
+        // Parent A keeps its original reference unchanged
+        $aAfter = json_decode(
+            $readTool->execute(['table' => 'tt_content', 'uid' => $parentAUid])->content[0]->text,
+            true
+        )['records'][0]['assets'];
+        $this->assertCount(1, $aAfter, 'Parent A must keep its original reference');
+        $this->assertSame($aRef, (int)$aAfter[0]['uid']);
+        $this->assertSame('A-original', $aAfter[0]['title']);
+
+        // Parent B is untouched as well
+        $bAfter = json_decode(
+            $readTool->execute(['table' => 'tt_content', 'uid' => $parentBUid])->content[0]->text,
+            true
+        )['records'][0]['assets'];
+        $this->assertCount(1, $bAfter, 'Parent B must keep its reference');
+        $this->assertSame($bRef, (int)$bAfter[0]['uid']);
+        $this->assertSame('B-original', $bAfter[0]['title']);
+    }
+
+    /**
+     * The create path must not silently update an existing child by uid either.
+     */
+    public function testCreateRejectsExistingChildUid(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+
+        $result = $writeTool->execute([
+            'table' => 'pages',
+            'action' => 'create',
+            'pid' => 0,
+            'data' => ['title' => 'Page for create-steal-test', 'doktype' => 1],
+        ]);
+        $pageUid = json_decode($result->content[0]->text, true)['uid'];
+
+        $result = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => $pageUid,
+            'data' => [
+                'header' => 'Existing parent',
+                'CType' => 'textmedia',
+                'assets' => [['uid_local' => 1, 'title' => 'existing']],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $existingParentUid = json_decode($result->content[0]->text, true)['uid'];
+        $existingRef = (int)json_decode(
+            $readTool->execute(['table' => 'tt_content', 'uid' => $existingParentUid])->content[0]->text,
+            true
+        )['records'][0]['assets'][0]['uid'];
+
+        // Create a new parent that tries to claim an existing child by uid
+        $result = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => $pageUid,
+            'data' => [
+                'header' => 'Hijacker',
+                'CType' => 'textmedia',
+                'assets' => [['uid' => $existingRef, 'title' => 'hijacked']],
+            ],
+        ]);
+        $this->assertTrue($result->isError, 'Create must reject embedded children that reference an existing uid');
+        $this->assertStringContainsString('does not belong to the current parent', $result->jsonSerialize()['content'][0]->text);
+
+        // Original parent is untouched
+        $assets = json_decode(
+            $readTool->execute(['table' => 'tt_content', 'uid' => $existingParentUid])->content[0]->text,
+            true
+        )['records'][0]['assets'];
+        $this->assertCount(1, $assets);
+        $this->assertSame($existingRef, (int)$assets[0]['uid']);
+        $this->assertSame('existing', $assets[0]['title']);
+    }
 }

--- a/Tests/Functional/MCP/Tool/InlineRelationWriteTest.php
+++ b/Tests/Functional/MCP/Tool/InlineRelationWriteTest.php
@@ -593,4 +593,70 @@ class InlineRelationWriteTest extends FunctionalTestCase
         $this->assertTrue($result->isError);
         $this->assertStringContainsString('must contain only positive integer UIDs', $result->jsonSerialize()['content'][0]->text);
     }
+
+    /**
+     * Test patching an existing embedded inline relation by uid.
+     *
+     * Regression: payloads like `assets: [{uid: <existing>, title: "patched"}]` previously
+     * ignored the uid and inserted a fresh sys_file_reference with uid_local=0 (broken),
+     * leaving the original reference orphaned in the workspace.
+     */
+    public function testUpdateExistingEmbeddedRelationByUid(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+
+        // Page + content element with one file reference (sys_file uid=1 from fixture)
+        $result = $writeTool->execute([
+            'table' => 'pages',
+            'action' => 'create',
+            'pid' => 0,
+            'data' => ['title' => 'Page for ref-update', 'doktype' => 1],
+        ]);
+        $pageUid = json_decode($result->content[0]->text, true)['uid'];
+
+        $result = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => $pageUid,
+            'data' => [
+                'header' => 'Content with file reference',
+                'CType' => 'textmedia',
+                'assets' => [
+                    ['uid_local' => 1, 'title' => 'original'],
+                ],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $contentUid = json_decode($result->content[0]->text, true)['uid'];
+
+        // Read back to capture the sys_file_reference uid
+        $result = $readTool->execute(['table' => 'tt_content', 'uid' => $contentUid]);
+        $record = json_decode($result->content[0]->text, true)['records'][0];
+        $this->assertCount(1, $record['assets']);
+        $originalRefUid = (int)$record['assets'][0]['uid'];
+        $this->assertSame(1, (int)$record['assets'][0]['uid_local']);
+        $this->assertSame('original', $record['assets'][0]['title']);
+
+        // Patch the existing reference by passing uid + new field value
+        $result = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'update',
+            'uid' => $contentUid,
+            'data' => [
+                'assets' => [
+                    ['uid' => $originalRefUid, 'title' => 'patched'],
+                ],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        // Verify: same reference uid, title patched, uid_local preserved (not reset to 0)
+        $result = $readTool->execute(['table' => 'tt_content', 'uid' => $contentUid]);
+        $record = json_decode($result->content[0]->text, true)['records'][0];
+        $this->assertCount(1, $record['assets'], 'No duplicate reference should be created');
+        $this->assertSame($originalRefUid, (int)$record['assets'][0]['uid'], 'Same sys_file_reference uid expected');
+        $this->assertSame('patched', $record['assets'][0]['title']);
+        $this->assertSame(1, (int)$record['assets'][0]['uid_local'], 'uid_local must not be wiped to 0');
+    }
 }

--- a/Tests/Functional/MCP/Tool/InlineRelationWriteTest.php
+++ b/Tests/Functional/MCP/Tool/InlineRelationWriteTest.php
@@ -806,4 +806,75 @@ class InlineRelationWriteTest extends FunctionalTestCase
         $this->assertSame($existingRef, (int)$assets[0]['uid']);
         $this->assertSame('existing', $assets[0]['title']);
     }
+
+    /**
+     * Reordering embedded children must follow array order.
+     *
+     * sorting_foreign is hidden from the write schema (auto-managed), so the only way
+     * a caller can reorder embedded relations is by passing them in the desired order.
+     */
+    public function testReorderEmbeddedRelationsByArrayOrder(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+
+        $result = $writeTool->execute([
+            'table' => 'pages',
+            'action' => 'create',
+            'pid' => 0,
+            'data' => ['title' => 'Page for reorder', 'doktype' => 1],
+        ]);
+        $pageUid = json_decode($result->content[0]->text, true)['uid'];
+
+        // Three references in order A, B, C
+        $result = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => $pageUid,
+            'data' => [
+                'header' => 'Reorder me',
+                'CType' => 'textmedia',
+                'assets' => [
+                    ['uid_local' => 1, 'title' => 'A'],
+                    ['uid_local' => 1, 'title' => 'B'],
+                    ['uid_local' => 1, 'title' => 'C'],
+                ],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $contentUid = json_decode($result->content[0]->text, true)['uid'];
+
+        $assets = json_decode(
+            $readTool->execute(['table' => 'tt_content', 'uid' => $contentUid])->content[0]->text,
+            true
+        )['records'][0]['assets'];
+        $this->assertSame(['A', 'B', 'C'], array_column($assets, 'title'));
+        $byTitle = [];
+        foreach ($assets as $asset) {
+            $byTitle[$asset['title']] = (int)$asset['uid'];
+        }
+
+        // Reorder to C, A, B by passing only the uids in the new desired order.
+        $result = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'update',
+            'uid' => $contentUid,
+            'data' => [
+                'assets' => [
+                    ['uid' => $byTitle['C']],
+                    ['uid' => $byTitle['A']],
+                    ['uid' => $byTitle['B']],
+                ],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $assets = json_decode(
+            $readTool->execute(['table' => 'tt_content', 'uid' => $contentUid])->content[0]->text,
+            true
+        )['records'][0]['assets'];
+        $this->assertCount(3, $assets, 'No references should be lost during reorder');
+        $this->assertSame(['C', 'A', 'B'], array_column($assets, 'title'),
+            'Embedded references must follow the order supplied in the update payload');
+    }
 }

--- a/Tests/Llm/EmbeddedRelationTest.php
+++ b/Tests/Llm/EmbeddedRelationTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Llm;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Test the LLM's ability to manipulate existing embedded inline relations on a content
+ * element: patching a single reference's metadata in place and reordering references
+ * by passing them in the desired order. Both rely on the WriteTable patch-by-uid path
+ * and on array-position driving sorting_foreign (which is hidden from the schema).
+ *
+ * @group llm
+ */
+class EmbeddedRelationTest extends LlmTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/tt_content.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/sys_file.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/sys_file_reference.csv');
+    }
+
+    #[DataProvider('modelProvider')]
+    #[TestDox('[$modelKey] Patch single image alternative on tt_content uid=100 → reuses existing sys_file_reference uid, no duplicate row')]
+    public function testLlmPatchesExistingFileReferenceMetadata(string $modelKey): void
+    {
+        $this->setModel($modelKey);
+
+        // tt_content uid=100 has two assets: ref uid=1 (Hero Image) and ref uid=2 (Second Image),
+        // both pointing to sys_file uid=1 (test.jpg).
+        $prompt = 'Content element uid=100 in tt_content has an image titled "Hero Image". ' .
+            'Update the alternative text of that image to "Updated alt text" without touching the other image.';
+
+        $response = $this->executeUntilToolFound(
+            $this->callLlm($prompt),
+            'WriteTable',
+            10
+        );
+
+        $writeCalls = $response->getToolCallsByName('WriteTable');
+        $this->assertNotEmpty($writeCalls,
+            'Expected WriteTable call. ' . $this->getFailureContext($response));
+
+        $currentResponse = $response;
+        for ($attempt = 0; $attempt < 6 && $currentResponse->hasToolCalls(); $attempt++) {
+            $currentResponse = $this->executeAndContinue($currentResponse);
+        }
+
+        $refs = $this->queryAssetReferences(100);
+        $this->assertCount(2, $refs,
+            'Patching one image must not create a duplicate row or drop the other reference. ' .
+            'Got ' . count($refs) . ' references. ' . $this->getFailureContext($currentResponse));
+
+        $refByUid = [];
+        foreach ($refs as $row) {
+            $refByUid[(int)$row['uid']] = $row;
+        }
+        $this->assertArrayHasKey(1, $refByUid,
+            'Original sys_file_reference uid=1 must be reused, not replaced. ' .
+            'Existing uids: ' . implode(',', array_keys($refByUid)) . '. ' .
+            $this->getFailureContext($currentResponse));
+        $this->assertArrayHasKey(2, $refByUid,
+            'Untouched sys_file_reference uid=2 must remain. ' .
+            $this->getFailureContext($currentResponse));
+
+        $hero = $refByUid[1];
+        $this->assertSame(1, (int)$hero['uid_local'],
+            'uid_local must be preserved (no broken reference with uid_local=0). ' .
+            $this->getFailureContext($currentResponse));
+        $this->assertSame('Updated alt text', (string)$hero['alternative'],
+            'alternative on the Hero Image reference should be updated. ' .
+            $this->getFailureContext($currentResponse));
+
+        $other = $refByUid[2];
+        $this->assertSame('Second photo', (string)$other['alternative'],
+            'The other reference must keep its original alternative text.');
+    }
+
+    #[DataProvider('modelProvider')]
+    #[TestDox('[$modelKey] Reorder images on tt_content uid=100 so "Second Image" comes first → array order is reflected in sorting_foreign')]
+    public function testLlmReordersFileReferencesByArrayOrder(string $modelKey): void
+    {
+        $this->setModel($modelKey);
+
+        $prompt = 'Content element uid=100 in tt_content has two images attached: "Hero Image" first, ' .
+            'then "Second Image". Swap their order so that "Second Image" appears first and "Hero Image" second. ' .
+            'Keep both images attached and do not change any other fields.';
+
+        $response = $this->executeUntilToolFound(
+            $this->callLlm($prompt),
+            'WriteTable',
+            10
+        );
+
+        $writeCalls = $response->getToolCallsByName('WriteTable');
+        $this->assertNotEmpty($writeCalls,
+            'Expected WriteTable call. ' . $this->getFailureContext($response));
+
+        $currentResponse = $response;
+        for ($attempt = 0; $attempt < 6 && $currentResponse->hasToolCalls(); $attempt++) {
+            $currentResponse = $this->executeAndContinue($currentResponse);
+        }
+
+        $refs = $this->queryAssetReferences(100);
+        $this->assertCount(2, $refs,
+            'Both references must remain after reordering. Got ' . count($refs) . '. ' .
+            $this->getFailureContext($currentResponse));
+
+        usort($refs, fn($a, $b) => (int)$a['sorting_foreign'] <=> (int)$b['sorting_foreign']);
+        $titles = array_column($refs, 'title');
+
+        $this->assertSame(['Second Image', 'Hero Image'], $titles,
+            'Reorder must change the sort order of existing references. ' .
+            'Got titles in order: ' . implode(' → ', $titles) . '. ' .
+            $this->getFailureContext($currentResponse));
+
+        $uidLocals = array_unique(array_map(fn($r) => (int)$r['uid_local'], $refs));
+        $this->assertSame([1], array_values($uidLocals),
+            'No reference should have been recreated with uid_local=0. ' .
+            $this->getFailureContext($currentResponse));
+    }
+
+    #[DataProvider('modelProvider')]
+    #[TestDox('[$modelKey] Add a third image to tt_content uid=100 without dropping the existing two')]
+    public function testLlmAddsImageWhilePreservingExisting(string $modelKey): void
+    {
+        $this->setModel($modelKey);
+
+        // person.jpg = sys_file uid=3
+        $prompt = 'Content element uid=100 in tt_content already has two images. ' .
+            'Add person.jpg as a third image to the existing assets, keeping the existing two images intact.';
+
+        $response = $this->executeUntilToolFound(
+            $this->callLlm($prompt),
+            'WriteTable',
+            12
+        );
+
+        $this->assertNotEmpty($response->getToolCallsByName('WriteTable'),
+            'Expected WriteTable call. ' . $this->getFailureContext($response));
+
+        $currentResponse = $response;
+        for ($attempt = 0; $attempt < 6 && $currentResponse->hasToolCalls(); $attempt++) {
+            $currentResponse = $this->executeAndContinue($currentResponse);
+        }
+
+        $refs = $this->queryAssetReferences(100);
+        $this->assertCount(3, $refs,
+            'Expected three asset references after adding a third image. Got ' . count($refs) . '. ' .
+            $this->getFailureContext($currentResponse));
+
+        $fileUids = array_map(fn($r) => (int)$r['uid_local'], $refs);
+        sort($fileUids);
+        $this->assertContains(3, $fileUids,
+            'New reference must point to person.jpg (sys_file uid=3). ' .
+            'Got uid_local values: ' . implode(',', $fileUids) . '. ' .
+            $this->getFailureContext($currentResponse));
+
+        // Both original references (uid=1, uid=2 — both pointing at sys_file uid=1) must still be there.
+        $existingRefUids = array_map(fn($r) => (int)$r['uid'], $refs);
+        $this->assertContains(1, $existingRefUids,
+            'Original Hero Image reference (uid=1) was dropped. ' .
+            $this->getFailureContext($currentResponse));
+        $this->assertContains(2, $existingRefUids,
+            'Original Second Image reference (uid=2) was dropped. ' .
+            $this->getFailureContext($currentResponse));
+    }
+
+    /**
+     * Read sys_file_reference rows for tt_content.assets, including workspace versions.
+     *
+     * Returns the workspace overlay if present, otherwise the live row, so that we
+     * always observe the LLM's most recent change in the workspace it wrote into.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    protected function queryAssetReferences(int $parentUid): array
+    {
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('sys_file_reference');
+        $qb->getRestrictions()->removeAll();
+
+        $rows = $qb->select(
+            'uid',
+            'uid_local',
+            'uid_foreign',
+            'sorting_foreign',
+            'title',
+            'alternative',
+            'tablenames',
+            'fieldname',
+            't3ver_oid',
+            't3ver_wsid',
+            't3ver_state',
+            'deleted',
+            'hidden'
+        )
+            ->from('sys_file_reference')
+            ->where(
+                $qb->expr()->eq('tablenames', $qb->createNamedParameter('tt_content')),
+                $qb->expr()->eq('fieldname', $qb->createNamedParameter('assets')),
+                $qb->expr()->or(
+                    $qb->expr()->eq('uid_foreign', $qb->createNamedParameter($parentUid, \Doctrine\DBAL\ParameterType::INTEGER)),
+                    $qb->expr()->eq('t3ver_oid', $qb->createNamedParameter($parentUid, \Doctrine\DBAL\ParameterType::INTEGER))
+                ),
+                $qb->expr()->eq('deleted', 0)
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        // Fold workspace overlays onto their live uid: if a row has t3ver_oid > 0, it
+        // represents an edit of that live record — prefer the overlay's data but key by
+        // the live uid the LLM operates on. Drop a live row whose overlay is also present.
+        $byLiveUid = [];
+        foreach ($rows as $row) {
+            $liveUid = (int)($row['t3ver_oid'] ?: $row['uid']);
+            if ((int)$row['t3ver_oid'] > 0) {
+                $row['uid'] = $liveUid;
+                $byLiveUid[$liveUid] = $row;
+            } elseif (!isset($byLiveUid[$liveUid])) {
+                $byLiveUid[$liveUid] = $row;
+            }
+        }
+
+        // Drop placeholder rows (DELETE_PLACEHOLDER state = 2)
+        return array_values(array_filter($byLiveUid, fn($r) => (int)$r['t3ver_state'] !== 2));
+    }
+}


### PR DESCRIPTION
## Summary

`WriteTableTool::processEmbeddedInlineRelations` always routed records through the create path, even when the caller passed an existing `uid`. Payloads like:

\`\`\`json
{
  \"action\": \"update\",
  \"table\": \"tt_content\",
  \"uid\": 100,
  \"data\": {
    \"assets\": [
      {\"uid\": 42, \"title\": \"patched\"}
    ]
  }
}
\`\`\`

inserted a fresh \`sys_file_reference\` with \`uid_local=0\` (broken — the file pointer is gone) instead of patching the existing reference \`#42\`. The original reference stayed in the workspace as an orphan and the field update was silently dropped.

## Fix

`processEmbeddedInlineRelations` now treats a numeric \`uid\` key as an update target:
- Resolve to the workspace version via \`resolveToWorkspaceUid\` so DataHandler patches the correct row.
- Skip \`pid\` / \`foreign_match_fields\` / \`foreign_sortby\` injection — those belong to insertion only.
- Short-circuit when only a uid was sent without other fields (no-op instead of an empty datamap row).

Create-path payloads (no \`uid\`) keep the existing behaviour.

## Test plan
- [x] Added `InlineRelationWriteTest::testUpdateExistingEmbeddedRelationByUid` covering the regression: same sys_file_reference uid is patched, no duplicate row, `uid_local` stays intact.
- [ ] CI green