### PR TITLE
Add source tracking to BeforeRecordReadEvent for call-site awareness

### DIFF
--- a/Classes/Event/BeforeRecordReadEvent.php
+++ b/Classes/Event/BeforeRecordReadEvent.php
@@ -7,17 +7,21 @@ namespace Hn\McpServer\Event;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 
 /**
- * PSR-14 event dispatched before ReadTableTool executes a database query.
+ * PSR-14 event dispatched before a tool executes a record-loading query.
  *
  * Listeners receive a mutable QueryBuilder and can attach additional WHERE
  * conditions to restrict what records the user is allowed to see. The event
- * is dispatched for each top-level SELECT and for inline-relation child
- * lookups — so any restriction applied here also filters embedded relations.
+ * is dispatched for top-level SELECTs, inline-relation child lookups, and
+ * SearchTool's per-table search queries — so any restriction applied here
+ * also filters embedded relations and search results.
  *
  * Typical uses:
  * - Filter sys_file rows to the user's file mounts
  * - Filter a tenant-scoped table to the user's tenant id
  * - Hide records based on workflow state
+ *
+ * Listeners that need different behavior per call site can branch on
+ * getSource(); most restrictions are tool-agnostic and ignore it.
  *
  * Not dispatched on internal integrity queries from WriteTableTool (duplicate
  * checks, child lookups during save), since those must see all rows to
@@ -25,15 +29,22 @@ use TYPO3\CMS\Core\Database\Query\QueryBuilder;
  */
 final class BeforeRecordReadEvent
 {
+    public const SOURCE_READ = 'read';
+    public const SOURCE_READ_INLINE = 'read-inline';
+    public const SOURCE_SEARCH = 'search';
+    public const SOURCE_SEARCH_PARENT = 'search-parent';
+
     /**
      * @param string $table The table being queried
      * @param QueryBuilder $queryBuilder Mutable query builder — listeners may call andWhere()
      * @param string $queryType 'select' for the result query, 'count' for the total-count query
+     * @param string $source The originating call site, e.g. self::SOURCE_READ, self::SOURCE_SEARCH
      */
     public function __construct(
         private readonly string $table,
         private readonly QueryBuilder $queryBuilder,
         private readonly string $queryType,
+        private readonly string $source = self::SOURCE_READ,
     ) {}
 
     public function getTable(): string
@@ -49,5 +60,10 @@ final class BeforeRecordReadEvent
     public function getQueryType(): string
     {
         return $this->queryType;
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
     }
 }

--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -343,8 +343,8 @@ class ReadTableTool extends AbstractRecordTool
 
         // Allow listeners to add restrictions (e.g. file mounts, tenant scopes)
         $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
-        $eventDispatcher->dispatch(new BeforeRecordReadEvent($table, $countQueryBuilder, 'count'));
-        $eventDispatcher->dispatch(new BeforeRecordReadEvent($table, $queryBuilder, 'select'));
+        $eventDispatcher->dispatch(new BeforeRecordReadEvent($table, $countQueryBuilder, 'count', BeforeRecordReadEvent::SOURCE_READ));
+        $eventDispatcher->dispatch(new BeforeRecordReadEvent($table, $queryBuilder, 'select', BeforeRecordReadEvent::SOURCE_READ));
 
         try {
             $totalCount = $countQueryBuilder->executeQuery()->fetchOne();
@@ -950,7 +950,7 @@ class ReadTableTool extends AbstractRecordTool
 
         // Allow listeners to add restrictions to inline-child lookups too
         $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
-        $eventDispatcher->dispatch(new BeforeRecordReadEvent($table, $queryBuilder, 'select'));
+        $eventDispatcher->dispatch(new BeforeRecordReadEvent($table, $queryBuilder, 'select', BeforeRecordReadEvent::SOURCE_READ_INLINE));
 
         $records = $queryBuilder->executeQuery()->fetchAllAssociative();
         $records = $this->applyWorkspaceOverlay($table, $records);

--- a/Classes/MCP/Tool/SearchTool.php
+++ b/Classes/MCP/Tool/SearchTool.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Hn\McpServer\MCP\Tool;
 
 use Doctrine\DBAL\ParameterType;
+use Hn\McpServer\Event\BeforeRecordReadEvent;
 use Hn\McpServer\Exception\DatabaseException;
 use Hn\McpServer\Exception\ValidationException;
 use Mcp\Types\CallToolResult;
 use Mcp\Types\TextContent;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
@@ -465,9 +467,13 @@ class SearchTool extends AbstractRecordTool
             return [];
         }
         
+        // Allow listeners to add restrictions to the parent-lookup query as well
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $eventDispatcher->dispatch(new BeforeRecordReadEvent($parentTable, $queryBuilder, 'select', BeforeRecordReadEvent::SOURCE_SEARCH_PARENT));
+
         try {
             $parentRecords = $queryBuilder->executeQuery()->fetchAllAssociative();
-            
+
             // Enhance with page information
             return $this->enhanceRecordsWithPageInfo($parentRecords, $parentTable);
         } catch (\Throwable $e) {
@@ -697,6 +703,11 @@ class SearchTool extends AbstractRecordTool
 
         // Apply limit
         $queryBuilder->setMaxResults($limit);
+
+        // Allow listeners to add restrictions (file mounts, tenant scopes, …)
+        // so search never surfaces records ReadTableTool would have hidden.
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $eventDispatcher->dispatch(new BeforeRecordReadEvent($table, $queryBuilder, 'select', BeforeRecordReadEvent::SOURCE_SEARCH));
 
         // Execute query with error handling
         try {


### PR DESCRIPTION
## Summary
This PR enhances the `BeforeRecordReadEvent` to track the originating call site, allowing event listeners to apply different restrictions based on where the record query originates. This enables more granular access control across different tools and query contexts.

## Key Changes
- **Added source constants to BeforeRecordReadEvent**: Introduced four source constants (`SOURCE_READ`, `SOURCE_READ_INLINE`, `SOURCE_SEARCH`, `SOURCE_SEARCH_PARENT`) to identify the query origin
- **Added `source` parameter to event constructor**: Made the source parameter part of the event's immutable state with a default value of `SOURCE_READ`
- **Added `getSource()` method**: Allows listeners to inspect the call site and conditionally apply restrictions
- **Updated ReadTableTool**: Dispatches events with `SOURCE_READ` for top-level queries and `SOURCE_READ_INLINE` for inline-relation child lookups
- **Updated SearchTool**: Dispatches events with `SOURCE_SEARCH` for table searches and `SOURCE_SEARCH_PARENT` for parent-record lookups during inline searches
- **Updated documentation**: Enhanced the class docblock to explain the new source parameter and its use cases

## Implementation Details
- The `source` parameter defaults to `SOURCE_READ` for backward compatibility
- All existing event dispatches have been updated to explicitly specify their source
- The documentation notes that most restrictions are tool-agnostic and can ignore the source, but listeners can branch on it when needed
- This allows listeners to implement different behavior for search queries vs. regular reads, or for parent lookups vs. direct record access

https://claude.ai/code/session_01BobrT2MJunSdd8txXkRJUN