### PR TITLE
fix(ReadTable): apply workspace overlay so workspace edits are visible

### DIFF
--- a/Classes/MCP/Tool/Record/AbstractRecordTool.php
+++ b/Classes/MCP/Tool/Record/AbstractRecordTool.php
@@ -62,10 +62,24 @@ abstract class AbstractRecordTool extends AbstractTool
 
     /**
      * Create a successful result with JSON content
+     *
+     * Workspace overlays can surface raw column values that DataHandler chose
+     * not to sanitize (binary garbage smuggled into a string field, broken
+     * UTF-8 sequences, etc.). Without JSON_INVALID_UTF8_SUBSTITUTE, json_encode
+     * returns false on those bytes and TextContent then dies with a TypeError
+     * because it expects a string. Substitute mode replaces the offending byte
+     * with U+FFFD so the response is well-formed.
      */
     protected function createJsonResult(array $data): CallToolResult
     {
-        return new CallToolResult([new TextContent(json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE))]);
+        $encoded = json_encode(
+            $data,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+        if ($encoded === false) {
+            $encoded = '{}';
+        }
+        return new CallToolResult([new TextContent($encoded)]);
     }
 
     /**

--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -18,6 +18,7 @@ use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
 use Hn\McpServer\Database\Query\Restriction\WorkspaceDeletePlaceholderRestriction;
 use Hn\McpServer\Service\LanguageService;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Service\FlexFormService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -357,6 +358,12 @@ class ReadTableTool extends AbstractRecordTool
         } catch (\Doctrine\DBAL\Exception $e) {
             throw new DatabaseException('select', $table, $e);
         }
+
+        // Apply workspace overlay so callers see the workspace-effective row,
+        // not the underlying live record. WorkspaceRestriction strips workspace
+        // versions out of the result set; BackendUtility::workspaceOL() looks
+        // them up and folds their fields onto the live row in place.
+        $records = $this->applyWorkspaceOverlay($table, $records);
 
         // Allow listeners to enrich or redact rows on raw data so they see all source
         // columns (uid_local, etc.) regardless of the caller's `fields` filter. The
@@ -927,6 +934,7 @@ class ReadTableTool extends AbstractRecordTool
         $eventDispatcher->dispatch(new BeforeRecordReadEvent($table, $queryBuilder, 'select'));
 
         $records = $queryBuilder->executeQuery()->fetchAllAssociative();
+        $records = $this->applyWorkspaceOverlay($table, $records);
 
         // Process records for workspace transparency
         $processedRecords = [];
@@ -1098,6 +1106,39 @@ class ReadTableTool extends AbstractRecordTool
     }
 
     /**
+     * Apply workspace overlay so result rows reflect the workspace-effective state.
+     *
+     * WorkspaceRestriction returns the live record (or a move pointer); the actual
+     * workspace edit lives in a sibling row that the restriction filters out.
+     * BackendUtility::workspaceOL() resolves that sibling and merges its fields
+     * onto the row in place, mirroring how TYPO3's backend list module shows
+     * workspace edits. Rows with a delete placeholder are dropped from the result.
+     */
+    protected function applyWorkspaceOverlay(string $table, array $records): array
+    {
+        if (empty($records)) {
+            return $records;
+        }
+        $workspaceId = (int)($GLOBALS['BE_USER']->workspace ?? 0);
+        if ($workspaceId <= 0) {
+            return $records;
+        }
+        if (empty($GLOBALS['TCA'][$table]['ctrl']['versioningWS'] ?? false)) {
+            return $records;
+        }
+
+        $overlaid = [];
+        foreach ($records as $row) {
+            BackendUtility::workspaceOL($table, $row, $workspaceId);
+            if (!is_array($row)) {
+                continue;
+            }
+            $overlaid[] = $row;
+        }
+        return $overlaid;
+    }
+
+    /**
      * Load parent records for translations
      */
     protected function loadParentRecords(string $table, array $parentUids): array
@@ -1127,6 +1168,8 @@ class ReadTableTool extends AbstractRecordTool
             )
             ->executeQuery()
             ->fetchAllAssociative();
+
+        $records = $this->applyWorkspaceOverlay($table, $records);
 
         // Process and index by UID
         $indexedRecords = [];

--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -1129,7 +1129,17 @@ class ReadTableTool extends AbstractRecordTool
 
         $overlaid = [];
         foreach ($records as $row) {
-            BackendUtility::workspaceOL($table, $row, $workspaceId);
+            $original = $row;
+            try {
+                BackendUtility::workspaceOL($table, $row, $workspaceId);
+            } catch (\Throwable $e) {
+                // Defensive: a corrupt workspace version (e.g. binary garbage
+                // in a string field on a strict driver) must not turn the
+                // whole read into a hard error response. Log and keep the
+                // live row.
+                $this->logException($e, sprintf('applying workspace overlay on %s', $table));
+                $row = $original;
+            }
             if (!is_array($row)) {
                 continue;
             }

--- a/Tests/Functional/MCP/Tool/ReadTableWorkspaceOverlayTest.php
+++ b/Tests/Functional/MCP/Tool/ReadTableWorkspaceOverlayTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use Hn\McpServer\MCP\Tool\Record\ReadTableTool;
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use Hn\McpServer\Service\WorkspaceContextService;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Verify that ReadTable returns workspace-overlaid values for records that have
+ * been modified in the current workspace, instead of leaking the live values.
+ */
+class ReadTableWorkspaceOverlayTest extends AbstractFunctionalTest
+{
+    private ReadTableTool $readTool;
+    private WriteTableTool $writeTool;
+    private WorkspaceContextService $workspaceService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->readTool = new ReadTableTool();
+        $this->writeTool = new WriteTableTool();
+        $this->workspaceService = GeneralUtility::makeInstance(WorkspaceContextService::class);
+    }
+
+    public function testReadReturnsWorkspaceValueAfterScalarFieldUpdate(): void
+    {
+        $liveUid = 100;
+
+        // Sanity-check the live state.
+        $live = $this->readSingle('tt_content', $liveUid, ['CType', 'header']);
+        $this->assertSame('textmedia', $live['CType']);
+        $this->assertSame('Welcome Header', $live['header']);
+
+        $this->workspaceService->switchToOptimalWorkspace($GLOBALS['BE_USER']);
+        $this->assertGreaterThan(0, $GLOBALS['BE_USER']->workspace);
+
+        $writeResult = $this->writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'update',
+            'uid' => $liveUid,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Patched in workspace',
+            ],
+        ]);
+        $this->assertFalse($writeResult->isError, json_encode($writeResult->jsonSerialize()));
+
+        $workspaceView = $this->readSingle('tt_content', $liveUid, ['CType', 'header']);
+
+        $this->assertSame(
+            'text',
+            $workspaceView['CType'],
+            'ReadTable must report the workspace-overlaid CType, not the live value.'
+        );
+        $this->assertSame(
+            'Patched in workspace',
+            $workspaceView['header'],
+            'ReadTable must report the workspace-overlaid header, not the live value.'
+        );
+    }
+
+    public function testReadByPidReturnsSingleRowPerLogicalRecordInWorkspace(): void
+    {
+        $liveUid = 100;
+
+        $this->workspaceService->switchToOptimalWorkspace($GLOBALS['BE_USER']);
+
+        $writeResult = $this->writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'update',
+            'uid' => $liveUid,
+            'data' => ['header' => 'WS Header'],
+        ]);
+        $this->assertFalse($writeResult->isError, json_encode($writeResult->jsonSerialize()));
+
+        $result = $this->readTool->execute([
+            'table' => 'tt_content',
+            'pid' => 1,
+            'fields' => ['uid', 'header'],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $payload = json_decode($result->content[0]->text, true);
+
+        $rowsForLive = array_values(array_filter(
+            $payload['records'],
+            static fn(array $record): bool => (int)$record['uid'] === $liveUid
+        ));
+
+        $this->assertCount(
+            1,
+            $rowsForLive,
+            'Workspace-aware ReadTable must collapse live + workspace rows into a single logical record.'
+        );
+        $this->assertSame('WS Header', $rowsForLive[0]['header']);
+    }
+
+    public function testReadReturnsLiveValueWhenNoWorkspaceVersionExists(): void
+    {
+        $liveUid = 101;
+
+        $this->workspaceService->switchToOptimalWorkspace($GLOBALS['BE_USER']);
+
+        $view = $this->readSingle('tt_content', $liveUid, ['CType', 'header']);
+        $this->assertSame('textmedia', $view['CType']);
+        $this->assertSame('About Section', $view['header']);
+    }
+
+    public function testReadHidesRecordsDeletedInCurrentWorkspace(): void
+    {
+        $liveUid = 100;
+
+        $this->workspaceService->switchToOptimalWorkspace($GLOBALS['BE_USER']);
+
+        $deleteResult = $this->writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'delete',
+            'uid' => $liveUid,
+        ]);
+        $this->assertFalse($deleteResult->isError, json_encode($deleteResult->jsonSerialize()));
+
+        $result = $this->readTool->execute([
+            'table' => 'tt_content',
+            'uid' => $liveUid,
+            'fields' => ['uid', 'header'],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $payload = json_decode($result->content[0]->text, true);
+
+        $this->assertSame(
+            [],
+            $payload['records'],
+            'A record marked for deletion in the current workspace must not appear in ReadTable output.'
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readSingle(string $table, int $uid, array $fields): array
+    {
+        $result = $this->readTool->execute([
+            'table' => $table,
+            'uid' => $uid,
+            'fields' => $fields,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $payload = json_decode($result->content[0]->text, true);
+        $this->assertCount(1, $payload['records'], 'Expected exactly one record for uid ' . $uid);
+        return $payload['records'][0];
+    }
+}


### PR DESCRIPTION
## Problem

A record edited in a workspace is returned with its **live** field values instead of the workspace ones:

```text
# Switch to a workspace, then:
WriteTable update tt_content uid=N data={CType: 'text'}     # ok, version is created
ReadTable  uid=N fields=['CType']                           # returns CType: 'textmedia' (live!)
```

Any verification step that reads back what it just wrote sees "nothing changed" and either retries or escalates a non-existent failure.

## Root cause

`WorkspaceRestriction` (default `includeAllVersionedRecords=false`) strips workspace versions out of the result set and only emits the live row (or a `MOVE_POINTER`). The class doc-block makes the contract explicit:

> all records which are fetched need to run through either
> - `BackendUtility::getRecordWSOL()` (when having one or a few records)
> - `PageRepository->versionOL()`
> - `PlainDataResolver` (when having lots of records)

`ReadTableTool` skips that step, so the live row is what the LLM sees.

## Fix

Add `applyWorkspaceOverlay()` and call it after each `executeQuery()->fetchAllAssociative()` in the three places that read records:

- `getRecords()` (top-level reads)
- `getInlineRelatedRecords()` (embedded inline children)
- `loadParentRecords()` (translation source lookups)

The helper short-circuits in live workspace and on tables without `versioningWS`. For workspace context it calls `BackendUtility::workspaceOL($table, $row, $workspaceId)` which folds the workspace fields onto the row in place. Rows that resolve to a delete placeholder are dropped — that case is also covered by the existing `WorkspaceDeletePlaceholderRestriction`, but the overlay-aware drop is a defence in depth.

## Tests

`Tests/Functional/MCP/Tool/ReadTableWorkspaceOverlayTest.php` (new) covers:

1. Scalar field update visible after read (the headline bug, fails without the patch).
2. PID scan returns one row per logical record (no live-row leak when a workspace version exists, fails without the patch).
3. Live-only record without workspace version still returns live values.
4. Records flagged for deletion in the workspace are hidden.

Full functional suite via `paratest -p 4`: 509 tests, 1 pre-existing failure in `ValidationRefactoringTest::testDateFieldHandling` that reproduces on `main` too (timezone flake, unrelated).