### PR TITLE
Fix warning message direction in MCP endpoint authorization error

### DIFF
--- a/Resources/Public/JavaScript/mcp-module.js
+++ b/Resources/Public/JavaScript/mcp-module.js
@@ -622,7 +622,7 @@ class McpModule {
                         const warningDiv = document.getElementById('auth-header-warning');
                         if (warningDiv) warningDiv.style.display = 'none';
                     } else {
-                        this.setEndpointStatus(element, 'error', 'MCP endpoint cannot receive Authorization headers - see warning below');
+                        this.setEndpointStatus(element, 'error', 'MCP endpoint cannot receive Authorization headers - see warning above');
                         const warningDiv = document.getElementById('auth-header-warning');
                         if (warningDiv) warningDiv.style.display = 'block';
                     }


### PR DESCRIPTION
## Summary
Updated the error message text to correctly reference the location of the authorization header warning message.

## Changes
- Changed error message from "see warning below" to "see warning above" in the MCP endpoint authorization validation logic
- This correction ensures the user guidance accurately reflects where the warning element is positioned on the page

## Details
When the MCP endpoint cannot receive Authorization headers, an error status is set with a message directing users to a warning. The warning element (`auth-header-warning`) is displayed above the error message in the UI, so the message text has been corrected to match the actual layout.

https://claude.ai/code/session_014YNrf5Vh2CyhEjV5kbcnF4