### PR TITLE
fix(WriteTable): make delete idempotent to protect sibling workspace drafts

### DIFF
--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -625,23 +625,63 @@ class WriteTableTool extends AbstractRecordTool
     {
         // Resolve the live UID to workspace UID
         $workspaceUid = $this->resolveToWorkspaceUid($table, $uid);
-        
+
+        // Idempotency: if a delete placeholder already exists in the current workspace,
+        // skip DataHandler. Re-entering process_cmdmap on an already-placeholdered record
+        // can undo the placeholder (placeholder count goes 1 → 0) and, in cascade-aware
+        // configurations like Gridelements, can wipe sibling drafts as a side effect.
+        // Returning the same shape as a fresh delete keeps callers (e.g. an LLM retrying
+        // after a transient error) safe.
+        if ($this->hasWorkspaceDeletePlaceholder($table, $uid)) {
+            return $this->createJsonResult([
+                'action' => 'delete',
+                'table' => $table,
+                'uid' => $uid,
+            ]);
+        }
+
         // Delete the record using DataHandler
         $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
         $dataHandler->BE_USER = $GLOBALS['BE_USER'];
         $dataHandler->start([], [$table => [$workspaceUid => ['delete' => 1]]]);
         $dataHandler->process_cmdmap();
-        
+
         // Check for errors
         if ($dataHandler->errorLog) {
             return $this->createErrorResult('Error deleting record: ' . implode(', ', $dataHandler->errorLog));
         }
-        
+
         return $this->createJsonResult([
             'action' => 'delete',
             'table' => $table,
             'uid' => $uid, // Return the live UID that was passed in
         ]);
+    }
+
+    /**
+     * Check whether a delete placeholder (t3ver_state=2) already exists for the live UID
+     * in the BE user's current workspace. Used to make deleteRecord idempotent.
+     */
+    protected function hasWorkspaceDeletePlaceholder(string $table, int $liveUid): bool
+    {
+        $wsid = (int)($GLOBALS['BE_USER']->workspace ?? 0);
+        if ($wsid === 0 || !$this->isTableWorkspaceCapable($table)) {
+            return false;
+        }
+
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
+        $qb->getRestrictions()->removeAll();
+        $count = (int)$qb->count('uid')
+            ->from($table)
+            ->where(
+                $qb->expr()->eq('t3ver_oid', $qb->createNamedParameter($liveUid, ParameterType::INTEGER)),
+                $qb->expr()->eq('t3ver_wsid', $qb->createNamedParameter($wsid, ParameterType::INTEGER)),
+                $qb->expr()->eq('t3ver_state', $qb->createNamedParameter(2, ParameterType::INTEGER))
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return $count > 0;
     }
     
     /**

--- a/Tests/Functional/MCP/Tool/ContainerDeleteIdempotencyTest.php
+++ b/Tests/Functional/MCP/Tool/ContainerDeleteIdempotencyTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use Doctrine\DBAL\ParameterType;
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use Hn\McpServer\Service\WorkspaceContextService;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Covers the report that retrying a delete on a record in a workspace produced
+ * side effects on unrelated workspace drafts (originally seen with Gridelements
+ * containers and their children).
+ *
+ * The MCP cannot control DataHandler cascade or extension hooks, but it CAN
+ * guarantee that retrying a delete is a no-op once a delete placeholder exists.
+ * The re-entry into DataHandler's cmdmap on an already-placeholdered record is
+ * what triggered the destructive cascade in the original report — making the
+ * second call short-circuit removes the trigger entirely.
+ */
+class ContainerDeleteIdempotencyTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+        'frontend',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'mcp_server',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/tt_content.csv');
+        $this->setUpBackendUser(1);
+    }
+
+    /**
+     * Sibling-draft survival: an unrelated workspace draft staged before the delete
+     * must remain intact across both the initial delete and the retry. The original
+     * regression saw children drafts disappear when the delete was retried.
+     */
+    public function testRetryingDeleteDoesNotClobberUnrelatedWorkspaceDrafts(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+        $workspaceService = GeneralUtility::makeInstance(WorkspaceContextService::class);
+
+        $targetUid = 100; // tt_content from fixture, live
+        $siblingUid = 101; // sibling record on the same page, also live
+
+        // Stage a workspace edit on the sibling — this is what we want to protect.
+        $stageSiblingDraft = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'update',
+            'uid' => $siblingUid,
+            'data' => ['bodytext' => 'Sibling edited in workspace'],
+        ]);
+        $this->assertFalse($stageSiblingDraft->isError, json_encode($stageSiblingDraft->jsonSerialize()));
+
+        $wsid = $workspaceService->getCurrentWorkspace();
+        $this->assertGreaterThan(0, $wsid, 'Test must run inside a real workspace');
+
+        $siblingDraftCount = fn(): int => $this->countWorkspaceVersions('tt_content', $siblingUid, $wsid);
+        $this->assertSame(1, $siblingDraftCount(), 'Baseline: sibling has exactly one workspace draft');
+
+        // First delete — creates the delete placeholder.
+        $firstDelete = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'delete',
+            'uid' => $targetUid,
+        ]);
+        $this->assertFalse($firstDelete->isError, json_encode($firstDelete->jsonSerialize()));
+        $this->assertSame(1, $this->countDeletePlaceholders('tt_content', $targetUid, $wsid), 'First delete creates one placeholder');
+        $this->assertSame(1, $siblingDraftCount(), 'Sibling draft survives the first delete');
+
+        // Retry — the regression-prone path. A second cmdmap on an already-placeholdered
+        // record is what wiped unrelated drafts in the original report.
+        $retryDelete = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'delete',
+            'uid' => $targetUid,
+        ]);
+        $this->assertFalse($retryDelete->isError, json_encode($retryDelete->jsonSerialize()));
+        $this->assertSame(1, $this->countDeletePlaceholders('tt_content', $targetUid, $wsid), 'Retry must not duplicate the placeholder');
+        $this->assertSame(1, $siblingDraftCount(), 'Sibling draft must survive the retried delete');
+    }
+
+    private function countWorkspaceVersions(string $table, int $liveUid, int $wsid): int
+    {
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
+        $qb->getRestrictions()->removeAll();
+        return (int)$qb->count('uid')
+            ->from($table)
+            ->where(
+                $qb->expr()->eq('t3ver_oid', $qb->createNamedParameter($liveUid, ParameterType::INTEGER)),
+                $qb->expr()->eq('t3ver_wsid', $qb->createNamedParameter($wsid, ParameterType::INTEGER))
+            )
+            ->executeQuery()
+            ->fetchOne();
+    }
+
+    private function countDeletePlaceholders(string $table, int $liveUid, int $wsid): int
+    {
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
+        $qb->getRestrictions()->removeAll();
+        return (int)$qb->count('uid')
+            ->from($table)
+            ->where(
+                $qb->expr()->eq('t3ver_oid', $qb->createNamedParameter($liveUid, ParameterType::INTEGER)),
+                $qb->expr()->eq('t3ver_wsid', $qb->createNamedParameter($wsid, ParameterType::INTEGER)),
+                $qb->expr()->eq('t3ver_state', $qb->createNamedParameter(2, ParameterType::INTEGER))
+            )
+            ->executeQuery()
+            ->fetchOne();
+    }
+}


### PR DESCRIPTION
## Summary

A retried delete on a record that already has a workspace delete placeholder re-enters \`DataHandler::process_cmdmap\`. The re-entry can undo the placeholder (placeholder count goes 1 → 0) and, in cascade-aware configurations like Gridelements containers, can wipe the workspace drafts of sibling/child records as a side effect — exactly the regression seen in the wild when an LLM client retried a delete after a transient error.

## Reproduction

In a workspace, with sibling \`tt_content:101\` carrying a draft edit:

\`\`\`php
\$writeTool->execute(['action' => 'delete', 'table' => 'tt_content', 'uid' => 100]); // creates placeholder
\$writeTool->execute(['action' => 'delete', 'table' => 'tt_content', 'uid' => 100]); // retries → placeholder gone
\`\`\`

\`ContainerDeleteIdempotencyTest::testRetryingDeleteDoesNotClobberUnrelatedWorkspaceDrafts\` exercises this and fails on \`main\` with \`Failed asserting that 0 is identical to 1\` (the placeholder is removed by the second call).

## Fix

Short-circuit in \`deleteRecord\`: if the live UID already has a \`t3ver_state=2\` placeholder in the BE user's workspace, return the same success shape without entering DataHandler again. The first call still does its work; retries become true no-ops.

\`hasWorkspaceDeletePlaceholder\` guards on \`workspace > 0\` and \`isTableWorkspaceCapable\`, so live-workspace deletes and non-versionable tables take the normal path unchanged.

## Test plan
- [x] New \`ContainerDeleteIdempotencyTest\` — fails on main, passes with this fix (9 assertions: placeholder count stable + sibling draft preserved through both calls)
- [x] Full functional suite (\`paratest\` -p 4) — only pre-existing TZ flake (\`ValidationRefactoringTest::testDateFieldHandling\`) reproducible on origin/main without this change