### PR TITLE
Filter plumbing fields from embedded inline children

### DIFF
--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -402,26 +402,20 @@ class ReadTableTool extends AbstractRecordTool
      *    where without this clamp every TYPO3 plumbing column (t3ver_*, l10n_*) would
      *    leak into the response.
      *
-     *    For inline children of hidden tables (sys_file_metadata, sys_file_reference)
-     *    the filter is tighter: essentials are dropped (the parent provides context),
-     *    the foreign reference back to the parent is dropped, and TCA columns of
-     *    type passthrough / category / none are dropped as virtual or rendering-only.
-     *
      * 2. Caller's `fields` whitelist — optional second pass, narrows further. uid is
-     *    always added. Skipped for embedded children (the LLM cannot whitelist them).
+     *    always added.
+     *
+     *    Inline children of hidden tables flow through this same whitelist with a
+     *    default computed by TableAccessService::getEmbeddedRecordFields(), which
+     *    drops plumbing/virtual TCA columns the LLM has no use for.
      *
      * @param array $record Raw database row
      * @param string $table Table name
      * @param array $requestedFields User-provided field whitelist from the "fields" tool parameter.
      *                               Empty = no additional filtering (default behavior).
-     * @param string|null $embeddedForeignField When set, the record is being processed as
-     *                                          an embedded child of a hidden table; the
-     *                                          tighter filter applies and this is the
-     *                                          inline foreign_field name to drop.
      */
-    protected function processRecord(array $record, string $table, array $requestedFields = [], ?string $embeddedForeignField = null): array
+    protected function processRecord(array $record, string $table, array $requestedFields = []): array
     {
-        $isEmbedded = $embeddedForeignField !== null;
         $processedRecord = [];
 
         // For workspace transparency, replace workspace UID with live UID
@@ -434,29 +428,19 @@ class ReadTableTool extends AbstractRecordTool
             // No change needed
         }
 
-        // Ensure uid is always in the requested fields when a field list is specified.
-        // Embedded children ignore the requested field list (the caller cannot reach
-        // through inline relations — uid is always emitted regardless).
-        if (!$isEmbedded && !empty($requestedFields) && !in_array('uid', $requestedFields)) {
+        // Ensure uid is always in the requested fields when a field list is specified
+        if (!empty($requestedFields) && !in_array('uid', $requestedFields)) {
             $requestedFields[] = 'uid';
         }
 
-        if ($isEmbedded) {
-            // Inline children: only TCA-advertised fields, minus plumbing/virtual columns.
-            // Essentials are NOT merged in — the parent provides language/timestamp context.
-            $availableFields = $this->tableAccessService->getAvailableFields($table, '');
-            $excluded = $this->tableAccessService->getEmbeddedRecordExclusions($table, $embeddedForeignField);
-            $allowedFields = array_diff(array_keys($availableFields), $excluded);
-            $allowedFields[] = 'uid';
-        } else {
-            // Top-level reads: schema fields + essential ctrl fields (uid, pid, timestamps,
-            // etc.) since they are valid to read but are typically absent from TCA showitem.
-            $essentialFields = $this->tableAccessService->getEssentialFields($table);
-            $typeField = $this->tableAccessService->getTypeFieldName($table);
-            $recordType = ($typeField && isset($record[$typeField])) ? (string)$record[$typeField] : '';
-            $availableFields = $this->tableAccessService->getAvailableFields($table, $recordType);
-            $allowedFields = array_unique(array_merge(array_keys($availableFields), $essentialFields));
-        }
+        // Build the set of fields the schema lets through. Always include essential
+        // ctrl fields (uid, pid, timestamps, etc.) since they are valid to read but
+        // are typically absent from TCA showitem definitions.
+        $essentialFields = $this->tableAccessService->getEssentialFields($table);
+        $typeField = $this->tableAccessService->getTypeFieldName($table);
+        $recordType = ($typeField && isset($record[$typeField])) ? (string)$record[$typeField] : '';
+        $availableFields = $this->tableAccessService->getAvailableFields($table, $recordType);
+        $allowedFields = array_unique(array_merge(array_keys($availableFields), $essentialFields));
 
         // Process each field
         foreach ($record as $field => $value) {
@@ -487,9 +471,8 @@ class ReadTableTool extends AbstractRecordTool
                 continue;
             }
 
-            // Skip fields not in the requested field list (top-level reads only;
-            // embedded children always emit their full filtered set).
-            if (!$isEmbedded && !empty($requestedFields) && !in_array($field, $requestedFields)) {
+            // Skip fields not in the requested field list
+            if (!empty($requestedFields) && !in_array($field, $requestedFields)) {
                 continue;
             }
 
@@ -964,12 +947,17 @@ class ReadTableTool extends AbstractRecordTool
 
         $records = $queryBuilder->executeQuery()->fetchAllAssociative();
 
-        // Process records for workspace transparency
+        // Embedded children get a curated default whitelist passed through the
+        // standard requestedFields filter. The caller still drops the foreign
+        // field at embedding time — it is re-injected here only so grouping by
+        // parent UID works.
+        $requestedFields = $embedAsChildren
+            ? $this->tableAccessService->getEmbeddedRecordFields($table, $foreignField)
+            : [];
+
         $processedRecords = [];
         foreach ($records as $record) {
-            $processed = $embedAsChildren
-                ? $this->processRecord($record, $table, [], $foreignField)
-                : $this->processRecord($record, $table);
+            $processed = $this->processRecord($record, $table, $requestedFields);
 
             // Ensure the foreign field is always included if it exists in the raw record
             if (isset($record[$foreignField]) && !isset($processed[$foreignField])) {

--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -948,15 +948,22 @@ class ReadTableTool extends AbstractRecordTool
         $records = $queryBuilder->executeQuery()->fetchAllAssociative();
 
         // Embedded children get a curated default whitelist passed through the
-        // standard requestedFields filter. The caller still drops the foreign
-        // field at embedding time — it is re-injected here only so grouping by
-        // parent UID works.
-        $requestedFields = $embedAsChildren
-            ? $this->tableAccessService->getEmbeddedRecordFields($table, $foreignField)
-            : [];
+        // standard requestedFields filter. The whitelist is computed per record
+        // off the row's own type so children of different sub-types in the same
+        // batch each keep their type-specific fields. The foreign field is
+        // re-injected below only so grouping by parent UID works; the caller
+        // drops it at embedding time.
+        $typeField = $embedAsChildren ? $this->tableAccessService->getTypeFieldName($table) : null;
 
         $processedRecords = [];
         foreach ($records as $record) {
+            if ($embedAsChildren) {
+                $recordType = ($typeField && isset($record[$typeField])) ? (string)$record[$typeField] : '';
+                $requestedFields = $this->tableAccessService->getEmbeddedRecordFields($table, $foreignField, $recordType);
+            } else {
+                $requestedFields = [];
+            }
+
             $processed = $this->processRecord($record, $table, $requestedFields);
 
             // Ensure the foreign field is always included if it exists in the raw record

--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -402,16 +402,26 @@ class ReadTableTool extends AbstractRecordTool
      *    where without this clamp every TYPO3 plumbing column (t3ver_*, l10n_*) would
      *    leak into the response.
      *
+     *    For inline children of hidden tables (sys_file_metadata, sys_file_reference)
+     *    the filter is tighter: essentials are dropped (the parent provides context),
+     *    the foreign reference back to the parent is dropped, and TCA columns of
+     *    type passthrough / category / none are dropped as virtual or rendering-only.
+     *
      * 2. Caller's `fields` whitelist — optional second pass, narrows further. uid is
-     *    always added.
+     *    always added. Skipped for embedded children (the LLM cannot whitelist them).
      *
      * @param array $record Raw database row
      * @param string $table Table name
      * @param array $requestedFields User-provided field whitelist from the "fields" tool parameter.
      *                               Empty = no additional filtering (default behavior).
+     * @param string|null $embeddedForeignField When set, the record is being processed as
+     *                                          an embedded child of a hidden table; the
+     *                                          tighter filter applies and this is the
+     *                                          inline foreign_field name to drop.
      */
-    protected function processRecord(array $record, string $table, array $requestedFields = []): array
+    protected function processRecord(array $record, string $table, array $requestedFields = [], ?string $embeddedForeignField = null): array
     {
+        $isEmbedded = $embeddedForeignField !== null;
         $processedRecord = [];
 
         // For workspace transparency, replace workspace UID with live UID
@@ -424,19 +434,29 @@ class ReadTableTool extends AbstractRecordTool
             // No change needed
         }
 
-        // Ensure uid is always in the requested fields when a field list is specified
-        if (!empty($requestedFields) && !in_array('uid', $requestedFields)) {
+        // Ensure uid is always in the requested fields when a field list is specified.
+        // Embedded children ignore the requested field list (the caller cannot reach
+        // through inline relations — uid is always emitted regardless).
+        if (!$isEmbedded && !empty($requestedFields) && !in_array('uid', $requestedFields)) {
             $requestedFields[] = 'uid';
         }
 
-        // Build the set of fields the schema lets through. Always include essential
-        // ctrl fields (uid, pid, timestamps, etc.) since they are valid to read but
-        // are typically absent from TCA showitem definitions.
-        $essentialFields = $this->tableAccessService->getEssentialFields($table);
-        $typeField = $this->tableAccessService->getTypeFieldName($table);
-        $recordType = ($typeField && isset($record[$typeField])) ? (string)$record[$typeField] : '';
-        $availableFields = $this->tableAccessService->getAvailableFields($table, $recordType);
-        $allowedFields = array_unique(array_merge(array_keys($availableFields), $essentialFields));
+        if ($isEmbedded) {
+            // Inline children: only TCA-advertised fields, minus plumbing/virtual columns.
+            // Essentials are NOT merged in — the parent provides language/timestamp context.
+            $availableFields = $this->tableAccessService->getAvailableFields($table, '');
+            $excluded = $this->tableAccessService->getEmbeddedRecordExclusions($table, $embeddedForeignField);
+            $allowedFields = array_diff(array_keys($availableFields), $excluded);
+            $allowedFields[] = 'uid';
+        } else {
+            // Top-level reads: schema fields + essential ctrl fields (uid, pid, timestamps,
+            // etc.) since they are valid to read but are typically absent from TCA showitem.
+            $essentialFields = $this->tableAccessService->getEssentialFields($table);
+            $typeField = $this->tableAccessService->getTypeFieldName($table);
+            $recordType = ($typeField && isset($record[$typeField])) ? (string)$record[$typeField] : '';
+            $availableFields = $this->tableAccessService->getAvailableFields($table, $recordType);
+            $allowedFields = array_unique(array_merge(array_keys($availableFields), $essentialFields));
+        }
 
         // Process each field
         foreach ($record as $field => $value) {
@@ -467,8 +487,9 @@ class ReadTableTool extends AbstractRecordTool
                 continue;
             }
 
-            // Skip fields not in the requested field list
-            if (!empty($requestedFields) && !in_array($field, $requestedFields)) {
+            // Skip fields not in the requested field list (top-level reads only;
+            // embedded children always emit their full filtered set).
+            if (!$isEmbedded && !empty($requestedFields) && !in_array($field, $requestedFields)) {
                 continue;
             }
 
@@ -831,7 +852,7 @@ class ReadTableTool extends AbstractRecordTool
         // (e.g., sys_file_reference uses tablenames/fieldname to distinguish which field owns each reference)
         $foreignSortBy = $fieldConfig['config']['foreign_sortby'] ?? '';
         $foreignMatchFields = $fieldConfig['config']['foreign_match_fields'] ?? [];
-        $relatedRecords = $this->getInlineRelatedRecords($foreignTable, $foreignField, $recordUids, $foreignSortBy, $foreignMatchFields);
+        $relatedRecords = $this->getInlineRelatedRecords($foreignTable, $foreignField, $recordUids, $foreignSortBy, $foreignMatchFields, $isHiddenTable);
 
         // Allow listeners to enrich or redact inline children (e.g. attach file metadata)
         if (!empty($relatedRecords)) {
@@ -859,8 +880,16 @@ class ReadTableTool extends AbstractRecordTool
             if ($uid !== null) {
                 if (isset($groupedRecords[$uid]) && !empty($groupedRecords[$uid])) {
                     if ($isHiddenTable) {
-                        // Embed full records for hidden tables (like sys_file_reference)
-                        $record[$fieldName] = $groupedRecords[$uid];
+                        // Embed full records for hidden tables (like sys_file_reference).
+                        // The foreign field that links each child back to its parent is
+                        // kept until grouping is done, then dropped — the parent is
+                        // already known by virtue of the embedding.
+                        $cleaned = [];
+                        foreach ($groupedRecords[$uid] as $child) {
+                            unset($child[$foreignField]);
+                            $cleaned[] = $child;
+                        }
+                        $record[$fieldName] = $cleaned;
                     } else {
                         // Return only UIDs for independent tables (like tt_content)
                         $record[$fieldName] = array_column($groupedRecords[$uid], 'uid');
@@ -876,9 +905,16 @@ class ReadTableTool extends AbstractRecordTool
     }
 
     /**
-     * Get inline related records
+     * Get inline related records.
+     *
+     * @param bool $embedAsChildren When true, the caller will embed the full records
+     *                              into the parent (hidden tables). processRecord
+     *                              applies the tighter "embedded" filter so plumbing
+     *                              and the foreign reference do not leak. The foreign
+     *                              field is re-injected here so the caller can group
+     *                              by parent UID; it is dropped at embedding time.
      */
-    protected function getInlineRelatedRecords(string $table, string $foreignField, array $parentUids, string $foreignSortBy = '', array $foreignMatchFields = []): array
+    protected function getInlineRelatedRecords(string $table, string $foreignField, array $parentUids, string $foreignSortBy = '', array $foreignMatchFields = [], bool $embedAsChildren = false): array
     {
         if (empty($parentUids)) {
             return [];
@@ -931,7 +967,9 @@ class ReadTableTool extends AbstractRecordTool
         // Process records for workspace transparency
         $processedRecords = [];
         foreach ($records as $record) {
-            $processed = $this->processRecord($record, $table);
+            $processed = $embedAsChildren
+                ? $this->processRecord($record, $table, [], $foreignField)
+                : $this->processRecord($record, $table);
 
             // Ensure the foreign field is always included if it exists in the raw record
             if (isset($record[$foreignField]) && !isset($processed[$foreignField])) {

--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -846,10 +846,13 @@ class TableAccessService implements SingletonInterface
      *
      * Computed read-only fields registered via AfterSchemaLoadEvent
      * (file_name, public_url, ...) are not in TCA columns and therefore stay.
+     *
+     * The caller passes each child's own type so sub-schema-specific columns
+     * are not silently dropped on a mixed-type child set.
      */
-    public function getEmbeddedRecordFields(string $table, string $foreignField = ''): array
+    public function getEmbeddedRecordFields(string $table, string $foreignField = '', string $recordType = ''): array
     {
-        $availableFields = $this->getAvailableFields($table, '');
+        $availableFields = $this->getAvailableFields($table, $recordType);
 
         $ctrl = $GLOBALS['TCA'][$table]['ctrl'] ?? [];
         $exclude = ['pid'];

--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -827,6 +827,50 @@ class TableAccessService implements SingletonInterface
     }
     
     /**
+     * Fields to drop from inline children of hidden tables.
+     *
+     * When a hidden table (e.g. sys_file_metadata) is embedded in a parent record,
+     * the parent already provides language/workspace/timestamp context. Surfacing
+     * those fields again, plus the foreign reference back to the parent and TCA
+     * columns that are virtual or DB-only, is just noise for the LLM.
+     *
+     * Excluded:
+     *  - pid (always plumbing for embedded children)
+     *  - ctrl-registered tracking fields (tstamp, crdate, languageField,
+     *    transOrigPointerField, transOrigDiffSourceField, translationSource)
+     *  - the foreign_field that links back to the parent
+     *  - TCA columns of type passthrough / category / none (virtual or
+     *    rendering-only — no useful value for the LLM)
+     *
+     * Computed read-only fields registered via AfterSchemaLoadEvent
+     * (file_name, public_url, ...) are not in TCA columns and therefore stay.
+     */
+    public function getEmbeddedRecordExclusions(string $table, string $foreignField = ''): array
+    {
+        $ctrl = $GLOBALS['TCA'][$table]['ctrl'] ?? [];
+        $exclude = ['pid'];
+
+        foreach (['tstamp', 'crdate', 'languageField', 'transOrigPointerField', 'transOrigDiffSourceField', 'translationSource'] as $ctrlKey) {
+            if (!empty($ctrl[$ctrlKey])) {
+                $exclude[] = $ctrl[$ctrlKey];
+            }
+        }
+
+        if ($foreignField !== '') {
+            $exclude[] = $foreignField;
+        }
+
+        foreach ($GLOBALS['TCA'][$table]['columns'] ?? [] as $name => $config) {
+            $type = $config['config']['type'] ?? '';
+            if (in_array($type, ['passthrough', 'category', 'none'], true)) {
+                $exclude[] = $name;
+            }
+        }
+
+        return array_values(array_unique($exclude));
+    }
+
+    /**
      * Get essential fields for a table (fields that should always be included)
      */
     public function getEssentialFields(string $table): array

--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -827,14 +827,16 @@ class TableAccessService implements SingletonInterface
     }
     
     /**
-     * Fields to drop from inline children of hidden tables.
+     * Default field whitelist for inline children of hidden tables.
      *
-     * When a hidden table (e.g. sys_file_metadata) is embedded in a parent record,
-     * the parent already provides language/workspace/timestamp context. Surfacing
-     * those fields again, plus the foreign reference back to the parent and TCA
-     * columns that are virtual or DB-only, is just noise for the LLM.
+     * Returned in the same shape as the user-facing `fields` parameter, so the
+     * caller can pass it straight through to the existing requestedFields filter
+     * in ReadTableTool::processRecord().
      *
-     * Excluded:
+     * The parent record already provides language/workspace/timestamp context;
+     * surfacing those fields, plus the foreign reference back to the parent and
+     * TCA columns that are virtual or DB-only, is noise for the LLM. So we
+     * advertise every available field except:
      *  - pid (always plumbing for embedded children)
      *  - ctrl-registered tracking fields (tstamp, crdate, languageField,
      *    transOrigPointerField, transOrigDiffSourceField, translationSource)
@@ -845,8 +847,10 @@ class TableAccessService implements SingletonInterface
      * Computed read-only fields registered via AfterSchemaLoadEvent
      * (file_name, public_url, ...) are not in TCA columns and therefore stay.
      */
-    public function getEmbeddedRecordExclusions(string $table, string $foreignField = ''): array
+    public function getEmbeddedRecordFields(string $table, string $foreignField = ''): array
     {
+        $availableFields = $this->getAvailableFields($table, '');
+
         $ctrl = $GLOBALS['TCA'][$table]['ctrl'] ?? [];
         $exclude = ['pid'];
 
@@ -867,7 +871,7 @@ class TableAccessService implements SingletonInterface
             }
         }
 
-        return array_values(array_unique($exclude));
+        return array_values(array_diff(array_keys($availableFields), $exclude));
     }
 
     /**

--- a/Tests/Functional/Fixtures/sys_file_metadata.csv
+++ b/Tests/Functional/Fixtures/sys_file_metadata.csv
@@ -1,0 +1,3 @@
+"sys_file_metadata"
+,"uid","pid","tstamp","crdate","sys_language_uid","l10n_parent","l10n_diffsource","title","alternative","description","categories","file","width","height"
+,1,0,1700000000,1700000000,0,0,,"Test Image Title","Alt text for test","Description text",0,1,1868,1261

--- a/Tests/Functional/MCP/Tool/FileReferenceTest.php
+++ b/Tests/Functional/MCP/Tool/FileReferenceTest.php
@@ -32,6 +32,7 @@ class FileReferenceTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/../../Fixtures/be_users.csv');
         $this->importCSVDataSet(__DIR__ . '/../../Fixtures/pages.csv');
         $this->importCSVDataSet(__DIR__ . '/../../Fixtures/sys_file.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/sys_file_metadata.csv');
         $this->importCSVDataSet(__DIR__ . '/../../Fixtures/tt_content.csv');
         $this->importCSVDataSet(__DIR__ . '/../../Fixtures/sys_file_reference.csv');
         $this->setUpBackendUser(1);
@@ -399,6 +400,51 @@ class FileReferenceTest extends FunctionalTestCase
         // Option a: inline children always include enrichment regardless of fields.
         $this->assertArrayHasKey('public_url', $ref);
         $this->assertArrayHasKey('file_name', $ref);
+    }
+
+    /**
+     * Embedded sys_file_metadata used to leak every plumbing column the LLM has
+     * no use for (pid, tstamp, crdate, sys_language_uid, l10n_parent,
+     * l10n_diffsource, categories, file). The parent sys_file already provides
+     * that context — the embedded child should expose only the user-visible
+     * data fields plus uid.
+     */
+    public function testInlineSysFileMetadataExposesOnlyDataFields(): void
+    {
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $result = $readTool->execute([
+            'table' => 'sys_file',
+            'uid' => 1,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $file = json_decode($result->content[0]->text, true)['records'][0];
+        $this->assertArrayHasKey('metadata', $file);
+        $this->assertCount(1, $file['metadata']);
+        $meta = $file['metadata'][0];
+
+        // Plumbing and virtual columns must be gone.
+        foreach ([
+            'pid',
+            'tstamp',
+            'crdate',
+            'sys_language_uid',
+            'l10n_parent',
+            'l10n_diffsource',
+            'categories',
+            'file',
+            'fileinfo',
+        ] as $leaked) {
+            $this->assertArrayNotHasKey($leaked, $meta, "embedded metadata should not expose '$leaked'");
+        }
+
+        // The data fields the LLM actually cares about must remain.
+        $this->assertSame(1, $meta['uid']);
+        $this->assertSame('Test Image Title', $meta['title']);
+        $this->assertSame('Alt text for test', $meta['alternative']);
+        $this->assertSame('Description text', $meta['description']);
+        $this->assertSame(1868, $meta['width']);
+        $this->assertSame(1261, $meta['height']);
     }
 
     /**

--- a/Tests/Functional/NewsExtension/NewsLinkInlineTest.php
+++ b/Tests/Functional/NewsExtension/NewsLinkInlineTest.php
@@ -98,29 +98,27 @@ class NewsLinkInlineTest extends FunctionalTestCase
             $linksByTitle[$link['title']] = $link;
         }
         
-        // Verify External link
+        // Verify External link. The foreign field 'parent' is intentionally
+        // dropped from embedded children — the parent is implied by the embedding.
         $this->assertArrayHasKey('External link', $linksByTitle);
         $externalLink = $linksByTitle['External link'];
         $this->assertArrayHasKey('uid', $externalLink);
         $this->assertArrayHasKey('uri', $externalLink);
         $this->assertArrayHasKey('description', $externalLink);
-        $this->assertArrayHasKey('parent', $externalLink);
+        $this->assertArrayNotHasKey('parent', $externalLink);
         $this->assertEquals('https://example.com', $externalLink['uri']);
         $this->assertEquals('Link to external website', $externalLink['description']);
-        $this->assertEquals($newsUid, $externalLink['parent']);
-        
+
         // Verify Internal page link
         $this->assertArrayHasKey('Internal page', $linksByTitle);
         $internalLink = $linksByTitle['Internal page'];
         $this->assertEquals('t3://page?uid=42', $internalLink['uri']);
         $this->assertEquals('Link to internal page', $internalLink['description']);
-        $this->assertEquals($newsUid, $internalLink['parent']);
-        
+
         // Verify Email link (no description)
         $this->assertArrayHasKey('Email link', $linksByTitle);
         $emailLink = $linksByTitle['Email link'];
         $this->assertEquals('mailto:info@example.com', $emailLink['uri']);
-        $this->assertEquals($newsUid, $emailLink['parent']);
     }
 
     /**

--- a/Tests/Functional/Service/TableAccessServiceFieldAccessTest.php
+++ b/Tests/Functional/Service/TableAccessServiceFieldAccessTest.php
@@ -186,6 +186,25 @@ class TableAccessServiceFieldAccessTest extends FunctionalTestCase
     }
 
     /**
+     * Embedded inline children of a table with sub-schemas must each get a
+     * whitelist scoped to their own type — otherwise valid type-specific
+     * columns (e.g. tt_content.assets on textmedia) would silently drop on
+     * mixed-type child sets.
+     */
+    public function testEmbeddedRecordFieldsHonorRecordType(): void
+    {
+        // textmedia keeps the file relation (assets) and bodytext.
+        $textmedia = $this->service->getEmbeddedRecordFields('tt_content', '', 'textmedia');
+        $this->assertContains('assets', $textmedia, 'textmedia children must keep assets');
+        $this->assertContains('bodytext', $textmedia, 'textmedia children must keep bodytext');
+
+        // header has neither assets nor bodytext in its showitem.
+        $header = $this->service->getEmbeddedRecordFields('tt_content', '', 'header');
+        $this->assertNotContains('assets', $header, 'header children must not list assets');
+        $this->assertNotContains('bodytext', $header, 'header children must not list bodytext');
+    }
+
+    /**
      * ReadTable enum includes sys_file, WriteTable enum excludes it.
      */
     public function testAccessibleTablesIncludeReadOnly(): void


### PR DESCRIPTION
## Summary
This change introduces a new method `getEmbeddedRecordFields()` to filter out database plumbing and virtual TCA columns from inline children of hidden tables, ensuring the LLM only sees user-visible data fields.

## Key Changes

- **New `TableAccessService::getEmbeddedRecordFields()` method**: Computes a whitelist of fields for embedded inline children by excluding:
  - `pid` (always plumbing for embedded children)
  - Control-registered tracking fields (`tstamp`, `crdate`, `languageField`, `transOrigPointerField`, `transOrigDiffSourceField`, `translationSource`)
  - The `foreign_field` that links back to the parent
  - Virtual/rendering-only TCA columns (`passthrough`, `category`, `none` types)

- **Updated `ReadTableTool::getInlineRelatedRecords()`**: Now accepts an `$embedAsChildren` parameter and applies the embedded field whitelist via `processRecord()` when processing inline children of hidden tables.

- **Cleaned up embedded child records**: The foreign field linking children back to their parent is now removed at embedding time, since the parent context is already implied by the embedding structure.

- **Updated tests**: 
  - Added `sys_file_metadata.csv` fixture for testing
  - New test `testInlineSysFileMetadataExposesOnlyDataFields()` verifies that embedded metadata only exposes data fields (uid, title, alternative, description, width, height) and excludes plumbing columns
  - Updated `NewsLinkInlineTest` to reflect that the `parent` foreign field is no longer exposed in embedded children

## Implementation Details

The whitelist is computed once per embedded table and passed through the existing `processRecord()` filter, ensuring consistent field filtering across all inline children. The foreign field is temporarily re-injected during record fetching to enable parent-UID grouping, then removed before final embedding.

https://claude.ai/code/session_013k9ECNS2VAGkehfssqxmUo