### PR TITLE
Fix TypeError when TCA select items have numeric labels

### DIFF
--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -1184,8 +1184,12 @@ class TableAccessService implements SingletonInterface
             }
             
             if ($itemValue !== '') {
+                // Cast both to string. TCA items can legitimately have numeric
+                // labels (e.g. sys_file_metadata.ranking on TYPO3 13 lists
+                // integer 1..5 as both value and label); translateLabel() and
+                // string concatenation downstream are type-strict.
                 $result['values'][] = (string)$itemValue;
-                $result['labels'][$itemValue] = $itemLabel;
+                $result['labels'][(string)$itemValue] = (string)$itemLabel;
             }
         }
         

--- a/Tests/Functional/MCP/Tool/GetTableSchemaToolTest.php
+++ b/Tests/Functional/MCP/Tool/GetTableSchemaToolTest.php
@@ -329,6 +329,53 @@ class GetTableSchemaToolTest extends FunctionalTestCase
     }
 
     /**
+     * Select TCA items with numeric (int) labels must not break schema
+     * formatting. Reproduces a real-world third-party `ranking` field on
+     * sys_file_metadata (TYPO3 13) that lists items with integer labels
+     * 0..5. Before the fix, parseSelectItems handed the int label straight
+     * to the type-strict TableAccessService::translateLabel(string $label),
+     * raising a TypeError — schema introspection (which an LLM client
+     * typically calls first) then failed entirely.
+     */
+    public function testSelectItemsWithIntegerLabelsDoNotBreakFormatting(): void
+    {
+        $service = GeneralUtility::makeInstance(\Hn\McpServer\Service\TableAccessService::class);
+        $parsed = $service->parseSelectItems([
+            ['label' => 0, 'value' => 0],
+            ['label' => 1, 'value' => 1],
+            ['label' => 5, 'value' => 5],
+        ]);
+
+        // Labels must be strings so downstream type-strict consumers
+        // (translateLabel, string concatenation) do not raise.
+        foreach ($parsed['labels'] as $label) {
+            $this->assertIsString($label);
+        }
+
+        // The select formatter feeds these labels through translateLabel and
+        // concatenates them — exercise the full path that would have thrown.
+        $config = [
+            'type' => 'select',
+            'renderType' => 'selectSingle',
+            'items' => [
+                ['label' => 0, 'value' => 0],
+                ['label' => 1, 'value' => 1],
+                ['label' => 5, 'value' => 5],
+            ],
+        ];
+        $rendered = '';
+        \Hn\McpServer\Utility\TcaFormattingUtility::addFieldDetailsInline(
+            $rendered,
+            $config,
+            'ranking',
+            'sys_file_metadata'
+        );
+        // Label 0 is dropped by the truthy `if ($label)` filter; 1 and 5 remain.
+        $this->assertStringContainsString('1 (1)', $rendered);
+        $this->assertStringContainsString('5 (5)', $rendered);
+    }
+
+    /**
      * Set up backend user with workspace
      */
     protected function setUpBackendUserWithWorkspace(int $uid): void


### PR DESCRIPTION
## Summary
Fixes a TypeError that occurs when TCA select field items have numeric (integer) labels instead of strings. This issue manifested when schema introspection was performed on fields like `sys_file_metadata.ranking` in TYPO3 13, which legitimately uses integer labels (0-5).

## Key Changes
- **TableAccessService.parseSelectItems()**: Cast both item values and labels to strings before storing them in the result arrays. This ensures downstream consumers like `translateLabel()` and string concatenation operations receive type-strict string values rather than integers.
- **Test coverage**: Added `testSelectItemsWithIntegerLabelsDoNotBreakFormatting()` to verify that:
  - Integer labels are properly converted to strings
  - The full formatting pipeline (including `TcaFormattingUtility::addFieldDetailsInline()`) works without raising TypeErrors
  - The rendered output correctly includes the formatted labels

## Implementation Details
The fix is minimal and focused: both the item value and label are now explicitly cast to strings in `parseSelectItems()`. This prevents type errors in downstream code that expects string values while maintaining backward compatibility with existing string-based labels. The test demonstrates the real-world scenario where this issue occurred and validates the complete code path that would have previously failed.

https://claude.ai/code/session_013cPTgYKTQsQTR6TmND8q5a