### PR TITLE
Fix TSconfig setup for TYPO3 14 compatibility in functional tests

### DIFF
--- a/Tests/Functional/MCP/Tool/DynamicSelectItemsTest.php
+++ b/Tests/Functional/MCP/Tool/DynamicSelectItemsTest.php
@@ -8,6 +8,7 @@ use Hn\McpServer\MCP\Tool\Record\GetTableSchemaTool;
 use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
 use Hn\McpServer\Service\SelectItemResolver;
 use Hn\McpServer\Service\TableAccessService;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -28,15 +29,6 @@ class DynamicSelectItemsTest extends FunctionalTestCase
         'typo3conf/ext/mcp_server',
     ];
 
-    protected array $configurationToUseInTestInstance = [
-        'BE' => [
-            'defaultPageTSconfig' => '
-                TCEFORM.tt_content.colPos.addItems.20 = Custom Column
-                TCEFORM.tt_content.colPos.addItems.30 = Another Column
-            ',
-        ],
-    ];
-
     protected WriteTableTool $writeTool;
     protected TableAccessService $tableAccessService;
     protected SelectItemResolver $selectItemResolver;
@@ -47,6 +39,16 @@ class DynamicSelectItemsTest extends FunctionalTestCase
 
         $this->importCSVDataSet(__DIR__ . '/../../Fixtures/be_users.csv');
         $this->importCSVDataSet(__DIR__ . '/../../Fixtures/pages.csv');
+
+        // Page-level TSconfig that adds custom colPos items.
+        // Using pages.TSconfig works on TYPO3 13 and 14;
+        // $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPageTSconfig'] was removed in TYPO3 14 (#105377).
+        GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('pages')
+            ->update('pages', [
+                'TSconfig' => "TCEFORM.tt_content.colPos.addItems.20 = Custom Column\n"
+                    . "TCEFORM.tt_content.colPos.addItems.30 = Another Column",
+            ], ['uid' => 1]);
 
         $this->setUpBackendUser(1);
         $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('en');
@@ -66,7 +68,7 @@ class DynamicSelectItemsTest extends FunctionalTestCase
 
     public function testSelectItemResolverReturnsTsconfigAddedItems(): void
     {
-        $resolved = $this->selectItemResolver->resolveSelectItems('tt_content', 'colPos');
+        $resolved = $this->selectItemResolver->resolveSelectItems('tt_content', 'colPos', ['pid' => 1]);
         $this->assertNotNull($resolved, 'colPos should resolve. Values: ' . json_encode($resolved));
 
         // Standard colPos value 0 should always be present


### PR DESCRIPTION
## Summary
Updated the functional test setup to use page-level TSconfig instead of global `defaultPageTSconfig`, ensuring compatibility with TYPO3 14 where the global configuration option was removed.

## Key Changes
- Removed `$configurationToUseInTestInstance` array that set `BE.defaultPageTSconfig` (deprecated in TYPO3 14)
- Moved TSconfig configuration to the `setUp()` method, applying it directly to the pages table via `pages.TSconfig` field
- Updated the test to pass the page ID (`['pid' => 1]`) when resolving select items, allowing the resolver to fetch page-specific TSconfig
- Added explanatory comment documenting the TYPO3 version compatibility rationale

## Implementation Details
The change uses `ConnectionPool` to directly update the pages table with TSconfig containing the custom `colPos` items. This approach works across TYPO3 13 and 14, as page-level TSconfig is the standard mechanism for configuration in TYPO3 14 after the removal of the global `defaultPageTSconfig` option (see TYPO3 issue #105377).

https://claude.ai/code/session_017UBw89BUjFUTMQikcFqhnW