### PR TITLE
ci(check-llm-results): treat all-skipped as neutral when no API key set

### DIFF
--- a/Build/check-llm-results.php
+++ b/Build/check-llm-results.php
@@ -131,10 +131,16 @@ foreach ($testCases as $name => $result) {
 
 echo "\n" . str_repeat('=', 80) . "\n";
 
-// Fail if no tests actually executed (e.g. missing API key caused all skips)
+// Distinguish "no API key available" (expected on fork PRs — GitHub does not share
+// secrets with workflows triggered from forks) from "API key set but nothing ran"
+// (real CI/test problem). Only the latter should fail the job.
 $executedCount = count(array_filter($testCases, fn($r) => array_diff($r['models'], ['SKIP'])));
 if ($executedCount === 0) {
-    fwrite(STDERR, "\033[31mNo LLM tests were executed (all skipped). Check OPENROUTER_API_KEY.\033[0m\n");
+    if (getenv('OPENROUTER_API_KEY') === false || getenv('OPENROUTER_API_KEY') === '') {
+        fwrite(STDERR, "\033[33mNo LLM tests were executed (no OPENROUTER_API_KEY available — fork PR or local run without secret). Skipping majority-pass check.\033[0m\n");
+        exit(0);
+    }
+    fwrite(STDERR, "\033[31mNo LLM tests were executed (all skipped) despite OPENROUTER_API_KEY being set. Check test runner.\033[0m\n");
     exit(1);
 }
 


### PR DESCRIPTION
## Summary

Fork PRs (e.g. #64) currently fail the LLM Tests job not because of the change under review, but because GitHub Actions does not pass `secrets.OPENROUTER_API_KEY` to workflows triggered from forks. Every LLM test then hits `markTestSkipped(\"No LLM API key configured\")`, and `Build/check-llm-results.php --min-pass=3` exits 1 (0/5 pass < 3).

This is an environmental constraint, not a real test failure. Distinguish the two cases:

- **All skipped + `OPENROUTER_API_KEY` empty** → expected on fork PRs / local runs without the secret. Print a yellow notice and `exit 0`.
- **All skipped + `OPENROUTER_API_KEY` present** → real test runner or paratest issue. Keep the existing `exit 1`.

Pushes to `main` and PRs from this repo (where the secret is always set) keep the failure mode untouched. Fork PRs surface their actual PHP unit test results without spurious red checks.

## Test plan
- [ ] Re-run failing fork PR (#64) after this lands → LLM Tests job should pass with yellow notice
- [ ] Push to main with secret unchanged → check still runs full majority-pass logic