### PR TITLE
Expose sys_file_metadata as a standalone editable table

### DIFF
--- a/Classes/EventListener/SysFileMetadataRestrictionListener.php
+++ b/Classes/EventListener/SysFileMetadataRestrictionListener.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\EventListener;
+
+use Hn\McpServer\Event\BeforeRecordReadEvent;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Restricts sys_file_metadata reads in two ways:
+ *
+ * 1. Mount restriction: a non-admin user may only see metadata for files that
+ *    are within their accessible file mounts. Implemented as a subquery on
+ *    sys_file using the same mount logic as SysFileMountRestrictionListener.
+ *
+ * 2. Orphan filter: metadata records whose `file` column points at a sys_file
+ *    uid that no longer exists are filtered out. Hard-deletion of sys_file
+ *    cascades to sys_file_metadata in the normal path, but old/inconsistent
+ *    installations can have leftovers — and the IN-subquery on sys_file gets
+ *    us this for free for both admin and non-admin users.
+ */
+final class SysFileMetadataRestrictionListener
+{
+    public function __invoke(BeforeRecordReadEvent $event): void
+    {
+        if ($event->getTable() !== 'sys_file_metadata') {
+            return;
+        }
+
+        $queryBuilder = $event->getQueryBuilder();
+
+        // Build a subquery: SELECT uid FROM sys_file WHERE <mount restriction or none>
+        // Parameters are registered on the outer QueryBuilder so the embedded
+        // SQL string keeps them bound when the wrapping query executes.
+        $subQb = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('sys_file');
+        $subQb->getRestrictions()->removeAll();
+        $subQb->select('uid')->from('sys_file');
+
+        $mountRestriction = SysFileMountRestrictionListener::buildSysFileMountRestriction($queryBuilder);
+        if ($mountRestriction !== null) {
+            $subQb->andWhere($mountRestriction);
+        }
+
+        $queryBuilder->andWhere(
+            $queryBuilder->expr()->in('file', '(' . $subQb->getSQL() . ')')
+        );
+    }
+}

--- a/Classes/EventListener/SysFileMountRestrictionListener.php
+++ b/Classes/EventListener/SysFileMountRestrictionListener.php
@@ -24,7 +24,7 @@ final class SysFileMountRestrictionListener
         }
 
         $queryBuilder = $event->getQueryBuilder();
-        $restriction = $this->buildFileMountRestriction($queryBuilder);
+        $restriction = self::buildSysFileMountRestriction($queryBuilder);
         if ($restriction !== null) {
             $queryBuilder->andWhere($restriction);
         }
@@ -35,8 +35,13 @@ final class SysFileMountRestrictionListener
      * the current user's accessible file mounts. Returns null when no
      * restriction applies (admin user). Returns an always-false expression
      * when the user has no mounts at all.
+     *
+     * Static so dependent listeners (e.g. sys_file_metadata) can reuse the
+     * exact same mount logic inside a subquery — parameters are registered
+     * on the passed-in QueryBuilder, so embedding the resulting expression
+     * via getSQL() in a wrapping query keeps them bound correctly.
      */
-    private function buildFileMountRestriction(QueryBuilder $queryBuilder): ?CompositeExpression
+    public static function buildSysFileMountRestriction(QueryBuilder $queryBuilder): ?CompositeExpression
     {
         $tableAccessService = GeneralUtility::makeInstance(TableAccessService::class);
         $isAdmin = false;

--- a/Classes/MCP/Tool/Record/AbstractRecordTool.php
+++ b/Classes/MCP/Tool/Record/AbstractRecordTool.php
@@ -104,7 +104,7 @@ abstract class AbstractRecordTool extends AbstractTool
     protected function getExtensionFromTable(string $table): string
     {
         // Core tables
-        if (in_array($table, ['pages', 'tt_content', 'sys_category', 'sys_file', 'sys_file_reference'])) {
+        if (in_array($table, ['pages', 'tt_content', 'sys_category', 'sys_file', 'sys_file_reference', 'sys_file_metadata'])) {
             return 'core';
         }
         

--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -834,9 +834,9 @@ class ReadTableTool extends AbstractRecordTool
             return;
         }
 
-        // Check if foreign table is hidden (dependent records that should be embedded)
-        $foreignTableTCA = $GLOBALS['TCA'][$foreignTable] ?? [];
-        $isHiddenTable = ($foreignTableTCA['ctrl']['hideTable'] ?? false) === true;
+        // Check if foreign table is treated as embedded inline child
+        // (TCA hideTable=true, unless overridden via additionalStandaloneTables)
+        $isHiddenTable = $this->tableAccessService->isEmbeddedChildTable($foreignTable);
 
         // Get all related records, filtering by foreign_match_fields if present
         // (e.g., sys_file_reference uses tablenames/fieldname to distinguish which field owns each reference)

--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -61,8 +61,11 @@ class ReadTableTool extends AbstractRecordTool
                 'description' => 'Filter by page ID (recommended for content tables). Omit for root-level tables like sys_file that store records at pid=0.',
             ],
             'uid' => [
-                'type' => 'integer',
-                'description' => 'Filter by record UID (use pid filter instead to read multiple records of a page)',
+                'oneOf' => [
+                    ['type' => 'integer'],
+                    ['type' => 'array', 'items' => ['type' => 'integer']],
+                ],
+                'description' => 'Filter by record UID. Pass a single integer for one record, or an array of integers to fetch several at once — useful when reading inline-relation hints like "metadata: [1, 5]". Use the pid filter to read all records of a page.',
             ],
             'where' => [
                 'type' => 'string',
@@ -126,7 +129,20 @@ class ReadTableTool extends AbstractRecordTool
         // Execute main logic
             // Extract and validate parameters
         $pid = isset($params['pid']) ? (int)$params['pid'] : null;
-        $uid = isset($params['uid']) ? (int)$params['uid'] : null;
+        // Normalize uid to int[]|null. Accept legacy single-int and the new
+        // array form so callers can read multiple records in one go (e.g.
+        // following a `metadata: [1, 5]` inline hint). When the caller did
+        // pass a uid filter but every value is non-positive, we keep the
+        // intent (filter applied) and let the query produce zero rows — the
+        // legacy single-int behaviour for `uid: -1`.
+        $uids = null;
+        if (isset($params['uid']) && $params['uid'] !== '' && $params['uid'] !== []) {
+            $rawValues = is_array($params['uid']) ? $params['uid'] : [$params['uid']];
+            $uids = array_values(array_filter(
+                array_map('intval', $rawValues),
+                fn($n) => $n > 0
+            ));
+        }
         $condition = $params['where'] ?? '';
         $limit = isset($params['limit']) ? (int)$params['limit'] : 20;
         $offset = isset($params['offset']) ? (int)$params['offset'] : 0;
@@ -163,7 +179,7 @@ class ReadTableTool extends AbstractRecordTool
         $result = $this->getRecords(
             $table,
             $pid,
-            $uid,
+            $uids,
             $condition,
             $limit,
             $offset,
@@ -189,7 +205,7 @@ class ReadTableTool extends AbstractRecordTool
     protected function getRecords(
         string $table,
         ?int $pid,
-        ?int $uid,
+        ?array $uids,
         string $condition,
         int $limit,
         int $offset,
@@ -232,27 +248,39 @@ class ReadTableTool extends AbstractRecordTool
             }
         }
 
-        // Filter by uid if specified
-        if ($uid !== null) {
-            // For workspace transparency, we need to handle both cases:
-            // 1. The UID is a workspace UID (for new records)
-            // 2. The UID is a live UID (for existing records with workspace versions)
-
-            $currentWorkspace = $GLOBALS['BE_USER']->workspace ?? 0;
-            if ($currentWorkspace > 0) {
-                // In workspace context, check both live and workspace UIDs
-                // The WorkspaceDeletePlaceholderRestriction will handle delete placeholders automatically
-                $queryBuilder->andWhere(
-                    $queryBuilder->expr()->or(
-                        $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, ParameterType::INTEGER)),
-                        $queryBuilder->expr()->eq('t3ver_oid', $queryBuilder->createNamedParameter($uid, ParameterType::INTEGER))
-                    )
-                );
+        // Filter by uid(s) if specified. Single int and array are normalised
+        // to a list — IN(...) handles both cases identically.
+        if ($uids !== null) {
+            if ($uids === []) {
+                // The caller passed a uid filter, but every value was
+                // non-positive after sanitisation. Match nothing.
+                $queryBuilder->andWhere('1 = 0');
             } else {
-                // In live workspace, just filter by UID
-                $queryBuilder->andWhere(
-                    $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, ParameterType::INTEGER))
-                );
+                $currentWorkspace = $GLOBALS['BE_USER']->workspace ?? 0;
+                if ($currentWorkspace > 0) {
+                    // In workspace context, match either the live uid or the
+                    // overlay's t3ver_oid. WorkspaceDeletePlaceholderRestriction
+                    // handles delete placeholders.
+                    $queryBuilder->andWhere(
+                        $queryBuilder->expr()->or(
+                            $queryBuilder->expr()->in(
+                                'uid',
+                                $queryBuilder->createNamedParameter($uids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
+                            ),
+                            $queryBuilder->expr()->in(
+                                't3ver_oid',
+                                $queryBuilder->createNamedParameter($uids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
+                            )
+                        )
+                    );
+                } else {
+                    $queryBuilder->andWhere(
+                        $queryBuilder->expr()->in(
+                            'uid',
+                            $queryBuilder->createNamedParameter($uids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
+                        )
+                    );
+                }
             }
         }
 
@@ -317,23 +345,32 @@ class ReadTableTool extends AbstractRecordTool
             }
         }
 
-        if ($uid !== null) {
-            // Apply the same UID filtering logic for count query
-            $currentWorkspace = $GLOBALS['BE_USER']->workspace ?? 0;
-            if ($currentWorkspace > 0) {
-                // In workspace context, check both live and workspace UIDs
-                // The WorkspaceDeletePlaceholderRestriction will handle delete placeholders automatically
-                $countQueryBuilder->andWhere(
-                    $countQueryBuilder->expr()->or(
-                        $countQueryBuilder->expr()->eq('uid', $countQueryBuilder->createNamedParameter($uid, ParameterType::INTEGER)),
-                        $countQueryBuilder->expr()->eq('t3ver_oid', $countQueryBuilder->createNamedParameter($uid, ParameterType::INTEGER))
-                    )
-                );
+        if ($uids !== null) {
+            if ($uids === []) {
+                $countQueryBuilder->andWhere('1 = 0');
             } else {
-                // In live workspace, just filter by UID
-                $countQueryBuilder->andWhere(
-                    $countQueryBuilder->expr()->eq('uid', $countQueryBuilder->createNamedParameter($uid, ParameterType::INTEGER))
-                );
+                $currentWorkspace = $GLOBALS['BE_USER']->workspace ?? 0;
+                if ($currentWorkspace > 0) {
+                    $countQueryBuilder->andWhere(
+                        $countQueryBuilder->expr()->or(
+                            $countQueryBuilder->expr()->in(
+                                'uid',
+                                $countQueryBuilder->createNamedParameter($uids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
+                            ),
+                            $countQueryBuilder->expr()->in(
+                                't3ver_oid',
+                                $countQueryBuilder->createNamedParameter($uids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
+                            )
+                        )
+                    );
+                } else {
+                    $countQueryBuilder->andWhere(
+                        $countQueryBuilder->expr()->in(
+                            'uid',
+                            $countQueryBuilder->createNamedParameter($uids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
+                        )
+                    );
+                }
             }
         }
 

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -473,9 +473,8 @@ class WriteTableTool extends AbstractRecordTool
                     }
                     
                     // Check if this is an embedded table
-                    $foreignTableTCA = $GLOBALS['TCA'][$foreignTable] ?? [];
-                    $isHiddenTable = ($foreignTableTCA['ctrl']['hideTable'] ?? false) === true;
-                    
+                    $isHiddenTable = $this->tableAccessService->isEmbeddedChildTable($foreignTable);
+
                     if ($isHiddenTable) {
                         // Collect the UIDs of created child records
                         $childUids = [];
@@ -589,9 +588,8 @@ class WriteTableTool extends AbstractRecordTool
                     }
                     
                     // Check if this is an embedded table
-                    $foreignTableTCA = $GLOBALS['TCA'][$foreignTable] ?? [];
-                    $isHiddenTable = ($foreignTableTCA['ctrl']['hideTable'] ?? false) === true;
-                    
+                    $isHiddenTable = $this->tableAccessService->isEmbeddedChildTable($foreignTable);
+
                     if ($isHiddenTable) {
                         // Collect the UIDs of created child records
                         $childUids = [];
@@ -1101,10 +1099,9 @@ class WriteTableTool extends AbstractRecordTool
                 continue;
             }
             
-            // Check if foreign table is hidden (embedded records)
-            $foreignTableTCA = $GLOBALS['TCA'][$foreignTable] ?? [];
-            $isHiddenTable = ($foreignTableTCA['ctrl']['hideTable'] ?? false) === true;
-            
+            // Check if foreign table is treated as embedded inline child
+            $isHiddenTable = $this->tableAccessService->isEmbeddedChildTable($foreignTable);
+
             if ($isHiddenTable) {
                 // Process embedded inline relations (e.g., tx_news_domain_model_link)
                 $this->processEmbeddedInlineRelations($dataMap, $foreignTable, $foreignField, $parentUid, $pid, $value, $config, $liveUid);
@@ -1404,10 +1401,9 @@ class WriteTableTool extends AbstractRecordTool
             return 'Invalid inline relation configuration: missing foreign_table';
         }
         
-        // Check if foreign table is hidden (embedded records)
-        $foreignTableTCA = $GLOBALS['TCA'][$foreignTable] ?? [];
-        $isHiddenTable = ($foreignTableTCA['ctrl']['hideTable'] ?? false) === true;
-        
+        // Check if foreign table is treated as embedded inline child
+        $isHiddenTable = $this->tableAccessService->isEmbeddedChildTable($foreignTable);
+
         // Validate each item
         foreach ($value as $index => $item) {
             if ($isHiddenTable) {

--- a/Classes/MCP/Tool/SearchTool.php
+++ b/Classes/MCP/Tool/SearchTool.php
@@ -529,8 +529,18 @@ class SearchTool extends AbstractRecordTool
                 // Check for inline fields
                 if ($fieldType === 'inline') {
                     $foreignTable = $fieldConfig['config']['foreign_table'] ?? '';
-                    
+
                     if (!empty($foreignTable) && isset($GLOBALS['TCA'][$foreignTable])) {
+                        // Only treat as inline-related when the foreign table is
+                        // still embedded into its parent. Tables exposed standalone
+                        // via additionalStandaloneTables are searched as primary
+                        // tables instead — keeping them in this path would
+                        // duplicate the search work and (worse) wrongly attribute
+                        // their hits back to the parent record they no longer
+                        // belong to.
+                        if (!$this->tableAccessService->isEmbeddedChildTable($foreignTable)) {
+                            continue;
+                        }
                         // Use TableAccessService to check if table is accessible and has searchable fields
                         if ($this->tableAccessService->canAccessTable($foreignTable) && !empty($this->getSearchableFields($foreignTable))) {
                             $inlineTables[$foreignTable] = [

--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -25,6 +25,7 @@ class TableAccessService implements SingletonInterface
     protected WorkspaceContextService $workspaceContextService;
     protected TcaSchemaFactory $tcaSchemaFactory;
     protected ?array $additionalReadOnlyTables = null;
+    protected ?array $additionalStandaloneTables = null;
 
     public function __construct()
     {
@@ -48,6 +49,44 @@ class TableAccessService implements SingletonInterface
             $this->additionalReadOnlyTables = GeneralUtility::trimExplode(',', (string)$config, true);
         }
         return $this->additionalReadOnlyTables;
+    }
+
+    /**
+     * Get the list of hideTable tables that should be exposed as standalone
+     * tables instead of being embedded into their parent's inline relation.
+     * Configured via extension settings (additionalStandaloneTables).
+     */
+    public function getAdditionalStandaloneTables(): array
+    {
+        if ($this->additionalStandaloneTables === null) {
+            try {
+                $config = GeneralUtility::makeInstance(ExtensionConfiguration::class)
+                    ->get('mcp_server', 'additionalStandaloneTables');
+            } catch (\Exception) {
+                $config = 'sys_file_metadata';
+            }
+            $this->additionalStandaloneTables = GeneralUtility::trimExplode(',', (string)$config, true);
+        }
+        return $this->additionalStandaloneTables;
+    }
+
+    /**
+     * Whether records of this table are embedded into their parent's inline
+     * relation by the read/write tools.
+     *
+     * Default: TCA `hideTable=true`. Tables listed in `additionalStandaloneTables`
+     * opt out of embedding even if their TCA marks them hidden — useful for
+     * inline structures whose translation/mount/orphan handling is too
+     * complex to be safely edited through the parent (e.g. sys_file_metadata).
+     */
+    public function isEmbeddedChildTable(string $table): bool
+    {
+        $tca = $GLOBALS['TCA'][$table] ?? [];
+        $hideTable = ($tca['ctrl']['hideTable'] ?? false) === true;
+        if (!$hideTable) {
+            return false;
+        }
+        return !in_array($table, $this->getAdditionalStandaloneTables(), true);
     }
     
     /**

--- a/Classes/Utility/TcaFormattingUtility.php
+++ b/Classes/Utility/TcaFormattingUtility.php
@@ -147,8 +147,8 @@ class TcaFormattingUtility
                     break;
                 }
 
-                $foreignTCA = $GLOBALS['TCA'][$foreignTable] ?? [];
-                $isHiddenTable = ($foreignTCA['ctrl']['hideTable'] ?? false) === true;
+                $isHiddenTable = GeneralUtility::makeInstance(TableAccessService::class)
+                    ->isEmbeddedChildTable($foreignTable);
 
                 if ($isHiddenTable) {
                     // Embedded relation: LLM writes array of record objects

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -69,6 +69,12 @@ services:
         event: Hn\McpServer\Event\BeforeRecordReadEvent
         identifier: 'mcp-server/sys-file-mount-restriction'
 
+  Hn\McpServer\EventListener\SysFileMetadataRestrictionListener:
+    tags:
+      - name: event.listener
+        event: Hn\McpServer\Event\BeforeRecordReadEvent
+        identifier: 'mcp-server/sys-file-metadata-restriction'
+
   # Explicitly configure the module controller
   Hn\McpServer\Controller\McpServerModuleController:
     public: true

--- a/Documentation/Architecture/InlineRelations.md
+++ b/Documentation/Architecture/InlineRelations.md
@@ -25,9 +25,39 @@ $result = $readTool->execute([
 
 ### 2. Embedded/Dependent Inline Relations
 - Tables that only exist as children (e.g., `sys_file_reference`, `tx_news_domain_model_link`)
-- Have `hideTable = true` in TCA
+- Have `hideTable = true` in TCA **AND** are not listed in the `additionalStandaloneTables` extension setting
 - Displayed as full embedded records in read results
 - Should be created together with parent record
+
+### 3. Standalone Exposure of `hideTable` Children
+
+Some `hideTable=true` tables have inline structure that's too complex to be safely
+edited through the parent — for example translations independent of the parent's
+language, or rows whose visibility depends on permissions of a different table.
+For these, embedding makes the parent's update path either lossy (drops
+translations the LLM didn't echo back) or unsafe (replaces rows the LLM never
+intended to touch).
+
+The extension setting `additionalStandaloneTables` opts a `hideTable` table out
+of embedding. Such tables stay hidden in the TYPO3 backend list module (TCA is
+not modified), but the MCP tools treat them as ordinary independent tables:
+
+- `ListTables` shows them
+- `ReadTable` / `WriteTable` allow direct CRUD
+- The parent's inline field collapses to a list of child UIDs, just like for
+  any independent relation
+
+`sys_file_metadata` is on this list by default. It has `hideTable=true` plus
+its own `languageField`, while its parent `sys_file` is read-only and not
+language-aware — embedding made translations invisible and edits dangerous.
+Exposing it standalone gives the LLM normal `update` and `translate` semantics
+on title/alternative/description, while the read path on `sys_file` still
+yields `metadata: [<uid>, ...]` as a discovery hint.
+
+Mount restrictions on `sys_file` propagate transitively to
+`sys_file_metadata` via a subquery in `SysFileMetadataRestrictionListener` —
+non-admin users only see metadata for files they could read on `sys_file`.
+The same subquery filters orphaned metadata pointing at non-existent files.
 
 Example:
 ```php

--- a/Tests/Functional/MCP/Tool/FileReferenceTest.php
+++ b/Tests/Functional/MCP/Tool/FileReferenceTest.php
@@ -403,13 +403,13 @@ class FileReferenceTest extends FunctionalTestCase
     }
 
     /**
-     * Embedded sys_file_metadata used to leak every plumbing column the LLM has
-     * no use for (pid, tstamp, crdate, sys_language_uid, l10n_parent,
-     * l10n_diffsource, categories, file). The parent sys_file already provides
-     * that context — the embedded child should expose only the user-visible
-     * data fields plus uid.
+     * sys_file_metadata is exposed as a standalone table (configured via
+     * `additionalStandaloneTables`), so reading sys_file no longer embeds the
+     * full metadata records. The inline `metadata` field collapses to a list
+     * of UIDs — enough for the LLM to discover that metadata exists and to
+     * fetch/edit it through the sys_file_metadata table directly.
      */
-    public function testInlineSysFileMetadataExposesOnlyDataFields(): void
+    public function testSysFileMetadataIsNotEmbeddedAsStandaloneTable(): void
     {
         $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
         $result = $readTool->execute([
@@ -420,31 +420,7 @@ class FileReferenceTest extends FunctionalTestCase
 
         $file = json_decode($result->content[0]->text, true)['records'][0];
         $this->assertArrayHasKey('metadata', $file);
-        $this->assertCount(1, $file['metadata']);
-        $meta = $file['metadata'][0];
-
-        // Plumbing and virtual columns must be gone.
-        foreach ([
-            'pid',
-            'tstamp',
-            'crdate',
-            'sys_language_uid',
-            'l10n_parent',
-            'l10n_diffsource',
-            'categories',
-            'file',
-            'fileinfo',
-        ] as $leaked) {
-            $this->assertArrayNotHasKey($leaked, $meta, "embedded metadata should not expose '$leaked'");
-        }
-
-        // The data fields the LLM actually cares about must remain.
-        $this->assertSame(1, $meta['uid']);
-        $this->assertSame('Test Image Title', $meta['title']);
-        $this->assertSame('Alt text for test', $meta['alternative']);
-        $this->assertSame('Description text', $meta['description']);
-        $this->assertSame(1868, $meta['width']);
-        $this->assertSame(1261, $meta['height']);
+        $this->assertSame([1], $file['metadata'], 'metadata field should be a list of uids, not embedded objects');
     }
 
     /**

--- a/Tests/Functional/MCP/Tool/ReadTableToolTest.php
+++ b/Tests/Functional/MCP/Tool/ReadTableToolTest.php
@@ -587,4 +587,87 @@ class ReadTableToolTest extends AbstractFunctionalTest
         // Non-requested fields should still be excluded
         $this->assertArrayNotHasKey('colPos', $record);
     }
+
+    /**
+     * Reading several records in a single call by passing an array of UIDs.
+     * This is the natural follow-up after seeing an inline-relation hint
+     * like `metadata: [1, 5]` on a parent record.
+     */
+    public function testReadMultipleRecordsByUidArray(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'uid' => [100, 101],
+            'includeRelations' => false,
+        ]);
+
+        $this->assertSuccessfulToolResult($result);
+        $data = $this->extractJsonFromResult($result);
+
+        $this->assertCount(2, $data['records']);
+        $uids = array_column($data['records'], 'uid');
+        $this->assertContains(100, $uids);
+        $this->assertContains(101, $uids);
+    }
+
+    /**
+     * Single-int form keeps working alongside the array form.
+     */
+    public function testUidArrayWithSingleEntryEqualsLegacyInt(): void
+    {
+        $resultArray = $this->tool->execute([
+            'table' => 'tt_content',
+            'uid' => [100],
+            'includeRelations' => false,
+        ]);
+        $resultInt = $this->tool->execute([
+            'table' => 'tt_content',
+            'uid' => 100,
+            'includeRelations' => false,
+        ]);
+
+        $this->assertEquals(
+            $this->extractJsonFromResult($resultArray)['records'],
+            $this->extractJsonFromResult($resultInt)['records']
+        );
+    }
+
+    /**
+     * Mixed valid and invalid UIDs: invalid ones (<= 0) drop out, the rest
+     * still match.
+     */
+    public function testUidArrayDropsNonPositiveEntries(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'uid' => [100, -1, 0, 101],
+            'includeRelations' => false,
+        ]);
+
+        $this->assertSuccessfulToolResult($result);
+        $uids = array_column(
+            $this->extractJsonFromResult($result)['records'],
+            'uid'
+        );
+        sort($uids);
+        $this->assertSame([100, 101], $uids);
+    }
+
+    /**
+     * A uid filter that sanitises to an empty list must still apply (return
+     * zero rows), preserving the legacy `uid: -1 → empty result` semantics.
+     */
+    public function testUidArrayWithOnlyInvalidEntriesReturnsEmpty(): void
+    {
+        $result = $this->tool->execute([
+            'table' => 'tt_content',
+            'uid' => [-1, 0],
+            'includeRelations' => false,
+        ]);
+
+        $this->assertSuccessfulToolResult($result);
+        $data = $this->extractJsonFromResult($result);
+        $this->assertSame(0, $data['total']);
+        $this->assertEmpty($data['records']);
+    }
 }

--- a/Tests/Functional/MCP/Tool/SearchToolTest.php
+++ b/Tests/Functional/MCP/Tool/SearchToolTest.php
@@ -652,4 +652,90 @@ class SearchToolTest extends FunctionalTestCase
         $this->assertStringContainsString('Web Development', $content);
         $this->assertStringContainsString('[UID: 4] Web Development', $content);
     }
+
+    /**
+     * sys_file_metadata is configured as standalone via additionalStandaloneTables,
+     * so when a primary table (sys_file) lists it as `type=inline foreign_table=...`,
+     * it must be excluded from the inline-related-search path. Otherwise hits in
+     * sys_file_metadata would be searched twice and falsely attributed back to
+     * the parent sys_file record.
+     *
+     * Forces searchFields onto sys_file_metadata for the duration of the test
+     * so the path is actually exercised — without searchFields, the table is
+     * filtered out earlier (a separate core-level issue tracked outside MCP).
+     */
+    public function testInlineRelatedHiddenTablesSkipsStandaloneTables(): void
+    {
+        $originalSearchFields = $GLOBALS['TCA']['sys_file_metadata']['ctrl']['searchFields'] ?? null;
+        $GLOBALS['TCA']['sys_file_metadata']['ctrl']['searchFields'] = 'title,alternative,description';
+        try {
+            $tool = new SearchTool();
+
+            // Reach into the protected discovery method. We could exercise this
+            // through the public search path too, but isolating the helper makes
+            // the assertion unambiguous: the primary-vs-inline classification is
+            // exactly what we care about.
+            $reflected = new \ReflectionMethod($tool, 'getInlineRelatedHiddenTables');
+            $reflected->setAccessible(true);
+            $inlineTables = $reflected->invoke($tool, ['sys_file']);
+
+            $inlineNames = array_column($inlineTables, 'table');
+            $this->assertNotContains(
+                'sys_file_metadata',
+                $inlineNames,
+                'sys_file_metadata is exposed standalone and must not be discovered ' .
+                'via the inline-related path. Got: ' . implode(',', $inlineNames)
+            );
+        } finally {
+            if ($originalSearchFields === null) {
+                unset($GLOBALS['TCA']['sys_file_metadata']['ctrl']['searchFields']);
+            } else {
+                $GLOBALS['TCA']['sys_file_metadata']['ctrl']['searchFields'] = $originalSearchFields;
+            }
+        }
+    }
+
+    /**
+     * Counter-test: when sys_file_metadata is NOT in additionalStandaloneTables
+     * (i.e. it remains a hideTable inline child), the inline-related path
+     * must still pick it up. Otherwise our fix would have over-blocked the
+     * embedded path entirely.
+     */
+    public function testInlineRelatedHiddenTablesIncludesNonStandaloneHideTable(): void
+    {
+        $originalSearchFields = $GLOBALS['TCA']['sys_file_metadata']['ctrl']['searchFields'] ?? null;
+        $GLOBALS['TCA']['sys_file_metadata']['ctrl']['searchFields'] = 'title,alternative,description';
+
+        // Reach into the singleton TableAccessService and override its
+        // standalone-tables cache so the test exercises the "no standalone
+        // override" world without touching extension configuration.
+        $tableAccessService = GeneralUtility::makeInstance(\Hn\McpServer\Service\TableAccessService::class);
+        $standaloneProperty = new \ReflectionProperty($tableAccessService, 'additionalStandaloneTables');
+        $standaloneProperty->setAccessible(true);
+        $originalStandalone = $standaloneProperty->getValue($tableAccessService);
+        $standaloneProperty->setValue($tableAccessService, []);
+
+        try {
+            $tool = new SearchTool();
+            $reflected = new \ReflectionMethod($tool, 'getInlineRelatedHiddenTables');
+            $reflected->setAccessible(true);
+            $inlineTables = $reflected->invoke($tool, ['sys_file']);
+
+            $inlineNames = array_column($inlineTables, 'table');
+            $this->assertContains(
+                'sys_file_metadata',
+                $inlineNames,
+                'Without the standalone opt-out, sys_file_metadata should still ' .
+                'be discovered via sys_file.metadata inline relation. Got: ' .
+                implode(',', $inlineNames)
+            );
+        } finally {
+            $standaloneProperty->setValue($tableAccessService, $originalStandalone);
+            if ($originalSearchFields === null) {
+                unset($GLOBALS['TCA']['sys_file_metadata']['ctrl']['searchFields']);
+            } else {
+                $GLOBALS['TCA']['sys_file_metadata']['ctrl']['searchFields'] = $originalSearchFields;
+            }
+        }
+    }
 }

--- a/Tests/Functional/MCP/Tool/SysFileMetadataStandaloneTest.php
+++ b/Tests/Functional/MCP/Tool/SysFileMetadataStandaloneTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use Hn\McpServer\MCP\Tool\Record\ListTablesTool;
+use Hn\McpServer\MCP\Tool\Record\ReadTableTool;
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use Symfony\Component\Yaml\Yaml;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * sys_file_metadata is exposed as a standalone editable table (configured via
+ * `additionalStandaloneTables`), instead of being embedded into sys_file.
+ * sys_file itself remains read-only — only metadata is editable.
+ */
+class SysFileMetadataStandaloneTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+        'frontend',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'mcp_server',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createMultiLanguageSiteConfiguration();
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/sys_filemounts.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/sys_file.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/sys_file_metadata.csv');
+        $this->setUpBackendUser(1);
+    }
+
+    private function createMultiLanguageSiteConfiguration(): void
+    {
+        $siteConfiguration = [
+            'rootPageId' => 1,
+            'base' => 'https://example.com/',
+            'websiteTitle' => 'Test Site',
+            'languages' => [
+                0 => [
+                    'title' => 'English', 'enabled' => true, 'languageId' => 0,
+                    'base' => '/', 'locale' => 'en_US.UTF-8', 'iso-639-1' => 'en',
+                    'hreflang' => 'en-us', 'direction' => 'ltr', 'flag' => 'us',
+                    'navigationTitle' => 'English',
+                ],
+                1 => [
+                    'title' => 'German', 'enabled' => true, 'languageId' => 1,
+                    'base' => '/de/', 'locale' => 'de_DE.UTF-8', 'iso-639-1' => 'de',
+                    'hreflang' => 'de-de', 'direction' => 'ltr', 'flag' => 'de',
+                    'navigationTitle' => 'Deutsch',
+                ],
+            ],
+            'routes' => [],
+            'errorHandling' => [],
+        ];
+        $configPath = $this->instancePath . '/typo3conf/sites/test-site';
+        GeneralUtility::mkdir_deep($configPath);
+        GeneralUtility::writeFile($configPath . '/config.yaml', Yaml::dump($siteConfiguration, 99, 2), true);
+    }
+
+    public function testListTablesShowsSysFileMetadataAsCoreFile(): void
+    {
+        $tool = GeneralUtility::makeInstance(ListTablesTool::class);
+        $result = $tool->execute([]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $content = $result->content[0]->text;
+
+        // sys_file_metadata must appear as core/file, not as "unknown" extension.
+        $this->assertStringContainsString('sys_file_metadata', $content);
+        $this->assertMatchesRegularExpression(
+            '/CORE TABLES:.*?sys_file_metadata.*?\[file\]/s',
+            $content,
+            'sys_file_metadata should be listed under CORE TABLES with [file] type. Got: ' . $content
+        );
+        // Specifically: not read-only.
+        $this->assertDoesNotMatchRegularExpression(
+            '/sys_file_metadata.*?\[READ-ONLY\]/',
+            $content,
+            'sys_file_metadata should NOT be flagged as read-only'
+        );
+    }
+
+    public function testSysFileEmbedsMetadataAsUidListNotObjects(): void
+    {
+        $tool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $result = $tool->execute(['table' => 'sys_file', 'uid' => 1]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $file = json_decode($result->content[0]->text, true)['records'][0];
+        $this->assertArrayHasKey('metadata', $file);
+        $this->assertSame(
+            [1],
+            $file['metadata'],
+            'metadata should collapse to a list of uids when sys_file_metadata is exposed standalone'
+        );
+    }
+
+    public function testReadSysFileMetadataDirectly(): void
+    {
+        $tool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $result = $tool->execute(['table' => 'sys_file_metadata', 'uid' => 1]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $records = json_decode($result->content[0]->text, true)['records'];
+        $this->assertCount(1, $records);
+        $this->assertSame('Test Image Title', $records[0]['title']);
+        $this->assertSame(1, $records[0]['file'], 'foreign key to sys_file is exposed for discovery');
+    }
+
+    public function testUpdateSysFileMetadataDirectly(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+        $result = $writeTool->execute([
+            'table' => 'sys_file_metadata',
+            'action' => 'update',
+            'uid' => 1,
+            'data' => [
+                'title' => 'New Title via MCP',
+                'alternative' => 'New Alt via MCP',
+                'description' => 'New Description via MCP',
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        // Read back through the standard read pipeline (workspace overlay applied).
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $result = $readTool->execute(['table' => 'sys_file_metadata', 'uid' => 1]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $record = json_decode($result->content[0]->text, true)['records'][0];
+        $this->assertSame('New Title via MCP', $record['title']);
+        $this->assertSame('New Alt via MCP', $record['alternative']);
+        $this->assertSame('New Description via MCP', $record['description']);
+    }
+
+    public function testSysFileItselfRemainsReadOnly(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+        $result = $writeTool->execute([
+            'table' => 'sys_file',
+            'action' => 'update',
+            'uid' => 1,
+            'data' => ['name' => 'hacked.jpg'],
+        ]);
+        $this->assertTrue($result->isError, 'sys_file must stay read-only — only metadata is editable');
+    }
+
+    /**
+     * Translation works through the standard create-with-language path because
+     * sys_file_metadata is now a normal language-aware table — no special
+     * embedded-translation handling needed.
+     */
+    public function testTranslateSysFileMetadata(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+        $result = $writeTool->execute([
+            'table' => 'sys_file_metadata',
+            'action' => 'translate',
+            'uid' => 1,
+            'data' => [
+                'sys_language_uid' => 1,
+                'title' => 'DE Titel',
+                'alternative' => 'DE Alt',
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        // Default-language record is unchanged
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $result = $readTool->execute(['table' => 'sys_file_metadata', 'uid' => 1]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $record = json_decode($result->content[0]->text, true)['records'][0];
+        $this->assertSame('Test Image Title', $record['title']);
+    }
+
+    /**
+     * Non-admin users only see sys_file_metadata for files within their mounts.
+     */
+    public function testNonAdminMountRestrictionAppliesToMetadata(): void
+    {
+        // Add metadata records for files at uids 3 and 5 too. We can then verify
+        // that a /user_upload/team/ mount only exposes metadata for uid=5.
+        // We assert against the `file` foreign key rather than `title` because
+        // title is `exclude=true` in the TCA, so non-admin users without the
+        // matching non_exclude_fields permission don't see it. The mount
+        // restriction itself is unrelated to that — it filters on the row,
+        // not the column.
+        $conn = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('sys_file_metadata');
+        $conn->insert('sys_file_metadata', [
+            'pid' => 0,
+            'tstamp' => 1700000000,
+            'crdate' => 1700000000,
+            'sys_language_uid' => 0,
+            'l10n_parent' => 0,
+            'l10n_diffsource' => '',
+            'title' => 'Person',
+            'alternative' => '',
+            'description' => 'desc-3',
+            'file' => 3,
+        ]);
+        $conn->insert('sys_file_metadata', [
+            'pid' => 0,
+            'tstamp' => 1700000000,
+            'crdate' => 1700000000,
+            'sys_language_uid' => 0,
+            'l10n_parent' => 0,
+            'l10n_diffsource' => '',
+            'title' => 'Team',
+            'alternative' => '',
+            'description' => 'desc-5',
+            'file' => 5,
+        ]);
+
+        $userUid = $this->createNonAdminUserWithMounts('2'); // /user_upload/team/
+        $this->authenticateAsNonAdmin($userUid, ['sys_file', 'sys_file_metadata']);
+
+        $tool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $result = $tool->execute(['table' => 'sys_file_metadata']);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $payload = $result->content[0]->text;
+        $records = json_decode($payload, true)['records'] ?? [];
+        $fileUids = array_column($records, 'file');
+        $this->assertContains(5, $fileUids,
+            'Metadata for the file in the mount must be visible. Got: ' . $payload);
+        $this->assertNotContains(1, $fileUids,
+            'Metadata of files outside the mount must be hidden');
+        $this->assertNotContains(3, $fileUids,
+            'Metadata of files outside the mount must be hidden');
+    }
+
+    public function testNonAdminWithoutMountsSeesNoMetadata(): void
+    {
+        $userUid = $this->createNonAdminUserWithMounts('');
+        $this->authenticateAsNonAdmin($userUid, ['sys_file', 'sys_file_metadata']);
+
+        $tool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $result = $tool->execute(['table' => 'sys_file_metadata']);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $data = json_decode($result->content[0]->text, true);
+        $this->assertSame(0, $data['total']);
+    }
+
+    /**
+     * Orphaned metadata (file FK points to a non-existent sys_file uid) is
+     * filtered out — admin too. The IN-subquery on sys_file gives this for free.
+     */
+    public function testOrphanMetadataIsFiltered(): void
+    {
+        $conn = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('sys_file_metadata');
+        $conn->insert('sys_file_metadata', [
+            'pid' => 0,
+            'tstamp' => 1700000000,
+            'crdate' => 1700000000,
+            'sys_language_uid' => 0,
+            'l10n_parent' => 0,
+            'l10n_diffsource' => '',
+            'title' => 'Orphan',
+            'alternative' => '',
+            'description' => '',
+            'file' => 999, // non-existent
+        ]);
+
+        $tool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $result = $tool->execute(['table' => 'sys_file_metadata']);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $titles = array_column(
+            json_decode($result->content[0]->text, true)['records'],
+            'title'
+        );
+        $this->assertNotContains('Orphan', $titles);
+    }
+
+    private function createNonAdminUserWithMounts(string $fileMountUids): int
+    {
+        GeneralUtility::makeInstance(CacheManager::class)->getCache('runtime')->flush();
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('be_users');
+
+        $connection->insert('be_users', [
+            'pid' => 0,
+            'username' => 'editor_' . uniqid(),
+            'password' => '$argon2i$v=19$m=65536,t=16,p=1$dGVzdHNhbHQ$testpasswordhash',
+            'admin' => 0,
+            'file_mountpoints' => $fileMountUids,
+            'deleted' => 0,
+            'disable' => 0,
+            'tstamp' => time(),
+            'crdate' => time(),
+            'email' => 'test' . uniqid() . '@example.com',
+        ]);
+
+        return (int)$connection->lastInsertId();
+    }
+
+    private function authenticateAsNonAdmin(int $uid, array $tables): BackendUserAuthentication
+    {
+        $user = $this->setUpBackendUser($uid);
+        $user->groupData['tables_select'] = implode(',', $tables);
+        $user->groupData['tables_modify'] = implode(',', $tables);
+        $user->groupData['filemounts'] = (string)($user->user['file_mountpoints'] ?? '');
+        $user->user['admin'] = 0;
+        $GLOBALS['BE_USER'] = $user;
+
+        GeneralUtility::makeInstance(CacheManager::class)->getCache('runtime')->flush();
+
+        return $user;
+    }
+}

--- a/Tests/Llm/SysFileMetadataTest.php
+++ b/Tests/Llm/SysFileMetadataTest.php
@@ -34,10 +34,17 @@ class SysFileMetadataTest extends LlmTestCase
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/sys_file_metadata.csv');
 
         // The shared fixture only seeds metadata for sys_file uid=1 (test.jpg).
-        // Add a row for person.jpg (sys_file uid=3) so the LLM has a clearer
-        // target — both the prompt and the assertion can name a single file
-        // unambiguously, and we can verify the *other* metadata row stays
-        // untouched.
+        // We need additional rows so each scenario can target an unambiguous
+        // file: person.jpg (uid=3) for the alt-text/translation tests,
+        // logo.png (uid=4) and team-photo.jpg (uid=5) without alt text for
+        // the bulk-find-untagged test.
+        $this->insertMetadata(3, 'Person Photo', 'Original alt for person');
+        $this->insertMetadata(4, 'Company Logo', '');
+        $this->insertMetadata(5, 'Team Group Photo', '');
+    }
+
+    private function insertMetadata(int $fileUid, string $title, string $alternative, string $description = ''): int
+    {
         $conn = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('sys_file_metadata');
         $conn->insert('sys_file_metadata', [
@@ -47,11 +54,12 @@ class SysFileMetadataTest extends LlmTestCase
             'sys_language_uid' => 0,
             'l10n_parent' => 0,
             'l10n_diffsource' => '',
-            'title' => 'Person Photo',
-            'alternative' => 'Original alt for person',
-            'description' => '',
-            'file' => 3,
+            'title' => $title,
+            'alternative' => $alternative,
+            'description' => $description,
+            'file' => $fileUid,
         ]);
+        return (int)$conn->lastInsertId();
     }
 
     #[DataProvider('modelProvider')]
@@ -117,6 +125,193 @@ class SysFileMetadataTest extends LlmTestCase
         $this->assertSame('Alt text for test', (string)$testJpgMeta['alternative'],
             'Untouched file metadata (test.jpg) was modified — the LLM hit the wrong row. '
             . $writeArgsDump . "\n" . $this->getFailureContext($currentResponse));
+    }
+
+    #[DataProvider('modelProvider')]
+    #[TestDox('[$modelKey] Prompt "Translate metadata of person.jpg to German" → action=translate creates a sys_language_uid=1 row pointing at the default-language record')]
+    public function testLlmTranslatesMetadataToGerman(string $modelKey): void
+    {
+        $this->setModel($modelKey);
+
+        $prompt = 'Add a German translation for the metadata of the file "person.jpg". '
+            . 'The German title should be "Personenfoto" and the alternative text should be "Foto vom Teamleiter".';
+
+        $response = $this->executeUntilToolFound(
+            $this->callLlm($prompt),
+            'WriteTable',
+            12
+        );
+
+        $writeCalls = $response->getToolCallsByName('WriteTable');
+        $this->assertNotEmpty($writeCalls,
+            'Expected a WriteTable call. ' . $this->getFailureContext($response));
+
+        // Drive the conversation forward so the workspace overlay is written.
+        $currentResponse = $response;
+        for ($attempt = 0; $attempt < 6 && $currentResponse->hasToolCalls(); $attempt++) {
+            $currentResponse = $this->executeAndContinue($currentResponse);
+        }
+
+        $writeArgsDump = "\nWriteTable arguments seen: " . json_encode(
+            array_map(fn($c) => $c['arguments'] ?? [], $writeCalls),
+            JSON_PRETTY_PRINT
+        );
+
+        // Look for a German translation row pointing at the original
+        // metadata record for person.jpg. We accept either action=translate
+        // (the canonical path) or a direct create with l10n_parent set —
+        // both produce the same end state.
+        $deRow = $this->loadGermanTranslationForFile(3);
+        $this->assertNotNull($deRow,
+            'Expected a German translation row for person.jpg metadata. '
+            . $writeArgsDump . "\n" . $this->getFailureContext($currentResponse));
+        $this->assertSame('Personenfoto', (string)$deRow['title'],
+            'German title not stored on the translation row. '
+            . $writeArgsDump . "\n" . $this->getFailureContext($currentResponse));
+        $this->assertSame('Foto vom Teamleiter', (string)$deRow['alternative'],
+            'German alt text not stored on the translation row. '
+            . $writeArgsDump . "\n" . $this->getFailureContext($currentResponse));
+    }
+
+    #[DataProvider('modelProvider')]
+    #[TestDox('[$modelKey] Prompt "Find images without alt text and fix them" → discovers untagged metadata rows and updates each')]
+    public function testLlmFillsMissingAltTextOnUntaggedImages(string $modelKey): void
+    {
+        $this->setModel($modelKey);
+
+        $prompt = 'Some images on this site have no alternative text yet. '
+            . 'Find every image whose alternative text is empty and add a sensible alt text '
+            . 'based on the title that is already stored. Keep titles unchanged.';
+
+        $response = $this->executeUntilToolFound(
+            $this->callLlm($prompt),
+            'WriteTable',
+            18
+        );
+
+        $this->assertNotEmpty($response->getToolCallsByName('WriteTable'),
+            'Expected at least one WriteTable call. ' . $this->getFailureContext($response));
+
+        // The LLM may need several rounds: read to find untagged rows, then
+        // update each. Allow generous turn budget.
+        $currentResponse = $response;
+        for ($attempt = 0; $attempt < 10 && $currentResponse->hasToolCalls(); $attempt++) {
+            $currentResponse = $this->executeAndContinue($currentResponse);
+        }
+
+        $logoMeta = $this->loadMetadataForFile(4);
+        $teamMeta = $this->loadMetadataForFile(5);
+
+        $this->assertNotNull($logoMeta, 'logo.png metadata row should still exist.');
+        $this->assertNotNull($teamMeta, 'team-photo.jpg metadata row should still exist.');
+
+        $this->assertNotSame('', (string)$logoMeta['alternative'],
+            'logo.png alt text should have been filled. '
+            . $this->getFailureContext($currentResponse));
+        $this->assertNotSame('', (string)$teamMeta['alternative'],
+            'team-photo.jpg alt text should have been filled. '
+            . $this->getFailureContext($currentResponse));
+
+        // Pre-populated rows must not be flattened or overwritten.
+        $personMeta = $this->loadMetadataForFile(3);
+        $this->assertSame('Original alt for person', (string)$personMeta['alternative'],
+            'person.jpg already had alt text and must not have been touched. '
+            . $this->getFailureContext($currentResponse));
+
+        // Title field on the previously-untagged rows must survive — the
+        // prompt only asks for alt text changes.
+        $this->assertSame('Company Logo', (string)$logoMeta['title']);
+        $this->assertSame('Team Group Photo', (string)$teamMeta['title']);
+    }
+
+    #[DataProvider('modelProvider')]
+    #[TestDox('[$modelKey] Prompt "What metadata is stored for person.jpg?" → reads sys_file, follows the metadata uid hint into sys_file_metadata')]
+    public function testLlmFollowsMetadataUidHintFromSysFile(string $modelKey): void
+    {
+        $this->setModel($modelKey);
+
+        $prompt = 'Read the file "person.jpg" from sys_file and tell me what metadata is stored for it.';
+
+        // Collect tool calls across every iteration so we can assert on the
+        // full sequence, not just the first or last response.
+        $currentResponse = $this->callLlm($prompt);
+        $allReadCalls = [];
+        for ($iter = 0; $iter < 8 && $currentResponse->hasToolCalls(); $iter++) {
+            foreach ($currentResponse->getToolCallsByName('ReadTable') as $call) {
+                $allReadCalls[] = $call;
+            }
+            $currentResponse = $this->executeAndContinue($currentResponse);
+        }
+        // Catch any ReadTable calls in the final response too.
+        foreach ($currentResponse->getToolCallsByName('ReadTable') as $call) {
+            $allReadCalls[] = $call;
+        }
+
+        $tablesRead = array_values(array_unique(array_filter(array_map(
+            fn($call) => $call['arguments']['table'] ?? '',
+            $allReadCalls
+        ))));
+
+        $this->assertNotEmpty($allReadCalls,
+            'Expected at least one ReadTable call. ' . $this->getFailureContext($currentResponse));
+
+        // The whole point of leaving `metadata: [<uid>]` on sys_file is that
+        // the LLM follows the hint into sys_file_metadata.
+        $this->assertContains('sys_file_metadata', $tablesRead,
+            'Expected the LLM to read sys_file_metadata after seeing the metadata uid hint on sys_file. '
+            . 'Tables read: ' . implode(', ', $tablesRead) . "\n"
+            . $this->getFailureContext($currentResponse));
+
+        // The model's final answer should mention the metadata it discovered.
+        $finalText = $currentResponse->getContent();
+        $this->assertMatchesRegularExpression(
+            '/Person Photo|Original alt for person/i',
+            $finalText,
+            'LLM should have surfaced the discovered metadata in its answer. '
+            . $this->getFailureContext($currentResponse)
+        );
+    }
+
+    /**
+     * Load the German (sys_language_uid=1) metadata row for a sys_file uid,
+     * folding in any workspace overlay. Returns null if no translation row
+     * exists yet.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function loadGermanTranslationForFile(int $fileUid): ?array
+    {
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('sys_file_metadata');
+        $qb->getRestrictions()->removeAll();
+
+        $rows = $qb->select('uid', 't3ver_oid', 't3ver_state', 'sys_language_uid', 'deleted', 'alternative', 'title', 'l10n_parent', 'file')
+            ->from('sys_file_metadata')
+            ->where(
+                $qb->expr()->eq('file', $qb->createNamedParameter($fileUid, \Doctrine\DBAL\ParameterType::INTEGER)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(1, \Doctrine\DBAL\ParameterType::INTEGER))
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $byLiveUid = [];
+        foreach ($rows as $row) {
+            if ((int)$row['t3ver_state'] === 2) {
+                continue;
+            }
+            $deletedValue = $row['deleted'] ?? $row['"deleted"'] ?? 0;
+            if ((int)$deletedValue === 1) {
+                continue;
+            }
+            $liveUid = (int)($row['t3ver_oid'] ?: $row['uid']);
+            if ((int)$row['t3ver_oid'] > 0) {
+                $byLiveUid[$liveUid] = $row;
+            } elseif (!isset($byLiveUid[$liveUid])) {
+                $byLiveUid[$liveUid] = $row;
+            }
+        }
+
+        return $byLiveUid ? array_values($byLiveUid)[0] : null;
     }
 
     /**

--- a/Tests/Llm/SysFileMetadataTest.php
+++ b/Tests/Llm/SysFileMetadataTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Llm;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Test that the LLM understands sys_file metadata is exposed as a standalone
+ * editable table — not as an inline child of sys_file. The LLM has to:
+ *
+ *   1. find the file (sys_file by name, or via Search)
+ *   2. find the corresponding metadata row (either via the metadata-uid hint
+ *      embedded on sys_file or by reading sys_file_metadata directly)
+ *   3. WriteTable the alternative text on that metadata row
+ *
+ * This is the use case the standalone exposure was designed for, so the
+ * smoke test covers the discovery path end-to-end.
+ *
+ * @group llm
+ */
+class SysFileMetadataTest extends LlmTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/sys_file.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/sys_file_metadata.csv');
+
+        // The shared fixture only seeds metadata for sys_file uid=1 (test.jpg).
+        // Add a row for person.jpg (sys_file uid=3) so the LLM has a clearer
+        // target — both the prompt and the assertion can name a single file
+        // unambiguously, and we can verify the *other* metadata row stays
+        // untouched.
+        $conn = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('sys_file_metadata');
+        $conn->insert('sys_file_metadata', [
+            'pid' => 0,
+            'tstamp' => 1700000000,
+            'crdate' => 1700000000,
+            'sys_language_uid' => 0,
+            'l10n_parent' => 0,
+            'l10n_diffsource' => '',
+            'title' => 'Person Photo',
+            'alternative' => 'Original alt for person',
+            'description' => '',
+            'file' => 3,
+        ]);
+    }
+
+    #[DataProvider('modelProvider')]
+    #[TestDox('[$modelKey] Prompt "Set the alt text of person.jpg to ..." → discovers the metadata row and WriteTable updates only that row')]
+    public function testLlmSetsAltTextViaSysFileMetadata(string $modelKey): void
+    {
+        $this->setModel($modelKey);
+
+        $newAlt = 'Our team lead photo';
+        $prompt = 'Set the alternative text of the file "person.jpg" to "' . $newAlt . '". '
+            . 'Do not touch any other file metadata.';
+
+        $response = $this->executeUntilToolFound(
+            $this->callLlm($prompt),
+            'WriteTable',
+            12
+        );
+
+        $writeCalls = $response->getToolCallsByName('WriteTable');
+        $this->assertNotEmpty($writeCalls,
+            'Expected a WriteTable call. ' . $this->getFailureContext($response));
+
+        // The write must target sys_file_metadata. sys_file is read-only, and
+        // there is no embedded inline metadata field anymore, so a write on
+        // sys_file with a `metadata` payload would be the wrong path.
+        $metadataWrite = null;
+        foreach ($writeCalls as $call) {
+            if (($call['arguments']['table'] ?? '') === 'sys_file_metadata') {
+                $metadataWrite = $call['arguments'];
+                break;
+            }
+        }
+        $this->assertNotNull($metadataWrite,
+            'Expected WriteTable on sys_file_metadata. Tool history: '
+            . implode(' → ', $this->getToolCallHistory()) . "\n"
+            . $this->getFailureContext($response));
+
+        $this->assertSame('update', $metadataWrite['action'] ?? null,
+            'Metadata write must be an update, not a create. '
+            . $this->getFailureContext($response));
+
+        // Drive the conversation forward until tool calls dry up so the
+        // workspace overlay actually gets written.
+        $currentResponse = $response;
+        for ($attempt = 0; $attempt < 6 && $currentResponse->hasToolCalls(); $attempt++) {
+            $currentResponse = $this->executeAndContinue($currentResponse);
+        }
+
+        $writeArgsDump = "\nWriteTable arguments seen: " . json_encode(
+            array_map(fn($c) => $c['arguments'] ?? [], $writeCalls),
+            JSON_PRETTY_PRINT
+        );
+
+        $personMeta = $this->loadMetadataForFile(3);
+        $this->assertNotNull($personMeta,
+            'Could not find metadata row for person.jpg (sys_file uid=3) after the LLM run. '
+            . $writeArgsDump . "\n" . $this->getFailureContext($currentResponse));
+        $this->assertSame($newAlt, (string)$personMeta['alternative'],
+            'Alt text on person.jpg metadata was not updated. '
+            . $writeArgsDump . "\n" . $this->getFailureContext($currentResponse));
+
+        $testJpgMeta = $this->loadMetadataForFile(1);
+        $this->assertNotNull($testJpgMeta, 'test.jpg metadata row disappeared.');
+        $this->assertSame('Alt text for test', (string)$testJpgMeta['alternative'],
+            'Untouched file metadata (test.jpg) was modified — the LLM hit the wrong row. '
+            . $writeArgsDump . "\n" . $this->getFailureContext($currentResponse));
+    }
+
+    /**
+     * Load the workspace-overlaid metadata row for a given sys_file uid.
+     *
+     * The LLM writes through DataHandler in the optimal workspace selected by
+     * WorkspaceContextService, so the new alt text lives on a t3ver_oid >0 row
+     * rather than the live record. We pick the overlay if present, otherwise
+     * fall back to live, and ignore delete placeholders.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function loadMetadataForFile(int $fileUid): ?array
+    {
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('sys_file_metadata');
+        $qb->getRestrictions()->removeAll();
+
+        // Don't filter on sys_language_uid/deleted in SQL — workspace overlays
+        // sometimes store sys_language_uid=-1 as the "concept" marker, which
+        // would skip the overlay row. Filter in PHP instead.
+        $rows = $qb->select('uid', 't3ver_oid', 't3ver_state', 'sys_language_uid', 'deleted', 'alternative', 'title', 'description', 'file')
+            ->from('sys_file_metadata')
+            ->where(
+                $qb->expr()->eq('file', $qb->createNamedParameter($fileUid, \Doctrine\DBAL\ParameterType::INTEGER))
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $byLiveUid = [];
+        foreach ($rows as $row) {
+            if ((int)$row['t3ver_state'] === 2) {
+                continue; // delete placeholder
+            }
+            // `deleted` is a Doctrine reserved word and may surface under a
+            // quoted key on some DBs; default to 0 (not deleted) when absent.
+            $deletedValue = $row['deleted'] ?? $row['"deleted"'] ?? 0;
+            if ((int)$deletedValue === 1) {
+                continue;
+            }
+            // Default-language only: live row sys_language_uid=0; workspace
+            // overlays inherit that (or carry -1 as concept marker).
+            $lang = (int)$row['sys_language_uid'];
+            if ($lang !== 0 && $lang !== -1) {
+                continue;
+            }
+            $liveUid = (int)($row['t3ver_oid'] ?: $row['uid']);
+            if ((int)$row['t3ver_oid'] > 0) {
+                $byLiveUid[$liveUid] = $row;
+            } elseif (!isset($byLiveUid[$liveUid])) {
+                $byLiveUid[$liveUid] = $row;
+            }
+        }
+
+        return $byLiveUid ? array_values($byLiveUid)[0] : null;
+    }
+}

--- a/Tests/Llm/SysFileMetadataTest.php
+++ b/Tests/Llm/SysFileMetadataTest.php
@@ -61,8 +61,7 @@ class SysFileMetadataTest extends LlmTestCase
         $this->setModel($modelKey);
 
         $newAlt = 'Our team lead photo';
-        $prompt = 'Set the alternative text of the file "person.jpg" to "' . $newAlt . '". '
-            . 'Do not touch any other file metadata.';
+        $prompt = 'Set the alternative text of the file "person.jpg" to "' . $newAlt . '".';
 
         $response = $this->executeUntilToolFound(
             $this->callLlm($prompt),

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,2 +1,5 @@
 # cat=mcp/tables; type=string; label=Additional read-only tables: Comma-separated list of non-workspace-capable tables to expose as read-only via MCP tools. These tables become available in ReadTable but cannot be written. Example: tx_blog_domain_model_author,tx_myext_domain_model_setting
 additionalReadOnlyTables = sys_file
+
+# cat=mcp/tables; type=string; label=Additional standalone tables: Comma-separated list of tables marked as hideTable=true in TCA that should still be exposed as independent tables instead of being embedded into their parent's inline relation. Use this for hideTable tables whose inline structure is too complex (translations, mounts, ...) to be safely edited through the parent. Example: sys_file_metadata,tx_myext_complex_child
+additionalStandaloneTables = sys_file_metadata


### PR DESCRIPTION
sys_file is read-only via additionalReadOnlyTables, but its embedded metadata (sys_file_metadata) was silently writable through a side door: TableAccessService allowed direct WriteTable on it because the table is workspace-capable. The embedded read view also leaked all language records flat with no way for the LLM to tell them apart, and the embed write path would have orphan-deleted translations on partial updates.

Solution: keep sys_file_metadata workspace-capable, but stop embedding it. Introduce the new extension setting `additionalStandaloneTables` (defaults to `sys_file_metadata`) that lets integrators opt hideTable children out of inline embedding when their structure is too complex for parent-driven edits. The hideTable lookup is centralised in TableAccessService::isEmbeddedChildTable() so ReadTableTool, WriteTableTool and TcaFormattingUtility all consult the same source.

A new SysFileMetadataRestrictionListener mirrors the existing sys_file mount filter via subquery, so non-admins only see metadata for files they could read on sys_file. The same subquery filters orphaned rows.