### PR TITLE
Add --no-docker mode for E2E tests with local PHP and SQLite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,52 @@ jobs:
       - name: Run functional test suite
         run: composer test
 
+  e2e-tests:
+    runs-on: ubuntu-latest
+    name: E2E Tests
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        with:
+          php-version: '8.4'
+          extensions: sqlite3, pdo_sqlite, intl
+          coverage: none
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: Build/package-lock.json
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Install Playwright npm packages
+        working-directory: Build
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: Build
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E test suite
+        run: bash Build/runTests.sh -s e2e --no-docker
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-report
+          path: |
+            Build/playwright-report
+            Build/test-results
+          retention-days: 7
+
   llm-trigger:
     runs-on: ubuntu-latest
     name: Check LLM trigger

--- a/Build/runTests.sh
+++ b/Build/runTests.sh
@@ -375,6 +375,8 @@ case "${TEST_SUITE}" in
             if [ ! -d node_modules ]; then
                 npm ci
             fi
+            # Idempotent: a no-op once the matching browser is cached.
+            npx playwright install chromium
             TYPO3_BASE_URL="${LOCAL_WEB_URL}" CI="${CI:-}" \
                 npx playwright test ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
             exit 0

--- a/Build/runTests.sh
+++ b/Build/runTests.sh
@@ -17,6 +17,7 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PHP_VERSION="8.3"
 DBMS="sqlite"
 TEST_SUITE="functional"
+NO_DOCKER=0
 EXTRA_ARGS=()
 
 # Unique prefix for this run (used for container and network names)
@@ -41,6 +42,7 @@ Options:
     -p <version>    PHP version: 8.2, 8.3 (default), 8.4, 8.5
     -d <dbms>       Database backend: sqlite (default), mysql, mariadb, postgres
     -s <suite>      Test suite: functional (default), lint, e2e
+    -n, --no-docker Run e2e locally without Docker (uses host PHP, SQLite, local Playwright)
     -h, --help      Show this help
 
 Any arguments after -- are passed directly to phpunit.
@@ -75,6 +77,10 @@ while [ $# -gt 0 ]; do
             TEST_SUITE="$2"
             shift 2
             ;;
+        -n|--no-docker)
+            NO_DOCKER=1
+            shift
+            ;;
         -h|--help)
             usage
             ;;
@@ -108,11 +114,25 @@ case "${TEST_SUITE}" in
     *) echo "Error: unsupported test suite '${TEST_SUITE}'. Use functional, lint, or e2e." >&2; exit 1 ;;
 esac
 
-# Cleanup function — removes containers and network
+# Auto-enable no-docker mode when docker is not installed or the daemon is unreachable.
+if [ "${NO_DOCKER}" -eq 0 ] && [ "${TEST_SUITE}" = "e2e" ]; then
+    if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+        echo "Note: docker unavailable, running e2e tests locally (--no-docker)." >&2
+        NO_DOCKER=1
+    fi
+fi
+
+# Cleanup function — removes containers and network (docker mode) or background PHP server (local mode)
+LOCAL_WEB_PID=""
 cleanup() {
     set +e
-    docker rm -f "${CONTAINER_NAME}" "${RUN_ID}-web" "${RUN_ID}-db" "${RUN_ID}-pw" >/dev/null 2>&1
-    docker network rm "${NETWORK_NAME}" >/dev/null 2>&1
+    if [ -n "${LOCAL_WEB_PID}" ]; then
+        kill "${LOCAL_WEB_PID}" >/dev/null 2>&1
+    fi
+    if command -v docker >/dev/null 2>&1; then
+        docker rm -f "${CONTAINER_NAME}" "${RUN_ID}-web" "${RUN_ID}-db" "${RUN_ID}-pw" >/dev/null 2>&1
+        docker network rm "${NETWORK_NAME}" >/dev/null 2>&1
+    fi
     set -e
 }
 trap cleanup EXIT
@@ -291,6 +311,75 @@ case "${TEST_SUITE}" in
             "
         ;;
     e2e)
+        if [ "${NO_DOCKER}" -eq 1 ]; then
+            echo "Running E2E tests locally (host PHP + SQLite + Playwright)..."
+
+            command -v php >/dev/null 2>&1 || { echo "Error: php is required for --no-docker mode." >&2; exit 1; }
+            command -v composer >/dev/null 2>&1 || { echo "Error: composer is required for --no-docker mode." >&2; exit 1; }
+            command -v npx >/dev/null 2>&1 || { echo "Error: npx (Node.js) is required for --no-docker mode." >&2; exit 1; }
+            php -r 'exit(extension_loaded("pdo_sqlite")?0:1);' \
+                || { echo "Error: PHP extension pdo_sqlite is required for --no-docker mode." >&2; exit 1; }
+
+            cd "${ROOT_DIR}"
+            rm -rf var/cache var/log config/system/settings.php config/system/additional.php var/*.db 2>/dev/null || true
+
+            echo "Installing composer dependencies..."
+            composer install --no-interaction --prefer-dist --no-scripts -q
+
+            echo "Setting up TYPO3 (SQLite)..."
+            vendor/bin/typo3 setup \
+                --driver=sqlite \
+                --dbname="${ROOT_DIR}/var/sqlite.db" \
+                --admin-username=admin \
+                --admin-user-password=Admin123! \
+                --admin-email=admin@example.com \
+                --project-name=mcp-server-e2e \
+                --server-type=other \
+                --no-interaction \
+                --force >/dev/null
+
+            # Relax trusted-hosts / devIPmask for the built-in web server.
+            php -r '$s=include"config/system/settings.php";$s["SYS"]["trustedHostsPattern"]=".*";$s["SYS"]["devIPmask"]="*";file_put_contents("config/system/settings.php","<?php\nreturn ".var_export($s,true).";\n");'
+            rm -rf var/cache
+
+            LOCAL_WEB_HOST="127.0.0.1"
+            LOCAL_WEB_PORT="${TYPO3_E2E_PORT:-8080}"
+            LOCAL_WEB_URL="http://${LOCAL_WEB_HOST}:${LOCAL_WEB_PORT}"
+
+            echo "Starting PHP built-in web server at ${LOCAL_WEB_URL}..."
+            mkdir -p var/log
+            php -S "${LOCAL_WEB_HOST}:${LOCAL_WEB_PORT}" -t public/ >"${ROOT_DIR}/var/log/typo3-e2e-web.log" 2>&1 &
+            LOCAL_WEB_PID=$!
+
+            echo "Waiting for TYPO3..."
+            for i in $(seq 1 60); do
+                if ! kill -0 "${LOCAL_WEB_PID}" 2>/dev/null; then
+                    echo "Web server exited unexpectedly. Logs:" >&2
+                    tail -30 "${ROOT_DIR}/var/log/typo3-e2e-web.log" >&2
+                    exit 1
+                fi
+                if curl -sf "${LOCAL_WEB_URL}/typo3/" -o /dev/null 2>&1; then
+                    echo "TYPO3 is ready."
+                    break
+                fi
+                if [ "$i" -eq 60 ]; then
+                    echo "TYPO3 web server timeout. Logs:" >&2
+                    tail -30 "${ROOT_DIR}/var/log/typo3-e2e-web.log" >&2
+                    exit 1
+                fi
+                sleep 1
+            done
+
+            echo "Running Playwright tests..."
+            cd "${ROOT_DIR}/Build"
+            if [ ! -d node_modules ]; then
+                npm ci
+            fi
+            TYPO3_BASE_URL="${LOCAL_WEB_URL}" CI="${CI:-}" \
+                npx playwright test ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
+            exit 0
+        fi
+
         echo "Running E2E tests (Docker: MySQL + PHP web server + Playwright)..."
 
         # Clean up stale state from previous runs (may be root-owned from Docker)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 - This project is about developing the mcp_server typo3 extension, that allows someone without technical knowledge to edit content using LLM's.
 - Run the tests using `composer test`. Test must cover the TYPO3 integration.
-- Run E2E (Playwright) tests using `Build/runTests.sh -s e2e`. This spins up MySQL, TYPO3, and Playwright in Docker containers automatically.
+- Run E2E (Playwright) tests using `Build/runTests.sh -s e2e`. This spins up MySQL, TYPO3, and Playwright in Docker containers automatically. If Docker is unavailable, the script falls back to a local mode (host PHP + SQLite + local Playwright); this can also be forced with `-n` / `--no-docker`.
 - Read the TECHNICAL_OVERVIEW.md and documentation in the Documentation/Architecture/ folder to understand important design decisions and implementation details.
 - The Tools for LLMs don't need backwards compatibility. We can completely change parameters or even their names if it better describes them without it being a breaking change.
 - Every Tool (that uses the database) must use TYPO3 Workspaces explicitly. Live data must never be directly edited. However: Ensure that the workspaces are invisible to the MCP client, for example, by only exposing the live id.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ composer test
 # E2E tests — spins up MySQL, TYPO3, and Playwright in Docker
 Build/runTests.sh -s e2e
 
+# E2E without Docker (host PHP + SQLite + local Playwright).
+# Auto-selected when Docker is unavailable.
+Build/runTests.sh -s e2e --no-docker
+
 # E2E against an existing TYPO3 instance
 TYPO3_BASE_URL=https://my.ddev.site Build/runTests.sh -s e2e
 


### PR DESCRIPTION
## Summary
This PR adds support for running E2E tests locally without Docker, using the host PHP installation, SQLite database, and local Playwright. The script automatically falls back to this mode when Docker is unavailable.

## Key Changes
- **New `--no-docker` flag** for `Build/runTests.sh` to explicitly run E2E tests locally instead of in Docker containers
- **Auto-detection of Docker availability**: When Docker is not installed or unreachable, the script automatically enables local mode for E2E tests
- **Local E2E test setup**: Implements a complete local test environment that:
  - Validates required dependencies (PHP, Composer, Node.js, pdo_sqlite extension)
  - Sets up TYPO3 with SQLite database
  - Configures trusted hosts and dev IP mask for the built-in web server
  - Starts PHP's built-in web server on a configurable port (default 8080)
  - Waits for TYPO3 to be ready before running tests
  - Runs Playwright tests against the local instance
- **Improved cleanup function**: Now handles both Docker containers and local PHP server processes
- **GitHub Actions workflow**: Added new `e2e-tests` job that runs E2E tests in local mode on Ubuntu with PHP 8.4, Node.js 22, and SQLite
- **Documentation updates**: Updated README and CLAUDE.md to document the new `--no-docker` option

## Implementation Details
- The local mode uses environment variable `TYPO3_E2E_PORT` (default 8080) for the web server port
- Health checks poll the TYPO3 backend URL with a 60-second timeout
- Web server logs are captured to `var/log/typo3-e2e-web.log` for debugging
- The implementation maintains backward compatibility—existing Docker-based E2E tests continue to work unchanged
- Auto-fallback to local mode is transparent to users and only applies to E2E tests

https://claude.ai/code/session_01Hx5thCi7pGa4KSVGy91yqK