### PR TITLE
Skip empty tabs in table schema generation

### DIFF
--- a/Classes/MCP/Tool/Record/GetTableSchemaTool.php
+++ b/Classes/MCP/Tool/Record/GetTableSchemaTool.php
@@ -211,94 +211,108 @@ class GetTableSchemaTool extends AbstractRecordTool
         
         // Process each tab's fields
         $processedFields = [];
-        
+
         foreach ($tabFields as $tabName => $tabFieldsList) {
-            // Translate the tab name
-            $translatedTabName = TableAccessService::translateLabel($tabName);
-            $result .= "  (" . $translatedTabName . "):\n";
-            
+            $tabContent = '';
+
             foreach ($tabFieldsList as $item) {
                 $itemParts = GeneralUtility::trimExplode(';', $item, true);
                 $fieldName = $itemParts[0];
-                
+
                 // Check if this is a palette
                 if ($fieldName === '--palette--' || strpos($fieldName, '--palette--') === 0) {
                     // Extract palette name from the parts
                     $paletteParts = explode(';', $item);
                     $paletteName = $paletteParts[2] ?? '';
                     $paletteLabel = $paletteParts[1] ?? '';
-                    
+
                     // Translate the palette label if it's a language reference
                     if (!empty($paletteLabel)) {
                         $paletteLabel = TableAccessService::translateLabel($paletteLabel);
                     }
-                    
+
                     // Use palette name as fallback if label is empty
                     if (empty($paletteLabel)) {
                         $paletteLabel = ucfirst(str_replace('_', ' ', $paletteName));
                     }
-                    
+
                     if (!empty($paletteName) && isset($GLOBALS['TCA'][$table]['palettes'][$paletteName])) {
-                        // Add the palette to the current tab's fields
-                        $result .= "    ┌─ (" . $paletteLabel . ")\n";
-                        
                         // Get the palette fields
                         $paletteFields = $GLOBALS['TCA'][$table]['palettes'][$paletteName]['showitem'] ?? '';
                         $paletteFieldsList = GeneralUtility::trimExplode(',', $paletteFields, true);
-                        
-                        // Process each palette field
-                        $lastPaletteField = end($paletteFieldsList);
-                        reset($paletteFieldsList);
-                        
+
+                        // Pre-filter to only items whose fields are accessible so we
+                        // don't emit a palette header with no children.
+                        $accessiblePaletteItems = [];
                         foreach ($paletteFieldsList as $paletteItem) {
                             $paletteItemParts = GeneralUtility::trimExplode(';', $paletteItem, true);
                             $paletteFieldName = $paletteItemParts[0];
-                            
-                            // Skip special fields
                             if ($paletteFieldName === '--linebreak--') {
                                 continue;
                             }
-                            
-                            // Add the field to the result if it's accessible
                             if (isset($availableFields[$paletteFieldName])) {
-                                $fieldConfig = $availableFields[$paletteFieldName];
-                                
-                                // Mark as processed
-                                $processedFields[$paletteFieldName] = true;
-                                
-                                // Add the field to the result with proper indentation
-                                $prefix = ($paletteItem === $lastPaletteField) ? "└─ " : "├─ ";
-                                $fieldLabel = isset($fieldConfig['label']) ? TableAccessService::translateLabel($fieldConfig['label']) : $paletteFieldName;
-                                // TcaSchemaFactory returns flattened config where type is at top level
-                                $fieldType = $fieldConfig['type'] ?? $fieldConfig['config']['type'] ?? 'unknown';
-                                $result .= "    " . $prefix . $paletteFieldName . " (" . $fieldLabel . "): " . $fieldType;
-                                
-                                // Add field details inline
-                                $this->addFieldDetailsInline($result, $fieldConfig, $paletteFieldName, $table, $filterType);
-                                $result .= "\n";
+                                $accessiblePaletteItems[] = $paletteItem;
                             }
+                        }
+
+                        if (empty($accessiblePaletteItems)) {
+                            continue;
+                        }
+
+                        $tabContent .= "    ┌─ (" . $paletteLabel . ")\n";
+
+                        $lastPaletteField = end($accessiblePaletteItems);
+                        reset($accessiblePaletteItems);
+
+                        foreach ($accessiblePaletteItems as $paletteItem) {
+                            $paletteItemParts = GeneralUtility::trimExplode(';', $paletteItem, true);
+                            $paletteFieldName = $paletteItemParts[0];
+                            $fieldConfig = $availableFields[$paletteFieldName];
+
+                            // Mark as processed
+                            $processedFields[$paletteFieldName] = true;
+
+                            // Add the field to the result with proper indentation
+                            $prefix = ($paletteItem === $lastPaletteField) ? "└─ " : "├─ ";
+                            $fieldLabel = isset($fieldConfig['label']) ? TableAccessService::translateLabel($fieldConfig['label']) : $paletteFieldName;
+                            // TcaSchemaFactory returns flattened config where type is at top level
+                            $fieldType = $fieldConfig['type'] ?? $fieldConfig['config']['type'] ?? 'unknown';
+                            $tabContent .= "    " . $prefix . $paletteFieldName . " (" . $fieldLabel . "): " . $fieldType;
+
+                            // Add field details inline
+                            $this->addFieldDetailsInline($tabContent, $fieldConfig, $paletteFieldName, $table, $filterType);
+                            $tabContent .= "\n";
                         }
                     }
                 } else {
                     // Regular field
                     if (isset($availableFields[$fieldName])) {
                         $fieldConfig = $availableFields[$fieldName];
-                        
+
                         // Mark as processed
                         $processedFields[$fieldName] = true;
-                        
+
                         // Add the field to the result
                         $fieldLabel = isset($fieldConfig['label']) ? TableAccessService::translateLabel($fieldConfig['label']) : $fieldName;
                         // TcaSchemaFactory returns flattened config where type is at top level
                         $fieldType = $fieldConfig['type'] ?? $fieldConfig['config']['type'] ?? 'unknown';
-                        $result .= "    - " . $fieldName . " (" . $fieldLabel . "): " . $fieldType;
-                        
+                        $tabContent .= "    - " . $fieldName . " (" . $fieldLabel . "): " . $fieldType;
+
                         // Add field details inline
-                        $this->addFieldDetailsInline($result, $fieldConfig, $fieldName, $table, $filterType);
-                        $result .= "\n";
+                        $this->addFieldDetailsInline($tabContent, $fieldConfig, $fieldName, $table, $filterType);
+                        $tabContent .= "\n";
                     }
                 }
             }
+
+            // Skip tabs that have no accessible fields after filtering.
+            if ($tabContent === '') {
+                continue;
+            }
+
+            $translatedTabName = TableAccessService::translateLabel($tabName);
+            $result .= "  (" . $translatedTabName . "):\n";
+            $result .= $tabContent;
         }
         
         // Check for fields that are available but not in showitem (e.g., dynamically added fields like pi_flexform for plugins)

--- a/Tests/Functional/MCP/Tool/GetTableSchemaToolTest.php
+++ b/Tests/Functional/MCP/Tool/GetTableSchemaToolTest.php
@@ -292,6 +292,43 @@ class GetTableSchemaToolTest extends FunctionalTestCase
     }
 
     /**
+     * Tabs whose fields are all filtered out — or that have no fields at all
+     * in the TCA showitem (e.g. sys_file_metadata's "Extended" tab) — must not
+     * be rendered as orphan headers.
+     */
+    public function testEmptyTabsAreNotRendered(): void
+    {
+        $tool = new GetTableSchemaTool();
+
+        $result = $tool->execute([
+            'table' => 'sys_file_metadata',
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $content = $result->content[0]->text;
+
+        // The "Extended" tab in sys_file_metadata's TCA contains no fields,
+        // so it should not appear in the output at all.
+        $this->assertStringNotContainsString('(Extended):', $content);
+
+        // No tab header should be left without at least one field/palette below it.
+        $lines = explode("\n", $content);
+        $tabHeader = '/^  \([^)]+\):$/';
+        $childLine = '/^    [\s\S]/';
+        foreach ($lines as $index => $line) {
+            if (!preg_match($tabHeader, $line)) {
+                continue;
+            }
+            $next = $lines[$index + 1] ?? '';
+            $this->assertMatchesRegularExpression(
+                $childLine,
+                $next,
+                "Tab header '{$line}' has no field below it (next line: '{$next}')"
+            );
+        }
+    }
+
+    /**
      * Set up backend user with workspace
      */
     protected function setUpBackendUserWithWorkspace(int $uid): void


### PR DESCRIPTION
## Summary
Refactored the table schema generation logic to prevent empty tabs from being rendered as orphan headers in the output. This improves the readability of generated schemas by only displaying tabs that contain accessible fields.

## Key Changes
- **Deferred tab header output**: Changed the logic to accumulate field content in a `$tabContent` buffer before writing the tab header to the result. This allows us to skip tabs entirely if they have no accessible fields.
- **Pre-filter palette items**: Added a pre-filtering step for palette fields to only include items that are accessible, preventing palettes with no accessible children from being rendered.
- **Skip empty tabs and palettes**: Added conditional checks to skip rendering tab headers and palette headers when their content is empty after filtering.
- **Added comprehensive test**: Implemented `testEmptyTabsAreNotRendered()` to verify that:
  - Tabs with no fields (like sys_file_metadata's "Extended" tab) are not rendered
  - No orphan tab headers exist without at least one field or palette below them

## Implementation Details
The refactoring maintains the same output format and field processing logic while improving the structure:
- Tab content is now built in a temporary buffer before being appended to the final result
- Empty tabs are skipped with a `continue` statement after checking if `$tabContent` is empty
- The same pattern is applied to palettes to avoid rendering palette headers with no accessible fields
- All whitespace and formatting changes are preserved for consistency

https://claude.ai/code/session_013QNGQpUdj3jAXNqY3fJSds