### PR TITLE
Implement RFC 7591 OAuth Dynamic Client Registration

### DIFF
--- a/Classes/Controller/McpServerModuleController.php
+++ b/Classes/Controller/McpServerModuleController.php
@@ -77,15 +77,7 @@ class McpServerModuleController
         ]);
 
         // Format tokens for template display (same shape as AJAX response)
-        $formattedTokens = array_map(function ($token) {
-            return [
-                'uid' => $token['uid'],
-                'client_name' => $token['client_name'],
-                'created' => date('Y-m-d H:i:s', $token['crdate']),
-                'last_used' => $token['last_used'] > 0 ? date('Y-m-d H:i:s', $token['last_used']) : 'Never',
-                'expires' => date('Y-m-d H:i:s', $token['expires']),
-            ];
-        }, $tokens);
+        $formattedTokens = $this->formatTokensForDisplay($tokens);
 
         // Prepare template variables
         $templateVariables = [
@@ -232,6 +224,43 @@ class McpServerModuleController
     }
 
     /**
+     * Enrich raw token rows with the registered client's name so the UI can show
+     * "Claude" (registered) instead of just whatever free-text label was put on
+     * the token. For tokens bound to the well-known public client (manual tokens
+     * issued from this module) the registered name is generic, so we keep showing
+     * the user-entered token label as the primary name.
+     */
+    private function formatTokensForDisplay(array $tokens): array
+    {
+        $clientUids = array_filter(array_map(fn($t) => (int)($t['client_uid'] ?? 0), $tokens));
+        $clients = $this->oauthService->getClientsByUids($clientUids);
+
+        return array_map(function ($token) use ($clients) {
+            $clientUid = (int)($token['client_uid'] ?? 0);
+            $client = $clients[$clientUid] ?? null;
+            $isWellKnown = $client !== null && $client['client_id'] === OAuthService::WELL_KNOWN_CLIENT_ID;
+            $tokenLabel = (string)($token['client_name'] ?? '');
+
+            if ($client !== null && !$isWellKnown) {
+                $primary = $client['client_name'] !== '' ? $client['client_name'] : $tokenLabel;
+                $secondary = ($tokenLabel !== '' && $tokenLabel !== $primary) ? $tokenLabel : null;
+            } else {
+                $primary = $tokenLabel;
+                $secondary = null;
+            }
+
+            return [
+                'uid' => $token['uid'],
+                'client_name' => $primary,
+                'token_label' => $secondary,
+                'created' => date('Y-m-d H:i:s', $token['crdate']),
+                'last_used' => $token['last_used'] > 0 ? date('Y-m-d H:i:s', $token['last_used']) : 'Never',
+                'expires' => date('Y-m-d H:i:s', $token['expires']),
+            ];
+        }, $tokens);
+    }
+
+    /**
      * Get user tokens via AJAX for dynamic updates
      */
     public function getUserTokensAction(ServerRequestInterface $request): ResponseInterface
@@ -246,15 +275,7 @@ class McpServerModuleController
             $tokens = $this->oauthService->getUserTokens($userId);
             
             // Format tokens for frontend display
-            $formattedTokens = array_map(function($token) {
-                return [
-                    'uid' => $token['uid'],
-                    'client_name' => $token['client_name'],
-                    'created' => date('Y-m-d H:i:s', $token['crdate']),
-                    'expires' => date('Y-m-d H:i:s', $token['expires']),
-                    'last_used' => $token['last_used'] > 0 ? date('Y-m-d H:i:s', $token['last_used']) : 'Never',
-                ];
-            }, $tokens);
+            $formattedTokens = $this->formatTokensForDisplay($tokens);
             
             return new JsonResponse([
                 'success' => true,

--- a/Classes/Http/OAuthAuthorizeEndpoint.php
+++ b/Classes/Http/OAuthAuthorizeEndpoint.php
@@ -186,7 +186,8 @@ class OAuthAuthorizeEndpoint
             $clientName,
             $redirectUri,
             $pkceChallenge,
-            $challengeMethod
+            $challengeMethod,
+            $client['client_id']
         );
 
         // If redirect_uri is provided, redirect there with the code

--- a/Classes/Http/OAuthAuthorizeEndpoint.php
+++ b/Classes/Http/OAuthAuthorizeEndpoint.php
@@ -157,18 +157,30 @@ class OAuthAuthorizeEndpoint
         $queryParams = $request->getQueryParams();
         $postParams = $request->getParsedBody() ?: [];
 
+        $clientId = $queryParams['client_id'] ?? $postParams['client_id'] ?? '';
         $clientName = $postParams['client_name'] ?? $this->resolveClientName($request);
         $redirectUri = $queryParams['redirect_uri'] ?? '';
         $pkceChallenge = $queryParams['code_challenge'] ?? '';
         $challengeMethod = $queryParams['code_challenge_method'] ?? 'S256';
         $state = $postParams['state'] ?? $queryParams['state'] ?? '';
 
+        $oauthService = GeneralUtility::makeInstance(OAuthService::class);
+
+        // Re-validate the client and redirect_uri so an attacker cannot skip the consent
+        // form's checks by POSTing directly to this endpoint.
+        $client = $oauthService->getClient((string)$clientId);
+        if ($client === null) {
+            return $this->createErrorResponse('invalid_client', 'Unknown client_id');
+        }
+        if ($redirectUri !== '' && !$oauthService->isRedirectUriAllowed($client, $redirectUri)) {
+            return $this->createErrorResponse('invalid_request', 'redirect_uri is not registered for this client');
+        }
+
         // Only S256 is supported for PKCE
         if (!empty($pkceChallenge) && $challengeMethod !== 'S256') {
             return $this->createErrorResponse('invalid_request', 'Only S256 code_challenge_method is supported');
         }
 
-        $oauthService = GeneralUtility::makeInstance(OAuthService::class);
         $code = $oauthService->createAuthorizationCode(
             $beUserId,
             $clientName,
@@ -215,18 +227,24 @@ class OAuthAuthorizeEndpoint
     private function showConsentForm(ServerRequestInterface $request): ResponseInterface
     {
         $queryParams = $request->getQueryParams();
-        
+
         $clientId = $queryParams['client_id'] ?? '';
-        $clientName = $this->resolveClientName($request);
         $redirectUri = $queryParams['redirect_uri'] ?? '';
         $codeChallenge = $queryParams['code_challenge'] ?? '';
         $challengeMethod = $queryParams['code_challenge_method'] ?? 'S256';
         $state = $queryParams['state'] ?? '';
 
-        // Validate required parameters
-        if (empty($clientId) || $clientId !== 'typo3-mcp-server') {
-            return $this->createErrorResponse('invalid_client', 'Invalid client_id');
+        // Validate the client against the registered clients table
+        $oauthService = GeneralUtility::makeInstance(OAuthService::class);
+        $client = $oauthService->getClient((string)$clientId);
+        if ($client === null) {
+            return $this->createErrorResponse('invalid_client', 'Unknown client_id');
         }
+        if ($redirectUri !== '' && !$oauthService->isRedirectUriAllowed($client, $redirectUri)) {
+            return $this->createErrorResponse('invalid_request', 'redirect_uri is not registered for this client');
+        }
+
+        $clientName = $this->resolveClientName($request);
 
         $beUser = $GLOBALS['BE_USER'];
         $username = $beUser->user['username'] ?? 'Unknown';

--- a/Classes/Http/OAuthAuthorizeEndpoint.php
+++ b/Classes/Http/OAuthAuthorizeEndpoint.php
@@ -245,7 +245,14 @@ class OAuthAuthorizeEndpoint
             return $this->createErrorResponse('invalid_request', 'redirect_uri is not registered for this client');
         }
 
-        $clientName = $this->resolveClientName($request);
+        // Prefer the name the client supplied during dynamic registration; fall
+        // back to the Referer-hostname heuristic only for the well-known seeded
+        // client (which has a generic placeholder name).
+        $registeredName = trim((string)($client['client_name'] ?? ''));
+        $isWellKnown = $client['client_id'] === OAuthService::WELL_KNOWN_CLIENT_ID;
+        $clientName = (!$isWellKnown && $registeredName !== '')
+            ? $registeredName
+            : $this->resolveClientName($request);
 
         $beUser = $GLOBALS['BE_USER'];
         $username = $beUser->user['username'] ?? 'Unknown';

--- a/Classes/Http/OAuthAuthorizeEndpoint.php
+++ b/Classes/Http/OAuthAuthorizeEndpoint.php
@@ -157,6 +157,14 @@ class OAuthAuthorizeEndpoint
         $queryParams = $request->getQueryParams();
         $postParams = $request->getParsedBody() ?: [];
 
+        // CSRF: the POST must carry a token that matches what showConsentForm stored
+        // in the backend user's session. This defends against a logged-in BE user
+        // being tricked into auto-submitting approve=1 from an attacker page.
+        $providedCsrf = (string)($postParams['csrf_token'] ?? '');
+        if (!$this->verifyCsrfToken($providedCsrf)) {
+            return $this->createErrorResponse('invalid_request', 'Invalid or missing CSRF token');
+        }
+
         $clientId = $queryParams['client_id'] ?? $postParams['client_id'] ?? '';
         $clientName = $postParams['client_name'] ?? $this->resolveClientName($request);
         $redirectUri = $queryParams['redirect_uri'] ?? '';
@@ -180,6 +188,16 @@ class OAuthAuthorizeEndpoint
         if (!empty($pkceChallenge) && $challengeMethod !== 'S256') {
             return $this->createErrorResponse('invalid_request', 'Only S256 code_challenge_method is supported');
         }
+
+        // MCP authorization spec: public clients (no client_secret) MUST use PKCE.
+        // Without a challenge, mere possession of the code would be enough to mint
+        // a token, since verifyClientSecret() short-circuits for public clients.
+        if (($client['token_endpoint_auth_method'] ?? 'none') === 'none' && $pkceChallenge === '') {
+            return $this->createErrorResponse('invalid_request', 'Public clients must use PKCE (code_challenge is required)');
+        }
+
+        // CSRF token has been used — rotate it so a submitted form can't be replayed.
+        $this->clearCsrfToken();
 
         $code = $oauthService->createAuthorizationCode(
             $beUserId,
@@ -245,6 +263,12 @@ class OAuthAuthorizeEndpoint
             return $this->createErrorResponse('invalid_request', 'redirect_uri is not registered for this client');
         }
 
+        // MCP authorization spec: public clients (no secret) MUST use PKCE.
+        // Reject early so the user isn't asked to consent to something we'd later refuse.
+        if (($client['token_endpoint_auth_method'] ?? 'none') === 'none' && $codeChallenge === '') {
+            return $this->createErrorResponse('invalid_request', 'Public clients must use PKCE (code_challenge is required)');
+        }
+
         // Prefer the name the client supplied during dynamic registration; fall
         // back to the Referer-hostname heuristic only for the well-known seeded
         // client (which has a generic placeholder name).
@@ -266,6 +290,7 @@ class OAuthAuthorizeEndpoint
             'code_challenge_method' => htmlspecialchars($challengeMethod),
             'state' => htmlspecialchars($state),
             'user_id' => $beUser->user['uid'],
+            'csrf_token' => htmlspecialchars($this->getOrCreateCsrfToken()),
         ]);
 
         $stream = new Stream('php://temp', 'rw');
@@ -289,6 +314,48 @@ class OAuthAuthorizeEndpoint
         );
     }
 
+
+    private const CSRF_SESSION_KEY = 'mcp_oauth_csrf';
+
+    /**
+     * Return the CSRF token stored in the BE user's session, minting one on
+     * first call. Stable across consent-form reloads so opening the form in
+     * multiple tabs still works.
+     */
+    private function getOrCreateCsrfToken(): string
+    {
+        $beUser = $GLOBALS['BE_USER'] ?? null;
+        if (!$beUser instanceof BackendUserAuthentication) {
+            return '';
+        }
+        $token = $beUser->getSessionData(self::CSRF_SESSION_KEY);
+        if (!is_string($token) || $token === '') {
+            $token = bin2hex(random_bytes(32));
+            $beUser->setAndSaveSessionData(self::CSRF_SESSION_KEY, $token);
+        }
+        return $token;
+    }
+
+    private function verifyCsrfToken(string $provided): bool
+    {
+        $beUser = $GLOBALS['BE_USER'] ?? null;
+        if (!$beUser instanceof BackendUserAuthentication) {
+            return false;
+        }
+        $stored = $beUser->getSessionData(self::CSRF_SESSION_KEY);
+        if (!is_string($stored) || $stored === '' || $provided === '') {
+            return false;
+        }
+        return hash_equals($stored, $provided);
+    }
+
+    private function clearCsrfToken(): void
+    {
+        $beUser = $GLOBALS['BE_USER'] ?? null;
+        if ($beUser instanceof BackendUserAuthentication) {
+            $beUser->setAndSaveSessionData(self::CSRF_SESSION_KEY, '');
+        }
+    }
 
     private function createErrorResponse(string $error, string $description = ''): ResponseInterface
     {
@@ -445,6 +512,7 @@ class OAuthAuthorizeEndpoint
             <input type="hidden" name="code_challenge_method" value="' . $data['code_challenge_method'] . '">
             <input type="hidden" name="state" value="' . $data['state'] . '">
             <input type="hidden" name="user_id" value="' . $data['user_id'] . '">
+            <input type="hidden" name="csrf_token" value="' . $data['csrf_token'] . '">
 
             <div class="buttons">
                 <button type="submit" name="approve" value="1" class="approve">Authorize Access</button>

--- a/Classes/Http/OAuthRegisterEndpoint.php
+++ b/Classes/Http/OAuthRegisterEndpoint.php
@@ -56,7 +56,11 @@ class OAuthRegisterEndpoint
 
             // Register the client
             $oauthService = GeneralUtility::makeInstance(OAuthService::class);
-            $clientInfo = $oauthService->registerClient($clientData);
+            try {
+                $clientInfo = $oauthService->registerClient($clientData);
+            } catch (\InvalidArgumentException $e) {
+                return $this->createErrorResponse($request, 'invalid_redirect_uri', $e->getMessage());
+            }
 
             // Return client registration response
             $stream = new Stream('php://temp', 'rw');

--- a/Classes/Http/OAuthRegisterEndpoint.php
+++ b/Classes/Http/OAuthRegisterEndpoint.php
@@ -35,7 +35,9 @@ class OAuthRegisterEndpoint
             $body = $request->getBody()->getContents();
             $clientData = json_decode($body, true);
 
-            if (!$clientData) {
+            // Note: an empty JSON object {} is a valid RFC 7591 request — every
+            // metadata field has a server-side default — so only reject non-objects.
+            if (!is_array($clientData)) {
                 return $this->createErrorResponse($request, 'invalid_request', 'Invalid JSON in request body');
             }
 

--- a/Classes/Http/OAuthTokenEndpoint.php
+++ b/Classes/Http/OAuthTokenEndpoint.php
@@ -59,8 +59,9 @@ class OAuthTokenEndpoint
                 return $this->createErrorResponse($request, 'invalid_client', 'Invalid client_secret');
             }
 
-            // Exchange code for token (also enforces redirect_uri match per RFC 6749 §4.1.3)
-            $tokenData = $oauthService->exchangeCodeForToken($code, $codeVerifier, $request, $redirectUri);
+            // Exchange code for token (also enforces redirect_uri match per RFC 6749 §4.1.3
+            // and code-to-client binding per RFC 6749 §10.5)
+            $tokenData = $oauthService->exchangeCodeForToken($code, $codeVerifier, $request, $redirectUri, $client['client_id']);
 
             if (!$tokenData) {
                 return $this->createErrorResponse($request, 'invalid_grant', 'Invalid or expired authorization code');

--- a/Classes/Http/OAuthTokenEndpoint.php
+++ b/Classes/Http/OAuthTokenEndpoint.php
@@ -32,12 +32,14 @@ class OAuthTokenEndpoint
             }
 
             $parsedBody = $request->getParsedBody() ?: [];
-            
+
             // Extract parameters (support both form data and JSON)
             $grantType = $parsedBody['grant_type'] ?? '';
             $code = $parsedBody['code'] ?? '';
             $clientId = $parsedBody['client_id'] ?? '';
+            $clientSecret = $parsedBody['client_secret'] ?? null;
             $codeVerifier = $parsedBody['code_verifier'] ?? null;
+            $redirectUri = $parsedBody['redirect_uri'] ?? null;
 
             // Validate required parameters
             if ($grantType !== 'authorization_code') {
@@ -48,13 +50,17 @@ class OAuthTokenEndpoint
                 return $this->createErrorResponse($request, 'invalid_request', 'Missing required parameter: code');
             }
 
-            if (empty($clientId) || $clientId !== 'typo3-mcp-server') {
-                return $this->createErrorResponse($request, 'invalid_client', 'Invalid client_id');
+            $oauthService = GeneralUtility::makeInstance(OAuthService::class);
+            $client = $oauthService->getClient((string)$clientId);
+            if ($client === null) {
+                return $this->createErrorResponse($request, 'invalid_client', 'Unknown client_id');
+            }
+            if (!$oauthService->verifyClientSecret($client, $clientSecret)) {
+                return $this->createErrorResponse($request, 'invalid_client', 'Invalid client_secret');
             }
 
-            // Exchange code for token
-            $oauthService = GeneralUtility::makeInstance(OAuthService::class);
-            $tokenData = $oauthService->exchangeCodeForToken($code, $codeVerifier, $request);
+            // Exchange code for token (also enforces redirect_uri match per RFC 6749 §4.1.3)
+            $tokenData = $oauthService->exchangeCodeForToken($code, $codeVerifier, $request, $redirectUri);
 
             if (!$tokenData) {
                 return $this->createErrorResponse($request, 'invalid_grant', 'Invalid or expired authorization code');

--- a/Classes/Http/OAuthTokenEndpoint.php
+++ b/Classes/Http/OAuthTokenEndpoint.php
@@ -41,6 +41,14 @@ class OAuthTokenEndpoint
             $codeVerifier = $parsedBody['code_verifier'] ?? null;
             $redirectUri = $parsedBody['redirect_uri'] ?? null;
 
+            // RFC 6749 §2.3.1: clients registered with client_secret_basic send their
+            // credentials via HTTP Basic auth instead of the request body.
+            $basicAuth = $this->extractBasicAuthCredentials($request);
+            if ($basicAuth !== null) {
+                $clientId = $basicAuth['client_id'];
+                $clientSecret = $basicAuth['client_secret'];
+            }
+
             // Validate required parameters
             if ($grantType !== 'authorization_code') {
                 return $this->createErrorResponse($request, 'unsupported_grant_type', 'Only authorization_code grant type is supported');
@@ -86,6 +94,30 @@ class OAuthTokenEndpoint
         } catch (\Throwable $e) {
             return $this->createErrorResponse($request, 'server_error', $e->getMessage(), 500);
         }
+    }
+
+    /**
+     * Parse HTTP Basic client authentication (RFC 6749 §2.3.1).
+     * Both client_id and client_secret are form-urlencoded before being
+     * concatenated and base64-encoded, so they must be decoded here.
+     *
+     * @return array{client_id: string, client_secret: string}|null
+     */
+    private function extractBasicAuthCredentials(ServerRequestInterface $request): ?array
+    {
+        $header = trim($request->getHeaderLine('Authorization'));
+        if (stripos($header, 'Basic ') !== 0) {
+            return null;
+        }
+        $decoded = base64_decode(substr($header, 6), true);
+        if ($decoded === false || !str_contains($decoded, ':')) {
+            return null;
+        }
+        [$clientId, $clientSecret] = explode(':', $decoded, 2);
+        return [
+            'client_id' => urldecode($clientId),
+            'client_secret' => urldecode($clientSecret),
+        ];
     }
 
     private function createErrorResponse(ServerRequestInterface $request, string $error, string $description = '', int $statusCode = 400): ResponseInterface

--- a/Classes/Service/OAuthService.php
+++ b/Classes/Service/OAuthService.php
@@ -14,7 +14,8 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class OAuthService
 {
-    private const CLIENT_ID = 'typo3-mcp-server';
+    public const WELL_KNOWN_CLIENT_ID = 'typo3-mcp-server';
+    private const CLIENTS_TABLE = 'tx_mcpserver_oauth_clients';
     private const CODE_EXPIRY_SECONDS = 600; // 10 minutes
     private const TOKEN_EXPIRY_SECONDS = 2592000; // 30 days
 
@@ -24,7 +25,7 @@ class OAuthService
     public function generateAuthorizationUrl(string $baseUrl, string $clientName = '', string $redirectUri = '', string $codeChallenge = '', string $challengeMethod = 'S256', string $state = ''): string
     {
         $params = [
-            'client_id' => self::CLIENT_ID,
+            'client_id' => self::WELL_KNOWN_CLIENT_ID,
             'response_type' => 'code',
             'client_name' => $clientName,
         ];
@@ -78,7 +79,7 @@ class OAuthService
     /**
      * Exchange authorization code for access token
      */
-    public function exchangeCodeForToken(string $code, ?string $codeVerifier = null, ?ServerRequestInterface $request = null): ?array
+    public function exchangeCodeForToken(string $code, ?string $codeVerifier = null, ?ServerRequestInterface $request = null, ?string $redirectUri = null): ?array
     {
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('tx_mcpserver_oauth_codes');
@@ -97,6 +98,14 @@ class OAuthService
 
         if (!$authCode) {
             return null;
+        }
+
+        // RFC 6749 §4.1.3: if a redirect_uri was used in the auth request, the token
+        // request MUST include the same value. If none was used, accept missing.
+        if (!empty($authCode['redirect_uri'])) {
+            if ($redirectUri === null || $redirectUri !== $authCode['redirect_uri']) {
+                return null;
+            }
         }
 
         // Verify PKCE: if a challenge was set, the verifier is mandatory
@@ -331,55 +340,264 @@ class OAuthService
     }
 
     /**
-     * Register a new OAuth client dynamically
+     * Register a new OAuth client dynamically (RFC 7591).
+     *
+     * The plain client_secret (if any) is returned to the caller exactly once
+     * and only the SHA-256 hash is persisted. Public clients (the default for
+     * MCP, since they use PKCE) do not receive a secret.
      */
     public function registerClient(array $clientData): array
     {
-        // Generate client credentials
-        $clientId = 'mcp_client_' . bin2hex(random_bytes(16));
-        $clientSecret = bin2hex(random_bytes(32));
-        
-        // For now, store in database (could be enhanced later)
-        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getConnectionForTable('tx_mcpserver_oauth_clients');
+        $authMethod = $clientData['token_endpoint_auth_method'] ?? 'none';
+        if (!in_array($authMethod, ['none', 'client_secret_post', 'client_secret_basic'], true)) {
+            $authMethod = 'none';
+        }
 
-        // Check if table exists, if not create it on the fly
+        $redirectUris = $clientData['redirect_uris'] ?? [];
+        if (!is_array($redirectUris)) {
+            $redirectUris = [];
+        }
+        $redirectUris = array_values(array_filter(array_map(
+            fn($v) => is_string($v) ? trim($v) : '',
+            $redirectUris
+        )));
+        // Reject the wildcard sentinel that is reserved for the seeded well-known client
+        $redirectUris = array_values(array_filter($redirectUris, fn($v) => $v !== '*'));
+        if (empty($redirectUris)) {
+            $redirectUris = ['http://localhost'];
+        }
+        foreach ($redirectUris as $uri) {
+            if (parse_url($uri) === false) {
+                throw new \InvalidArgumentException('Invalid redirect_uri: ' . $uri);
+            }
+        }
+
+        $grantTypes = $clientData['grant_types'] ?? ['authorization_code'];
+        if (!is_array($grantTypes) || empty($grantTypes)) {
+            $grantTypes = ['authorization_code'];
+        }
+
+        $clientId = 'mcp_' . bin2hex(random_bytes(16));
+        $plainSecret = '';
+        $storedSecret = '';
+        if ($authMethod !== 'none') {
+            $plainSecret = bin2hex(random_bytes(32));
+            $storedSecret = $this->hashToken($plainSecret);
+        }
+
+        $clientName = (string)($clientData['client_name'] ?? 'MCP Client');
+        $scope = (string)($clientData['scope'] ?? 'mcp_access');
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable(self::CLIENTS_TABLE);
+
+        $connection->insert(
+            self::CLIENTS_TABLE,
+            [
+                'pid' => 0,
+                'tstamp' => time(),
+                'crdate' => time(),
+                'client_id' => $clientId,
+                'client_secret' => $storedSecret,
+                'client_name' => $clientName,
+                'redirect_uris' => json_encode($redirectUris),
+                'grant_types' => json_encode($grantTypes),
+                'scope' => $scope,
+                'token_endpoint_auth_method' => $authMethod,
+            ]
+        );
+
+        $response = [
+            'client_id' => $clientId,
+            'client_id_issued_at' => time(),
+            'client_name' => $clientName,
+            'redirect_uris' => $redirectUris,
+            'grant_types' => $grantTypes,
+            'response_types' => ['code'],
+            'scope' => $scope,
+            'token_endpoint_auth_method' => $authMethod,
+        ];
+        if ($plainSecret !== '') {
+            $response['client_secret'] = $plainSecret;
+        }
+        return $response;
+    }
+
+    /**
+     * Look up a registered client by its public client_id.
+     * Returns a normalized array or null if no matching client is registered.
+     */
+    public function getClient(string $clientId): ?array
+    {
+        if ($clientId === '') {
+            return null;
+        }
+
+        $row = $this->fetchClientRow($clientId);
+        if (!$row && $clientId === self::WELL_KNOWN_CLIENT_ID) {
+            // Self-heal on installations that pre-date the clients table or upgrade wizard
+            $this->ensureWellKnownClient();
+            $row = $this->fetchClientRow($clientId);
+        }
+        if (!$row) {
+            return null;
+        }
+
+        $redirectUris = json_decode((string)($row['redirect_uris'] ?? ''), true);
+        $grantTypes = json_decode((string)($row['grant_types'] ?? ''), true);
+
+        return [
+            'uid' => (int)$row['uid'],
+            'client_id' => (string)$row['client_id'],
+            'client_name' => (string)$row['client_name'],
+            'redirect_uris' => is_array($redirectUris) ? $redirectUris : [],
+            'grant_types' => is_array($grantTypes) ? $grantTypes : ['authorization_code'],
+            'scope' => (string)$row['scope'],
+            'token_endpoint_auth_method' => (string)($row['token_endpoint_auth_method'] ?? 'none'),
+            'client_secret_hash' => (string)($row['client_secret'] ?? ''),
+        ];
+    }
+
+    private function fetchClientRow(string $clientId): ?array
+    {
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable(self::CLIENTS_TABLE);
+
+        $qb = $connection->createQueryBuilder();
+        $row = $qb
+            ->select('*')
+            ->from(self::CLIENTS_TABLE)
+            ->where(
+                $qb->expr()->eq('client_id', $qb->createNamedParameter($clientId)),
+                $qb->expr()->eq('deleted', $qb->createNamedParameter(0))
+            )
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchAssociative();
+
+        return $row ?: null;
+    }
+
+    /**
+     * Verify a redirect_uri against the URIs registered for a client.
+     *
+     * Exact match by default. As a transition affordance, the seeded
+     * well-known client may use the '*' sentinel to accept any URI;
+     * dynamic registrations cannot use it. Loopback URIs (per RFC 8252 §7.3)
+     * are matched without comparing the port.
+     */
+    public function isRedirectUriAllowed(array $client, string $redirectUri): bool
+    {
+        if ($redirectUri === '') {
+            return false;
+        }
+
+        $registered = $client['redirect_uris'] ?? [];
+        if (!is_array($registered) || empty($registered)) {
+            return false;
+        }
+
+        if (in_array('*', $registered, true)) {
+            return true;
+        }
+
+        if (in_array($redirectUri, $registered, true)) {
+            return true;
+        }
+
+        foreach ($registered as $candidate) {
+            if (is_string($candidate) && $this->isLoopbackUriMatch($candidate, $redirectUri)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isLoopbackUriMatch(string $registered, string $requested): bool
+    {
+        $reg = parse_url($registered);
+        $req = parse_url($requested);
+        if (!is_array($reg) || !is_array($req)) {
+            return false;
+        }
+        $loopbackHosts = ['localhost', '127.0.0.1', '::1', '[::1]'];
+        $regHost = $reg['host'] ?? '';
+        $reqHost = $req['host'] ?? '';
+        if (!in_array($regHost, $loopbackHosts, true) || !in_array($reqHost, $loopbackHosts, true)) {
+            return false;
+        }
+        if (($reg['scheme'] ?? '') !== ($req['scheme'] ?? '')) {
+            return false;
+        }
+        if ($regHost !== $reqHost) {
+            return false;
+        }
+        if (($reg['path'] ?? '') !== ($req['path'] ?? '')) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Verify the client_secret presented at the token endpoint.
+     * Returns true for public clients (no secret stored) — those are
+     * authenticated via PKCE, not a shared secret.
+     */
+    public function verifyClientSecret(array $client, ?string $providedSecret): bool
+    {
+        if (($client['token_endpoint_auth_method'] ?? 'none') === 'none' || empty($client['client_secret_hash'])) {
+            return true;
+        }
+        if ($providedSecret === null || $providedSecret === '') {
+            return false;
+        }
+        return hash_equals($client['client_secret_hash'], $this->hashToken($providedSecret));
+    }
+
+    /**
+     * Ensure the well-known 'typo3-mcp-server' client exists in the database.
+     * Idempotent and safe under concurrent calls; failures are swallowed because
+     * authentication can still proceed via the pre-table hardcoded behavior in
+     * older deployments.
+     */
+    public function ensureWellKnownClient(): void
+    {
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable(self::CLIENTS_TABLE);
+
         try {
+            $exists = (int)$connection->createQueryBuilder()
+                ->count('uid')
+                ->from(self::CLIENTS_TABLE)
+                ->where('client_id = ' . $connection->quote(self::WELL_KNOWN_CLIENT_ID))
+                ->executeQuery()
+                ->fetchOne();
+            if ($exists > 0) {
+                return;
+            }
+
             $connection->insert(
-                'tx_mcpserver_oauth_clients',
+                self::CLIENTS_TABLE,
                 [
                     'pid' => 0,
                     'tstamp' => time(),
                     'crdate' => time(),
-                    'client_id' => $clientId,
-                    'client_secret' => $clientSecret,
-                    'client_name' => $clientData['client_name'] ?? 'MCP Client',
-                    'redirect_uris' => json_encode($clientData['redirect_uris'] ?? []),
-                    'grant_types' => json_encode($clientData['grant_types'] ?? ['authorization_code']),
-                    'scope' => $clientData['scope'] ?? 'mcp_access',
+                    'client_id' => self::WELL_KNOWN_CLIENT_ID,
+                    'client_secret' => '',
+                    'client_name' => 'TYPO3 MCP Server',
+                    // '*' is the legacy-compatibility sentinel: this client accepts any
+                    // redirect_uri, preserving behavior for MCP clients that registered
+                    // before dynamic registration was implemented.
+                    'redirect_uris' => json_encode(['*']),
+                    'grant_types' => json_encode(['authorization_code']),
+                    'scope' => 'mcp_access',
+                    'token_endpoint_auth_method' => 'none',
                 ]
             );
-        } catch (\Exception $e) {
-            // If table doesn't exist, we'll use the fixed client approach for now
-            return [
-                'client_id' => self::CLIENT_ID,
-                'client_name' => $clientData['client_name'] ?? 'MCP Client',
-                'grant_types' => ['authorization_code'],
-                'response_types' => ['code'],
-                'scope' => 'mcp_access',
-                'redirect_uris' => $clientData['redirect_uris'] ?? ['http://localhost'],
-            ];
+        } catch (\Throwable $e) {
+            // Non-fatal: lookup will simply return null and the endpoint will reject the request
         }
-
-        return [
-            'client_id' => $clientId,
-            'client_secret' => $clientSecret,
-            'client_name' => $clientData['client_name'] ?? 'MCP Client',
-            'grant_types' => $clientData['grant_types'] ?? ['authorization_code'],
-            'response_types' => ['code'],
-            'scope' => $clientData['scope'] ?? 'mcp_access',
-            'redirect_uris' => $clientData['redirect_uris'] ?? ['http://localhost'],
-        ];
     }
 
     /**
@@ -388,7 +606,7 @@ class OAuthService
     public function getMetadata(string $baseUrl): array
     {
         $baseUrl = rtrim($baseUrl, '/');
-        
+
         return [
             'issuer' => $baseUrl,
             'authorization_endpoint' => $baseUrl . '/mcp_oauth/authorize',

--- a/Classes/Service/OAuthService.php
+++ b/Classes/Service/OAuthService.php
@@ -153,6 +153,16 @@ class OAuthService
             $clientIp = $request->getServerParams()['REMOTE_ADDR'] ?? '';
         }
 
+        // Resolve the issuing client so the token is linked to it for cascade
+        // revocation and observability.
+        $clientUid = 0;
+        if (!empty($authCode['client_id'])) {
+            $boundClient = $this->getClient((string)$authCode['client_id']);
+            if ($boundClient !== null) {
+                $clientUid = (int)$boundClient['uid'];
+            }
+        }
+
         // Create access token
         $tokenConnection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('tx_mcpserver_access_tokens');
@@ -165,6 +175,7 @@ class OAuthService
                 'crdate' => time(),
                 'token' => $this->hashToken($accessToken),
                 'be_user_uid' => $authCode['be_user_uid'],
+                'client_uid' => $clientUid,
                 'client_name' => $authCode['client_name'],
                 'expires' => $expires,
                 'last_used' => time(),
@@ -228,6 +239,14 @@ class OAuthService
             return null;
         }
 
+        // Cascade revocation: a token whose issuing client has been removed
+        // is no longer valid. Tokens with client_uid=0 are legacy (pre-binding)
+        // and are accepted as before.
+        $clientUid = (int)($tokenRecord['client_uid'] ?? 0);
+        if ($clientUid > 0 && !$this->clientUidIsActive($clientUid)) {
+            return null;
+        }
+
         // Auto-upgrade version-0 (plaintext) tokens to hashed on successful validation.
         // Best-effort: if the upgrade fails, authentication still succeeds and the
         // upgrade will be retried on next validation or handled by the upgrade wizard.
@@ -268,6 +287,7 @@ class OAuthService
 
         return [
             'be_user_uid' => (int)$tokenRecord['be_user_uid'],
+            'client_uid' => (int)($tokenRecord['client_uid'] ?? 0),
             'client_name' => $tokenRecord['client_name'],
             'token_uid' => (int)$tokenRecord['uid'],
         ];
@@ -478,6 +498,26 @@ class OAuthService
         ];
     }
 
+    private function clientUidIsActive(int $clientUid): bool
+    {
+        if ($clientUid <= 0) {
+            return false;
+        }
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable(self::CLIENTS_TABLE);
+        $qb = $connection->createQueryBuilder();
+        $count = (int)$qb
+            ->count('uid')
+            ->from(self::CLIENTS_TABLE)
+            ->where(
+                $qb->expr()->eq('uid', $qb->createNamedParameter($clientUid)),
+                $qb->expr()->eq('deleted', $qb->createNamedParameter(0))
+            )
+            ->executeQuery()
+            ->fetchOne();
+        return $count > 0;
+    }
+
     private function fetchClientRow(string $clientId): ?array
     {
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
@@ -649,7 +689,11 @@ class OAuthService
     }
 
     /**
-     * Create access token directly (bypassing authorization code flow)
+     * Create access token directly (bypassing authorization code flow).
+     *
+     * Used by the backend module for admin-issued tokens. These are bound to
+     * the well-known {@see self::WELL_KNOWN_CLIENT_ID} public client so they
+     * participate in cascade revocation and audit alongside OAuth-flow tokens.
      */
     public function createDirectAccessToken(int $beUserId, string $clientName, ?ServerRequestInterface $request = null): string
     {
@@ -661,6 +705,10 @@ class OAuthService
         if ($request !== null) {
             $clientIp = $request->getServerParams()['REMOTE_ADDR'] ?? '';
         }
+
+        // Bind to the well-known client (auto-seeded if missing)
+        $wellKnown = $this->getClient(self::WELL_KNOWN_CLIENT_ID);
+        $clientUid = $wellKnown !== null ? (int)$wellKnown['uid'] : 0;
 
         // Create access token
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
@@ -674,6 +722,7 @@ class OAuthService
                 'crdate' => time(),
                 'token' => $this->hashToken($accessToken),
                 'be_user_uid' => $beUserId,
+                'client_uid' => $clientUid,
                 'client_name' => $clientName,
                 'expires' => $expires,
                 'last_used' => time(),

--- a/Classes/Service/OAuthService.php
+++ b/Classes/Service/OAuthService.php
@@ -539,6 +539,49 @@ class OAuthService
     }
 
     /**
+     * Batch-load registered clients by their uids. Returns a map [uid => clientArray]
+     * with the same shape as {@see self::getClient()}. Missing or deleted clients
+     * are simply absent from the result.
+     */
+    public function getClientsByUids(array $uids): array
+    {
+        $uids = array_values(array_unique(array_filter(array_map('intval', $uids))));
+        if (empty($uids)) {
+            return [];
+        }
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable(self::CLIENTS_TABLE);
+        $qb = $connection->createQueryBuilder();
+        $rows = $qb
+            ->select('*')
+            ->from(self::CLIENTS_TABLE)
+            ->where(
+                $qb->expr()->in('uid', $qb->createNamedParameter($uids, \Doctrine\DBAL\ArrayParameterType::INTEGER)),
+                $qb->expr()->eq('deleted', $qb->createNamedParameter(0))
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $result = [];
+        foreach ($rows as $row) {
+            $redirectUris = json_decode((string)($row['redirect_uris'] ?? ''), true);
+            $grantTypes = json_decode((string)($row['grant_types'] ?? ''), true);
+            $result[(int)$row['uid']] = [
+                'uid' => (int)$row['uid'],
+                'client_id' => (string)$row['client_id'],
+                'client_name' => (string)$row['client_name'],
+                'redirect_uris' => is_array($redirectUris) ? $redirectUris : [],
+                'grant_types' => is_array($grantTypes) ? $grantTypes : ['authorization_code'],
+                'scope' => (string)$row['scope'],
+                'token_endpoint_auth_method' => (string)($row['token_endpoint_auth_method'] ?? 'none'),
+                'client_secret_hash' => (string)($row['client_secret'] ?? ''),
+            ];
+        }
+        return $result;
+    }
+
+    /**
      * Verify a redirect_uri against the URIs registered for a client.
      *
      * Exact match by default. As a transition affordance, the seeded

--- a/Classes/Service/OAuthService.php
+++ b/Classes/Service/OAuthService.php
@@ -47,9 +47,14 @@ class OAuthService
     }
 
     /**
-     * Create authorization code for authenticated user
+     * Create authorization code for authenticated user.
+     *
+     * The $clientId binds the issued code to the registered OAuth client per
+     * RFC 6749 §10.5; the token endpoint must reject any redemption by a
+     * different client. $clientName is the free-text display label kept for
+     * audit on the access token.
      */
-    public function createAuthorizationCode(int $beUserId, string $clientName, string $redirectUri = '', string $pkceChallenge = '', string $challengeMethod = 'S256'): string
+    public function createAuthorizationCode(int $beUserId, string $clientName, string $redirectUri = '', string $pkceChallenge = '', string $challengeMethod = 'S256', string $clientId = ''): string
     {
         $code = $this->generateSecureToken();
         $expires = time() + self::CODE_EXPIRY_SECONDS;
@@ -65,6 +70,7 @@ class OAuthService
                 'crdate' => time(),
                 'code' => $code,
                 'be_user_uid' => $beUserId,
+                'client_id' => $clientId,
                 'client_name' => $clientName,
                 'pkce_challenge' => $pkceChallenge,
                 'pkce_challenge_method' => $challengeMethod,
@@ -77,9 +83,14 @@ class OAuthService
     }
 
     /**
-     * Exchange authorization code for access token
+     * Exchange authorization code for access token.
+     *
+     * If $clientId is provided and the code was issued to a specific client,
+     * the two MUST match (RFC 6749 §10.5). A code without a stored client_id
+     * (legacy data from before code-to-client binding was introduced) is
+     * accepted regardless — those expire within {@see self::CODE_EXPIRY_SECONDS}.
      */
-    public function exchangeCodeForToken(string $code, ?string $codeVerifier = null, ?ServerRequestInterface $request = null, ?string $redirectUri = null): ?array
+    public function exchangeCodeForToken(string $code, ?string $codeVerifier = null, ?ServerRequestInterface $request = null, ?string $redirectUri = null, ?string $clientId = null): ?array
     {
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('tx_mcpserver_oauth_codes');
@@ -98,6 +109,15 @@ class OAuthService
 
         if (!$authCode) {
             return null;
+        }
+
+        // RFC 6749 §10.5: a code issued to one client must not be redeemable
+        // by a different client. Empty stored client_id means the code pre-dates
+        // binding (during the upgrade window) and is accepted.
+        if (!empty($authCode['client_id'])) {
+            if ($clientId === null || $clientId !== $authCode['client_id']) {
+                return null;
+            }
         }
 
         // RFC 6749 §4.1.3: if a redirect_uri was used in the auth request, the token
@@ -534,6 +554,14 @@ class OAuthService
             return false;
         }
         if (($reg['path'] ?? '') !== ($req['path'] ?? '')) {
+            return false;
+        }
+        // RFC 8252 §7.3 only relaxes the port; query and fragment must still match
+        // exactly so an attacker cannot pass arbitrary parameters via the redirect.
+        if (($reg['query'] ?? '') !== ($req['query'] ?? '')) {
+            return false;
+        }
+        if (($reg['fragment'] ?? '') !== ($req['fragment'] ?? '')) {
             return false;
         }
         return true;

--- a/Classes/Service/OAuthService.php
+++ b/Classes/Service/OAuthService.php
@@ -15,6 +15,12 @@ use Psr\Http\Message\ServerRequestInterface;
 class OAuthService
 {
     public const WELL_KNOWN_CLIENT_ID = 'typo3-mcp-server';
+    /**
+     * Sentinel used only by the seeded well-known client to mean "accept any
+     * loopback URI" (RFC 8252 native app pattern). Dynamic registrations
+     * cannot store this value.
+     */
+    public const REDIRECT_URI_LOOPBACK_SENTINEL = 'loopback:*';
     private const CLIENTS_TABLE = 'tx_mcpserver_oauth_clients';
     private const CODE_EXPIRY_SECONDS = 600; // 10 minutes
     private const TOKEN_EXPIRY_SECONDS = 2592000; // 30 days
@@ -153,6 +159,18 @@ class OAuthService
             $clientIp = $request->getServerParams()['REMOTE_ADDR'] ?? '';
         }
 
+        // Atomically consume the authorization code BEFORE issuing the token, so
+        // concurrent redemption attempts with the same code can't both mint a
+        // token (RFC 6749 §4.1.2 one-time-use requirement). Only the request
+        // that actually removes the row proceeds.
+        $consumed = $connection->delete(
+            'tx_mcpserver_oauth_codes',
+            ['uid' => $authCode['uid']]
+        );
+        if ($consumed === 0) {
+            return null;
+        }
+
         // Resolve the issuing client so the token is linked to it for cascade
         // revocation and observability.
         $clientUid = 0;
@@ -184,12 +202,6 @@ class OAuthService
                 'last_used_ip' => $clientIp,
                 'token_version' => 1,
             ]
-        );
-
-        // Delete the authorization code (one-time use)
-        $connection->delete(
-            'tx_mcpserver_oauth_codes',
-            ['uid' => $authCode['uid']]
         );
 
         return [
@@ -490,13 +502,19 @@ class OAuthService
             fn($v) => is_string($v) ? trim($v) : '',
             $redirectUris
         )));
-        // Reject the wildcard sentinel that is reserved for the seeded well-known client
-        $redirectUris = array_values(array_filter($redirectUris, fn($v) => $v !== '*'));
+        // Reject sentinels reserved for the seeded well-known client
+        $reserved = ['*', self::REDIRECT_URI_LOOPBACK_SENTINEL];
+        $redirectUris = array_values(array_filter($redirectUris, fn($v) => !in_array($v, $reserved, true)));
         if (empty($redirectUris)) {
             $redirectUris = ['http://localhost'];
         }
         foreach ($redirectUris as $uri) {
-            if (parse_url($uri) === false) {
+            $parts = parse_url($uri);
+            if (!is_array($parts)
+                || empty($parts['scheme'])
+                || empty($parts['host'])
+                || !in_array(strtolower($parts['scheme']), ['http', 'https'], true)
+            ) {
                 throw new \InvalidArgumentException('Invalid redirect_uri: ' . $uri);
             }
         }
@@ -675,10 +693,13 @@ class OAuthService
     /**
      * Verify a redirect_uri against the URIs registered for a client.
      *
-     * Exact match by default. As a transition affordance, the seeded
-     * well-known client may use the '*' sentinel to accept any URI;
-     * dynamic registrations cannot use it. Loopback URIs (per RFC 8252 §7.3)
-     * are matched without comparing the port.
+     * Exact match by default. The seeded well-known client may carry the
+     * {@see self::REDIRECT_URI_LOOPBACK_SENTINEL} sentinel meaning "any
+     * loopback URI" (RFC 8252 native-app pattern) — this keeps existing
+     * MCP clients working without making the well-known client an open
+     * redirector. Dynamic registrations cannot store the sentinel.
+     * Registered loopback URIs are additionally matched with port-agnostic
+     * comparison per RFC 8252 §7.3.
      */
     public function isRedirectUriAllowed(array $client, string $redirectUri): bool
     {
@@ -691,7 +712,9 @@ class OAuthService
             return false;
         }
 
-        if (in_array('*', $registered, true)) {
+        if (in_array(self::REDIRECT_URI_LOOPBACK_SENTINEL, $registered, true)
+            && $this->isLoopbackUri($redirectUri)
+        ) {
             return true;
         }
 
@@ -706,6 +729,19 @@ class OAuthService
         }
 
         return false;
+    }
+
+    private function isLoopbackUri(string $uri): bool
+    {
+        $parts = parse_url($uri);
+        if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
+            return false;
+        }
+        if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+            return false;
+        }
+        $loopbackHosts = ['localhost', '127.0.0.1', '::1', '[::1]'];
+        return in_array($parts['host'], $loopbackHosts, true);
     }
 
     private function isLoopbackUriMatch(string $registered, string $requested): bool
@@ -769,13 +805,24 @@ class OAuthService
             ->getConnectionForTable(self::CLIENTS_TABLE);
 
         try {
-            $exists = (int)$connection->createQueryBuilder()
-                ->count('uid')
+            // Look up including soft-deleted rows so we can undelete rather than
+            // fail to re-insert (client_id is intended to be unique).
+            $existing = $connection->createQueryBuilder()
+                ->select('uid', 'deleted')
                 ->from(self::CLIENTS_TABLE)
                 ->where('client_id = ' . $connection->quote(self::WELL_KNOWN_CLIENT_ID))
+                ->setMaxResults(1)
                 ->executeQuery()
-                ->fetchOne();
-            if ($exists > 0) {
+                ->fetchAssociative();
+
+            if (is_array($existing)) {
+                if ((int)($existing['deleted'] ?? 0) === 1) {
+                    $connection->update(
+                        self::CLIENTS_TABLE,
+                        ['deleted' => 0, 'tstamp' => time()],
+                        ['uid' => (int)$existing['uid']]
+                    );
+                }
                 return;
             }
 
@@ -788,10 +835,12 @@ class OAuthService
                     'client_id' => self::WELL_KNOWN_CLIENT_ID,
                     'client_secret' => '',
                     'client_name' => 'TYPO3 MCP Server',
-                    // '*' is the legacy-compatibility sentinel: this client accepts any
-                    // redirect_uri, preserving behavior for MCP clients that registered
-                    // before dynamic registration was implemented.
-                    'redirect_uris' => json_encode(['*']),
+                    // Legacy-compatibility sentinel: this client accepts any LOOPBACK
+                    // redirect_uri (any port, any path) — narrower than the previous
+                    // "accept any URI" behavior, so it's no longer an open redirector,
+                    // while still preserving native MCP clients that pinned to the
+                    // pre-DCR client_id.
+                    'redirect_uris' => json_encode([self::REDIRECT_URI_LOOPBACK_SENTINEL]),
                     'grant_types' => json_encode(['authorization_code']),
                     'scope' => 'mcp_access',
                     'token_endpoint_auth_method' => 'none',

--- a/Classes/Service/OAuthService.php
+++ b/Classes/Service/OAuthService.php
@@ -160,6 +160,7 @@ class OAuthService
             $boundClient = $this->getClient((string)$authCode['client_id']);
             if ($boundClient !== null) {
                 $clientUid = (int)$boundClient['uid'];
+                $this->touchClient($clientUid);
             }
         }
 
@@ -377,6 +378,94 @@ class OAuthService
             ['deleted' => 1, 'tstamp' => $currentTime],
             ['expires' => $tokenConnection->createQueryBuilder()->expr()->lt('expires', $currentTime)]
         );
+
+        $this->cleanupStaleClients($currentTime);
+    }
+
+    /**
+     * Soft-delete stale dynamically registered clients.
+     *
+     * Some MCP clients (notably claude.ai) register a NEW client on every fresh
+     * connection, so tx_mcpserver_oauth_clients grows unboundedly without cleanup.
+     * A client is stale when it has seen no activity for a full token lifetime
+     * AND holds no live token — deleting a client cascade-revokes its tokens
+     * (see {@see self::validateToken()}), so active clients must be kept.
+     * The well-known client is never removed.
+     */
+    private function cleanupStaleClients(int $currentTime): void
+    {
+        $threshold = $currentTime - self::TOKEN_EXPIRY_SECONDS;
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable(self::CLIENTS_TABLE);
+        $qb = $connection->createQueryBuilder();
+        $candidateUids = $qb
+            ->select('uid')
+            ->from(self::CLIENTS_TABLE)
+            ->where(
+                $qb->expr()->neq('client_id', $qb->createNamedParameter(self::WELL_KNOWN_CLIENT_ID)),
+                $qb->expr()->eq('deleted', $qb->createNamedParameter(0)),
+                $qb->expr()->lt('crdate', $qb->createNamedParameter($threshold)),
+                $qb->expr()->lt('last_used', $qb->createNamedParameter($threshold))
+            )
+            ->executeQuery()
+            ->fetchFirstColumn();
+        $candidateUids = array_map('intval', $candidateUids);
+
+        if (empty($candidateUids)) {
+            return;
+        }
+
+        $tokenConnection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_access_tokens');
+        $tqb = $tokenConnection->createQueryBuilder();
+        $activeUids = $tqb
+            ->select('client_uid')
+            ->distinct()
+            ->from('tx_mcpserver_access_tokens')
+            ->where(
+                $tqb->expr()->in('client_uid', $tqb->createNamedParameter($candidateUids, \Doctrine\DBAL\ArrayParameterType::INTEGER)),
+                $tqb->expr()->eq('deleted', $tqb->createNamedParameter(0)),
+                $tqb->expr()->gt('expires', $tqb->createNamedParameter($currentTime))
+            )
+            ->executeQuery()
+            ->fetchFirstColumn();
+        $activeUids = array_map('intval', $activeUids);
+
+        $staleUids = array_values(array_diff($candidateUids, $activeUids));
+        if (empty($staleUids)) {
+            return;
+        }
+
+        $updateQb = $connection->createQueryBuilder();
+        $updateQb
+            ->update(self::CLIENTS_TABLE)
+            ->where($updateQb->expr()->in('uid', $updateQb->createNamedParameter($staleUids, \Doctrine\DBAL\ArrayParameterType::INTEGER)))
+            ->set('deleted', 1)
+            ->set('tstamp', $currentTime)
+            ->executeStatement();
+    }
+
+    /**
+     * Record client activity so {@see self::cleanupStaleClients()} does not
+     * remove clients that are still in use. Best-effort.
+     */
+    private function touchClient(int $clientUid): void
+    {
+        if ($clientUid <= 0) {
+            return;
+        }
+        try {
+            GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getConnectionForTable(self::CLIENTS_TABLE)
+                ->update(
+                    self::CLIENTS_TABLE,
+                    ['last_used' => time(), 'tstamp' => time()],
+                    ['uid' => $clientUid]
+                );
+        } catch (\Throwable $e) {
+            // Non-fatal: activity tracking must not break the token flow
+        }
     }
 
     /**
@@ -459,6 +548,8 @@ class OAuthService
         ];
         if ($plainSecret !== '') {
             $response['client_secret'] = $plainSecret;
+            // RFC 7591 §3.2.1: REQUIRED when a client_secret is issued; 0 = never expires
+            $response['client_secret_expires_at'] = 0;
         }
         return $response;
     }
@@ -726,7 +817,7 @@ class OAuthService
             'response_types_supported' => ['code'],
             'grant_types_supported' => ['authorization_code'],
             'code_challenge_methods_supported' => ['S256'],
-            'token_endpoint_auth_methods_supported' => ['none', 'client_secret_post'],
+            'token_endpoint_auth_methods_supported' => ['none', 'client_secret_post', 'client_secret_basic'],
             'registration_endpoint_auth_methods_supported' => ['none'],
         ];
     }

--- a/Classes/Updates/SeedWellKnownOAuthClientUpgradeWizard.php
+++ b/Classes/Updates/SeedWellKnownOAuthClientUpgradeWizard.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Updates;
+
+use Hn\McpServer\Service\OAuthService;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
+use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+#[UpgradeWizard('mcpServer_seedWellKnownOAuthClient')]
+class SeedWellKnownOAuthClientUpgradeWizard implements UpgradeWizardInterface
+{
+    private const TABLE = 'tx_mcpserver_oauth_clients';
+
+    public function getTitle(): string
+    {
+        return 'MCP Server: Seed well-known OAuth client';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Inserts the legacy "typo3-mcp-server" public client into the new '
+            . 'OAuth clients table so MCP clients configured before dynamic '
+            . 'registration was implemented continue to work.';
+    }
+
+    public function executeUpdate(): bool
+    {
+        GeneralUtility::makeInstance(OAuthService::class)->ensureWellKnownClient();
+        return true;
+    }
+
+    public function updateNecessary(): bool
+    {
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable(self::TABLE);
+
+        $count = (int)$connection->createQueryBuilder()
+            ->count('uid')
+            ->from(self::TABLE)
+            ->where('client_id = ' . $connection->quote(OAuthService::WELL_KNOWN_CLIENT_ID))
+            ->executeQuery()
+            ->fetchOne();
+
+        return $count === 0;
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [DatabaseUpdatedPrerequisite::class];
+    }
+}

--- a/Classes/Updates/SeedWellKnownOAuthClientUpgradeWizard.php
+++ b/Classes/Updates/SeedWellKnownOAuthClientUpgradeWizard.php
@@ -39,10 +39,15 @@ class SeedWellKnownOAuthClientUpgradeWizard implements UpgradeWizardInterface
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable(self::TABLE);
 
+        // A soft-deleted well-known row must still count as "needs update" so
+        // executeUpdate() re-runs ensureWellKnownClient(), which restores it.
         $count = (int)$connection->createQueryBuilder()
             ->count('uid')
             ->from(self::TABLE)
-            ->where('client_id = ' . $connection->quote(OAuthService::WELL_KNOWN_CLIENT_ID))
+            ->where(
+                'client_id = ' . $connection->quote(OAuthService::WELL_KNOWN_CLIENT_ID),
+                'deleted = 0'
+            )
             ->executeQuery()
             ->fetchOne();
 

--- a/Resources/Private/Templates/McpServerModule.html
+++ b/Resources/Private/Templates/McpServerModule.html
@@ -368,7 +368,12 @@ RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]</code></pre>
                                         <tbody id="tokens-table-body">
                                             <f:for each="{tokens}" as="token">
                                                 <tr data-token-id="{token.uid}">
-                                                    <td><strong>{token.client_name}</strong></td>
+                                                    <td>
+                                                        <strong>{token.client_name}</strong>
+                                                        <f:if condition="{token.token_label}">
+                                                            <br><small class="text-muted">as &quot;{token.token_label}&quot;</small>
+                                                        </f:if>
+                                                    </td>
                                                     <td><small class="text-muted">{token.created}</small></td>
                                                     <td><small class="text-muted">{token.last_used}</small></td>
                                                     <td><small class="text-muted">{token.expires}</small></td>

--- a/Resources/Public/JavaScript/mcp-module.js
+++ b/Resources/Public/JavaScript/mcp-module.js
@@ -518,7 +518,10 @@ class McpModule {
                         <tbody>
                             ${tokens.map(token => `
                                 <tr data-token-id="${esc(token.uid)}">
-                                    <td><strong>${esc(token.client_name)}</strong></td>
+                                    <td>
+                                        <strong>${esc(token.client_name)}</strong>
+                                        ${token.token_label ? `<br><small class="text-muted">as &quot;${esc(token.token_label)}&quot;</small>` : ''}
+                                    </td>
                                     <td><small class="text-muted">${esc(token.created)}</small></td>
                                     <td><small class="text-muted">${esc(token.last_used)}</small></td>
                                     <td><small class="text-muted">${esc(token.expires)}</small></td>

--- a/Tests/Functional/Service/OAuthClientRegistrationTest.php
+++ b/Tests/Functional/Service/OAuthClientRegistrationTest.php
@@ -359,6 +359,48 @@ class OAuthClientRegistrationTest extends AbstractFunctionalTest
         );
     }
 
+    public function testGetClientsByUidsReturnsMapKeyedByUid(): void
+    {
+        $a = $this->service->registerClient([
+            'client_name' => 'A',
+            'redirect_uris' => ['http://localhost'],
+        ]);
+        $b = $this->service->registerClient([
+            'client_name' => 'B',
+            'redirect_uris' => ['http://localhost'],
+        ]);
+        $clientA = $this->service->getClient($a['client_id']);
+        $clientB = $this->service->getClient($b['client_id']);
+
+        $map = $this->service->getClientsByUids([$clientA['uid'], $clientB['uid'], 999999]);
+
+        $this->assertArrayHasKey($clientA['uid'], $map);
+        $this->assertArrayHasKey($clientB['uid'], $map);
+        $this->assertArrayNotHasKey(999999, $map);
+        $this->assertSame('A', $map[$clientA['uid']]['client_name']);
+        $this->assertSame('B', $map[$clientB['uid']]['client_name']);
+    }
+
+    public function testGetClientsByUidsExcludesDeletedClients(): void
+    {
+        $registered = $this->service->registerClient([
+            'client_name' => 'Doomed',
+            'redirect_uris' => ['http://localhost'],
+        ]);
+        $client = $this->service->getClient($registered['client_id']);
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_oauth_clients');
+        $connection->update('tx_mcpserver_oauth_clients', ['deleted' => 1], ['uid' => $client['uid']]);
+
+        $this->assertSame([], $this->service->getClientsByUids([$client['uid']]));
+    }
+
+    public function testGetClientsByUidsHandlesEmptyInput(): void
+    {
+        $this->assertSame([], $this->service->getClientsByUids([]));
+        $this->assertSame([], $this->service->getClientsByUids([0, 0]));
+    }
+
     public function testLegacyTokenWithoutClientUidStillValidates(): void
     {
         // A token row inserted before the client_uid column existed (client_uid=0)

--- a/Tests/Functional/Service/OAuthClientRegistrationTest.php
+++ b/Tests/Functional/Service/OAuthClientRegistrationTest.php
@@ -228,4 +228,68 @@ class OAuthClientRegistrationTest extends AbstractFunctionalTest
         $result = $this->service->exchangeCodeForToken($code);
         $this->assertNotNull($result);
     }
+
+    public function testCodeIsBoundToIssuingClient(): void
+    {
+        // RFC 6749 §10.5: a code issued to client A must not be redeemable by client B,
+        // even if both are valid registered clients with no secret (PKCE not used here).
+        $clientA = $this->service->registerClient([
+            'client_name' => 'Client A',
+            'redirect_uris' => ['http://localhost'],
+        ]);
+        $clientB = $this->service->registerClient([
+            'client_name' => 'Client B',
+            'redirect_uris' => ['http://localhost'],
+        ]);
+
+        $code = $this->service->createAuthorizationCode(
+            1,
+            'Client A',
+            '',
+            '',
+            'S256',
+            $clientA['client_id']
+        );
+
+        // Wrong client id must fail
+        $this->assertNull(
+            $this->service->exchangeCodeForToken($code, null, null, null, $clientB['client_id']),
+            'Code issued to client A must not be redeemable by client B'
+        );
+        // Missing client id must fail when one was bound
+        $this->assertNull(
+            $this->service->exchangeCodeForToken($code, null, null, null, null),
+            'Bound code must require the client_id at exchange'
+        );
+        // Correct client id succeeds (and the code is then consumed)
+        $result = $this->service->exchangeCodeForToken($code, null, null, null, $clientA['client_id']);
+        $this->assertNotNull($result);
+        $this->assertArrayHasKey('access_token', $result);
+    }
+
+    public function testLoopbackMatcherRejectsDifferingQueryString(): void
+    {
+        $registered = $this->service->registerClient([
+            'redirect_uris' => ['http://localhost/cb?x=1'],
+        ]);
+        $client = $this->service->getClient($registered['client_id']);
+
+        // Same query is fine (with port wildcarding)
+        $this->assertTrue($this->service->isRedirectUriAllowed($client, 'http://localhost:6274/cb?x=1'));
+        // Different query value must NOT match
+        $this->assertFalse($this->service->isRedirectUriAllowed($client, 'http://localhost:6274/cb?x=attacker'));
+        // Missing query when one is registered must NOT match
+        $this->assertFalse($this->service->isRedirectUriAllowed($client, 'http://localhost:6274/cb'));
+    }
+
+    public function testLoopbackMatcherRejectsDifferingFragment(): void
+    {
+        $registered = $this->service->registerClient([
+            'redirect_uris' => ['http://localhost/cb#a'],
+        ]);
+        $client = $this->service->getClient($registered['client_id']);
+
+        $this->assertTrue($this->service->isRedirectUriAllowed($client, 'http://localhost:6274/cb#a'));
+        $this->assertFalse($this->service->isRedirectUriAllowed($client, 'http://localhost:6274/cb#b'));
+    }
 }

--- a/Tests/Functional/Service/OAuthClientRegistrationTest.php
+++ b/Tests/Functional/Service/OAuthClientRegistrationTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\Service;
+
+use Hn\McpServer\Service\OAuthService;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Tests for OAuth Dynamic Client Registration (RFC 7591) and the related
+ * client lookup / redirect_uri validation paths.
+ */
+class OAuthClientRegistrationTest extends AbstractFunctionalTest
+{
+    private OAuthService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = GeneralUtility::makeInstance(OAuthService::class);
+    }
+
+    public function testRegisterClientPersistsAndReturnsClientId(): void
+    {
+        $result = $this->service->registerClient([
+            'client_name' => 'Inspector',
+            'redirect_uris' => ['http://localhost:6274/oauth/callback'],
+        ]);
+
+        $this->assertArrayHasKey('client_id', $result);
+        $this->assertStringStartsWith('mcp_', $result['client_id']);
+        $this->assertSame('Inspector', $result['client_name']);
+        $this->assertSame(['http://localhost:6274/oauth/callback'], $result['redirect_uris']);
+        $this->assertArrayNotHasKey('client_secret', $result, 'Public clients must not receive a secret');
+
+        $client = $this->service->getClient($result['client_id']);
+        $this->assertNotNull($client);
+        $this->assertSame('Inspector', $client['client_name']);
+        $this->assertSame('none', $client['token_endpoint_auth_method']);
+    }
+
+    public function testRegisterClientWithSecretReturnsAndHashesSecret(): void
+    {
+        $result = $this->service->registerClient([
+            'client_name' => 'Confidential',
+            'redirect_uris' => ['https://example.com/cb'],
+            'token_endpoint_auth_method' => 'client_secret_post',
+        ]);
+
+        $this->assertArrayHasKey('client_secret', $result);
+        $this->assertNotEmpty($result['client_secret']);
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_oauth_clients');
+        $row = $connection->createQueryBuilder()
+            ->select('client_secret')
+            ->from('tx_mcpserver_oauth_clients')
+            ->where('client_id = ' . $connection->quote($result['client_id']))
+            ->executeQuery()
+            ->fetchAssociative();
+
+        $this->assertNotEquals($result['client_secret'], $row['client_secret'], 'Plain secret must NOT be stored');
+        $this->assertSame(hash('sha256', $result['client_secret']), $row['client_secret']);
+    }
+
+    public function testWildcardRedirectUriIsRejectedForDynamicClients(): void
+    {
+        $result = $this->service->registerClient([
+            'client_name' => 'Try wildcard',
+            'redirect_uris' => ['*'],
+        ]);
+
+        // The '*' is filtered out, so the default fallback is used
+        $this->assertSame(['http://localhost'], $result['redirect_uris']);
+
+        $client = $this->service->getClient($result['client_id']);
+        $this->assertSame(['http://localhost'], $client['redirect_uris']);
+        $this->assertFalse(
+            $this->service->isRedirectUriAllowed($client, 'http://attacker.example.com/cb'),
+            'Dynamic clients must never allow arbitrary redirect URIs even when they tried to register *'
+        );
+    }
+
+    public function testInvalidRedirectUriThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->service->registerClient([
+            'redirect_uris' => ['http:///bad'],
+        ]);
+    }
+
+    public function testGetClientReturnsNullForUnknownId(): void
+    {
+        $this->assertNull($this->service->getClient('does_not_exist'));
+        $this->assertNull($this->service->getClient(''));
+    }
+
+    public function testWellKnownClientIsAutoSeededOnLookup(): void
+    {
+        $client = $this->service->getClient(OAuthService::WELL_KNOWN_CLIENT_ID);
+
+        $this->assertNotNull($client);
+        $this->assertSame(OAuthService::WELL_KNOWN_CLIENT_ID, $client['client_id']);
+        $this->assertSame('none', $client['token_endpoint_auth_method']);
+        $this->assertContains('*', $client['redirect_uris'], 'Well-known client must accept arbitrary redirect URIs for backward compatibility');
+    }
+
+    public function testEnsureWellKnownClientIsIdempotent(): void
+    {
+        $this->service->ensureWellKnownClient();
+        $this->service->ensureWellKnownClient();
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_oauth_clients');
+        $count = (int)$connection->createQueryBuilder()
+            ->count('uid')
+            ->from('tx_mcpserver_oauth_clients')
+            ->where('client_id = ' . $connection->quote(OAuthService::WELL_KNOWN_CLIENT_ID))
+            ->executeQuery()
+            ->fetchOne();
+
+        $this->assertSame(1, $count);
+    }
+
+    public function testRedirectUriExactMatchAllowed(): void
+    {
+        $registered = $this->service->registerClient([
+            'redirect_uris' => ['https://example.com/cb'],
+        ]);
+        $client = $this->service->getClient($registered['client_id']);
+
+        $this->assertTrue($this->service->isRedirectUriAllowed($client, 'https://example.com/cb'));
+        $this->assertFalse($this->service->isRedirectUriAllowed($client, 'https://example.com/cb2'));
+        $this->assertFalse($this->service->isRedirectUriAllowed($client, 'https://other.example.com/cb'));
+    }
+
+    public function testRedirectUriLoopbackPortWildcardingAllowed(): void
+    {
+        $registered = $this->service->registerClient([
+            'redirect_uris' => ['http://localhost/oauth/callback'],
+        ]);
+        $client = $this->service->getClient($registered['client_id']);
+
+        // Same path, different port — should match per RFC 8252 §7.3
+        $this->assertTrue($this->service->isRedirectUriAllowed($client, 'http://localhost:6274/oauth/callback'));
+        $this->assertTrue($this->service->isRedirectUriAllowed($client, 'http://localhost:1234/oauth/callback'));
+        // Different path must NOT match
+        $this->assertFalse($this->service->isRedirectUriAllowed($client, 'http://localhost:6274/other'));
+        // Non-loopback host must NOT match
+        $this->assertFalse($this->service->isRedirectUriAllowed($client, 'http://example.com:6274/oauth/callback'));
+    }
+
+    public function testRedirectUriEmptyIsRejected(): void
+    {
+        $registered = $this->service->registerClient([
+            'redirect_uris' => ['http://localhost'],
+        ]);
+        $client = $this->service->getClient($registered['client_id']);
+
+        $this->assertFalse($this->service->isRedirectUriAllowed($client, ''));
+    }
+
+    public function testVerifyClientSecretPublicClient(): void
+    {
+        $registered = $this->service->registerClient([
+            'redirect_uris' => ['http://localhost'],
+        ]);
+        $client = $this->service->getClient($registered['client_id']);
+
+        // Public clients pass without a secret (PKCE handles authentication)
+        $this->assertTrue($this->service->verifyClientSecret($client, null));
+        $this->assertTrue($this->service->verifyClientSecret($client, ''));
+        $this->assertTrue($this->service->verifyClientSecret($client, 'anything'));
+    }
+
+    public function testVerifyClientSecretConfidentialClient(): void
+    {
+        $registered = $this->service->registerClient([
+            'redirect_uris' => ['https://example.com/cb'],
+            'token_endpoint_auth_method' => 'client_secret_post',
+        ]);
+        $client = $this->service->getClient($registered['client_id']);
+
+        $this->assertTrue($this->service->verifyClientSecret($client, $registered['client_secret']));
+        $this->assertFalse($this->service->verifyClientSecret($client, 'wrong'));
+        $this->assertFalse($this->service->verifyClientSecret($client, ''));
+        $this->assertFalse($this->service->verifyClientSecret($client, null));
+    }
+
+    public function testCodeExchangeRequiresMatchingRedirectUri(): void
+    {
+        $code = $this->service->createAuthorizationCode(
+            1,
+            'test-client',
+            'http://localhost:6274/oauth/callback'
+        );
+
+        // Without redirect_uri the exchange must fail (auth code was bound to one)
+        $this->assertNull($this->service->exchangeCodeForToken($code));
+
+        // With wrong redirect_uri the exchange must fail
+        $code2 = $this->service->createAuthorizationCode(
+            1,
+            'test-client',
+            'http://localhost:6274/oauth/callback'
+        );
+        $this->assertNull($this->service->exchangeCodeForToken($code2, null, null, 'http://attacker.example.com'));
+
+        // With matching redirect_uri it succeeds
+        $code3 = $this->service->createAuthorizationCode(
+            1,
+            'test-client',
+            'http://localhost:6274/oauth/callback'
+        );
+        $result = $this->service->exchangeCodeForToken($code3, null, null, 'http://localhost:6274/oauth/callback');
+        $this->assertNotNull($result);
+        $this->assertArrayHasKey('access_token', $result);
+    }
+
+    public function testCodeExchangeWithoutBoundRedirectUriIsLenient(): void
+    {
+        // If the auth code wasn't bound to a redirect_uri (bare flow / pasted code),
+        // the token endpoint doesn't need to enforce one.
+        $code = $this->service->createAuthorizationCode(1, 'test-client');
+        $result = $this->service->exchangeCodeForToken($code);
+        $this->assertNotNull($result);
+    }
+}

--- a/Tests/Functional/Service/OAuthClientRegistrationTest.php
+++ b/Tests/Functional/Service/OAuthClientRegistrationTest.php
@@ -292,4 +292,93 @@ class OAuthClientRegistrationTest extends AbstractFunctionalTest
         $this->assertTrue($this->service->isRedirectUriAllowed($client, 'http://localhost:6274/cb#a'));
         $this->assertFalse($this->service->isRedirectUriAllowed($client, 'http://localhost:6274/cb#b'));
     }
+
+    public function testManualTokenIsBoundToWellKnownClient(): void
+    {
+        $plainToken = $this->service->createDirectAccessToken(1, 'My Laptop');
+        $wellKnown = $this->service->getClient(OAuthService::WELL_KNOWN_CLIENT_ID);
+
+        $info = $this->service->validateToken($plainToken);
+        $this->assertNotNull($info);
+        $this->assertSame($wellKnown['uid'], $info['client_uid']);
+    }
+
+    public function testOAuthTokenIsBoundToIssuingClient(): void
+    {
+        $registered = $this->service->registerClient([
+            'client_name' => 'Issuer',
+            'redirect_uris' => ['http://localhost'],
+        ]);
+        $code = $this->service->createAuthorizationCode(
+            1,
+            'Issuer',
+            '',
+            '',
+            'S256',
+            $registered['client_id']
+        );
+        $tokenData = $this->service->exchangeCodeForToken($code, null, null, null, $registered['client_id']);
+        $this->assertNotNull($tokenData);
+
+        $issuer = $this->service->getClient($registered['client_id']);
+        $info = $this->service->validateToken($tokenData['access_token']);
+        $this->assertNotNull($info);
+        $this->assertSame($issuer['uid'], $info['client_uid']);
+    }
+
+    public function testTokenIsRevokedWhenIssuingClientIsDeleted(): void
+    {
+        $registered = $this->service->registerClient([
+            'client_name' => 'ToBeDeleted',
+            'redirect_uris' => ['http://localhost'],
+        ]);
+        $code = $this->service->createAuthorizationCode(
+            1,
+            'ToBeDeleted',
+            '',
+            '',
+            'S256',
+            $registered['client_id']
+        );
+        $tokenData = $this->service->exchangeCodeForToken($code, null, null, null, $registered['client_id']);
+        $this->assertNotNull($tokenData);
+        $this->assertNotNull($this->service->validateToken($tokenData['access_token']));
+
+        // Soft-delete the client; the token must now be rejected
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_oauth_clients');
+        $connection->update(
+            'tx_mcpserver_oauth_clients',
+            ['deleted' => 1, 'tstamp' => time()],
+            ['client_id' => $registered['client_id']]
+        );
+
+        $this->assertNull(
+            $this->service->validateToken($tokenData['access_token']),
+            'Tokens for a deleted client must no longer validate'
+        );
+    }
+
+    public function testLegacyTokenWithoutClientUidStillValidates(): void
+    {
+        // A token row inserted before the client_uid column existed (client_uid=0)
+        // must remain valid for backward compatibility.
+        $plainToken = bin2hex(random_bytes(32));
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_access_tokens');
+        $connection->insert('tx_mcpserver_access_tokens', [
+            'pid' => 0, 'tstamp' => time(), 'crdate' => time(),
+            'token' => hash('sha256', $plainToken),
+            'token_version' => 1,
+            'be_user_uid' => 1,
+            'client_uid' => 0,
+            'client_name' => 'pre-binding-token',
+            'expires' => time() + 86400,
+            'last_used' => time(), 'created_ip' => '', 'last_used_ip' => '',
+        ]);
+
+        $info = $this->service->validateToken($plainToken);
+        $this->assertNotNull($info, 'Legacy token without client_uid must still validate');
+        $this->assertSame(0, $info['client_uid']);
+    }
 }

--- a/Tests/Functional/Service/OAuthClientRegistrationTest.php
+++ b/Tests/Functional/Service/OAuthClientRegistrationTest.php
@@ -52,6 +52,8 @@ class OAuthClientRegistrationTest extends AbstractFunctionalTest
 
         $this->assertArrayHasKey('client_secret', $result);
         $this->assertNotEmpty($result['client_secret']);
+        // RFC 7591 §3.2.1: client_secret_expires_at is REQUIRED when a secret is issued
+        $this->assertSame(0, $result['client_secret_expires_at']);
 
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('tx_mcpserver_oauth_clients');
@@ -399,6 +401,129 @@ class OAuthClientRegistrationTest extends AbstractFunctionalTest
     {
         $this->assertSame([], $this->service->getClientsByUids([]));
         $this->assertSame([], $this->service->getClientsByUids([0, 0]));
+    }
+
+    public function testTokenEndpointAcceptsClientSecretBasic(): void
+    {
+        $registered = $this->service->registerClient([
+            'client_name' => 'Basic Auth Client',
+            'redirect_uris' => ['https://example.com/cb'],
+            'token_endpoint_auth_method' => 'client_secret_basic',
+        ]);
+        $code = $this->service->createAuthorizationCode(
+            1,
+            'Basic Auth Client',
+            '',
+            '',
+            'S256',
+            $registered['client_id']
+        );
+
+        // RFC 6749 §2.3.1: credentials are form-urlencoded, then base64-encoded
+        $basic = base64_encode(urlencode($registered['client_id']) . ':' . urlencode($registered['client_secret']));
+        $request = (new \TYPO3\CMS\Core\Http\ServerRequest('https://example.com/mcp_oauth/token', 'POST'))
+            ->withHeader('Authorization', 'Basic ' . $basic)
+            ->withParsedBody([
+                'grant_type' => 'authorization_code',
+                'code' => $code,
+            ]);
+
+        $response = (new \Hn\McpServer\Http\OAuthTokenEndpoint())($request);
+        $body = json_decode((string)$response->getBody(), true);
+
+        $this->assertSame(200, $response->getStatusCode(), (string)json_encode($body));
+        $this->assertArrayHasKey('access_token', $body);
+    }
+
+    public function testTokenEndpointRejectsWrongBasicSecret(): void
+    {
+        $registered = $this->service->registerClient([
+            'client_name' => 'Basic Auth Client',
+            'redirect_uris' => ['https://example.com/cb'],
+            'token_endpoint_auth_method' => 'client_secret_basic',
+        ]);
+        $code = $this->service->createAuthorizationCode(1, 'Basic Auth Client', '', '', 'S256', $registered['client_id']);
+
+        $basic = base64_encode(urlencode($registered['client_id']) . ':' . urlencode('wrong-secret'));
+        $request = (new \TYPO3\CMS\Core\Http\ServerRequest('https://example.com/mcp_oauth/token', 'POST'))
+            ->withHeader('Authorization', 'Basic ' . $basic)
+            ->withParsedBody([
+                'grant_type' => 'authorization_code',
+                'code' => $code,
+            ]);
+
+        $response = (new \Hn\McpServer\Http\OAuthTokenEndpoint())($request);
+        $body = json_decode((string)$response->getBody(), true);
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('invalid_client', $body['error']);
+    }
+
+    public function testCleanupRemovesStaleClientsButKeepsActiveAndWellKnown(): void
+    {
+        $stale = $this->service->registerClient([
+            'client_name' => 'Stale',
+            'redirect_uris' => ['http://localhost'],
+        ]);
+        $active = $this->service->registerClient([
+            'client_name' => 'Active',
+            'redirect_uris' => ['http://localhost'],
+        ]);
+        $this->service->getClient(OAuthService::WELL_KNOWN_CLIENT_ID); // seed well-known
+
+        // Age all clients past the token lifetime
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_oauth_clients');
+        $old = time() - 2592000 - 86400;
+        foreach ([$stale['client_id'], $active['client_id'], OAuthService::WELL_KNOWN_CLIENT_ID] as $clientId) {
+            $connection->update(
+                'tx_mcpserver_oauth_clients',
+                ['crdate' => $old, 'last_used' => 0],
+                ['client_id' => $clientId]
+            );
+        }
+
+        // Give the active client a live token
+        $activeClient = $this->service->getClient($active['client_id']);
+        $tokenConnection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_access_tokens');
+        $tokenConnection->insert('tx_mcpserver_access_tokens', [
+            'pid' => 0, 'tstamp' => time(), 'crdate' => time(),
+            'token' => hash('sha256', bin2hex(random_bytes(32))),
+            'token_version' => 1,
+            'be_user_uid' => 1,
+            'client_uid' => $activeClient['uid'],
+            'client_name' => 'Active',
+            'expires' => time() + 86400,
+            'last_used' => time(), 'created_ip' => '', 'last_used_ip' => '',
+        ]);
+
+        $this->service->cleanupExpired();
+
+        $this->assertNull($this->service->getClient($stale['client_id']), 'Stale client without live tokens must be removed');
+        $this->assertNotNull($this->service->getClient($active['client_id']), 'Client with a live token must be kept');
+        $this->assertNotNull($this->service->getClient(OAuthService::WELL_KNOWN_CLIENT_ID), 'Well-known client must never be removed');
+    }
+
+    public function testTokenIssuanceUpdatesClientLastUsed(): void
+    {
+        $registered = $this->service->registerClient([
+            'client_name' => 'Tracked',
+            'redirect_uris' => ['http://localhost'],
+        ]);
+        $code = $this->service->createAuthorizationCode(1, 'Tracked', '', '', 'S256', $registered['client_id']);
+        $this->assertNotNull($this->service->exchangeCodeForToken($code, null, null, null, $registered['client_id']));
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_oauth_clients');
+        $lastUsed = (int)$connection->createQueryBuilder()
+            ->select('last_used')
+            ->from('tx_mcpserver_oauth_clients')
+            ->where('client_id = ' . $connection->quote($registered['client_id']))
+            ->executeQuery()
+            ->fetchOne();
+
+        $this->assertGreaterThan(0, $lastUsed, 'Issuing a token must record client activity for stale-client cleanup');
     }
 
     public function testLegacyTokenWithoutClientUidStillValidates(): void

--- a/Tests/Functional/Service/OAuthClientRegistrationTest.php
+++ b/Tests/Functional/Service/OAuthClientRegistrationTest.php
@@ -68,30 +68,34 @@ class OAuthClientRegistrationTest extends AbstractFunctionalTest
         $this->assertSame(hash('sha256', $result['client_secret']), $row['client_secret']);
     }
 
-    public function testWildcardRedirectUriIsRejectedForDynamicClients(): void
+    public function testWildcardSentinelsAreRejectedForDynamicClients(): void
     {
-        $result = $this->service->registerClient([
-            'client_name' => 'Try wildcard',
-            'redirect_uris' => ['*'],
-        ]);
+        foreach ([['*'], [OAuthService::REDIRECT_URI_LOOPBACK_SENTINEL]] as $attempt) {
+            $result = $this->service->registerClient([
+                'client_name' => 'Try wildcard',
+                'redirect_uris' => $attempt,
+            ]);
 
-        // The '*' is filtered out, so the default fallback is used
-        $this->assertSame(['http://localhost'], $result['redirect_uris']);
-
-        $client = $this->service->getClient($result['client_id']);
-        $this->assertSame(['http://localhost'], $client['redirect_uris']);
-        $this->assertFalse(
-            $this->service->isRedirectUriAllowed($client, 'http://attacker.example.com/cb'),
-            'Dynamic clients must never allow arbitrary redirect URIs even when they tried to register *'
-        );
+            $this->assertSame(['http://localhost'], $result['redirect_uris']);
+            $client = $this->service->getClient($result['client_id']);
+            $this->assertSame(['http://localhost'], $client['redirect_uris']);
+            $this->assertFalse(
+                $this->service->isRedirectUriAllowed($client, 'http://attacker.example.com/cb'),
+                'Dynamic clients must never allow arbitrary redirect URIs even when they tried to register a sentinel'
+            );
+        }
     }
 
-    public function testInvalidRedirectUriThrows(): void
+    public function testRegisterRejectsNonHttpRedirectUri(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->service->registerClient([
-            'redirect_uris' => ['http:///bad'],
-        ]);
+        foreach (['javascript:alert(1)', 'data:text/html,x', '//evil.example.com', 'ftp://a/', 'http:///nohost'] as $bad) {
+            try {
+                $this->service->registerClient(['redirect_uris' => [$bad]]);
+                $this->fail('Expected InvalidArgumentException for redirect_uri: ' . $bad);
+            } catch (\InvalidArgumentException $e) {
+                $this->assertStringContainsString('Invalid redirect_uri', $e->getMessage());
+            }
+        }
     }
 
     public function testGetClientReturnsNullForUnknownId(): void
@@ -107,7 +111,48 @@ class OAuthClientRegistrationTest extends AbstractFunctionalTest
         $this->assertNotNull($client);
         $this->assertSame(OAuthService::WELL_KNOWN_CLIENT_ID, $client['client_id']);
         $this->assertSame('none', $client['token_endpoint_auth_method']);
-        $this->assertContains('*', $client['redirect_uris'], 'Well-known client must accept arbitrary redirect URIs for backward compatibility');
+        $this->assertContains(
+            OAuthService::REDIRECT_URI_LOOPBACK_SENTINEL,
+            $client['redirect_uris'],
+            'Well-known client must be seeded with the loopback sentinel for backward compatibility'
+        );
+    }
+
+    public function testWellKnownClientLoopbackSentinelOnlyAcceptsLoopback(): void
+    {
+        $client = $this->service->getClient(OAuthService::WELL_KNOWN_CLIENT_ID);
+
+        // Loopback URIs (any port, any path) MUST be accepted for BC.
+        $this->assertTrue($this->service->isRedirectUriAllowed($client, 'http://localhost'));
+        $this->assertTrue($this->service->isRedirectUriAllowed($client, 'http://localhost:6274/oauth/callback'));
+        $this->assertTrue($this->service->isRedirectUriAllowed($client, 'http://127.0.0.1:12345/cb'));
+        $this->assertTrue($this->service->isRedirectUriAllowed($client, 'https://localhost:8443/cb'));
+
+        // Non-loopback hosts MUST be rejected — the sentinel is NOT an open redirector.
+        $this->assertFalse($this->service->isRedirectUriAllowed($client, 'http://attacker.example.com/cb'));
+        $this->assertFalse($this->service->isRedirectUriAllowed($client, 'https://example.com'));
+        $this->assertFalse($this->service->isRedirectUriAllowed($client, 'http://localhost.attacker.com/cb'));
+    }
+
+    public function testWellKnownClientIsRestoredIfSoftDeleted(): void
+    {
+        // Seed once
+        $client = $this->service->getClient(OAuthService::WELL_KNOWN_CLIENT_ID);
+        $this->assertNotNull($client);
+
+        // Soft-delete the row
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_oauth_clients');
+        $connection->update(
+            'tx_mcpserver_oauth_clients',
+            ['deleted' => 1],
+            ['uid' => $client['uid']]
+        );
+
+        // A subsequent lookup must self-heal — not deadlock
+        $restored = $this->service->getClient(OAuthService::WELL_KNOWN_CLIENT_ID);
+        $this->assertNotNull($restored, 'Well-known client must be restored, not skipped, when soft-deleted');
+        $this->assertSame($client['uid'], $restored['uid'], 'Should undelete the same row, not insert a duplicate');
     }
 
     public function testEnsureWellKnownClientIsIdempotent(): void
@@ -524,6 +569,19 @@ class OAuthClientRegistrationTest extends AbstractFunctionalTest
             ->fetchOne();
 
         $this->assertGreaterThan(0, $lastUsed, 'Issuing a token must record client activity for stale-client cleanup');
+    }
+
+    public function testAuthorizationCodeCannotBeRedeemedTwice(): void
+    {
+        // RFC 6749 §4.1.2: single-use. The atomicity fix deletes the code BEFORE
+        // issuing the token, so the second exchange sees no code and returns null.
+        $code = $this->service->createAuthorizationCode(1, 'test-client');
+
+        $first = $this->service->exchangeCodeForToken($code);
+        $this->assertNotNull($first, 'First redemption must succeed');
+
+        $second = $this->service->exchangeCodeForToken($code);
+        $this->assertNull($second, 'Second redemption of the same code must fail');
     }
 
     public function testLegacyTokenWithoutClientUidStillValidates(): void

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -48,3 +48,27 @@ CREATE TABLE tx_mcpserver_access_tokens (
 	KEY be_user_uid (be_user_uid),
 	KEY expires (expires)
 );
+
+#
+# OAuth registered clients table (Dynamic Client Registration, RFC 7591)
+#
+CREATE TABLE tx_mcpserver_oauth_clients (
+	uid int(11) NOT NULL auto_increment,
+	pid int(11) DEFAULT '0' NOT NULL,
+	tstamp int(11) unsigned DEFAULT '0' NOT NULL,
+	crdate int(11) unsigned DEFAULT '0' NOT NULL,
+	deleted tinyint(4) unsigned DEFAULT '0' NOT NULL,
+
+	client_id varchar(255) DEFAULT '' NOT NULL,
+	client_secret varchar(255) DEFAULT '' NOT NULL,
+	client_name varchar(255) DEFAULT '' NOT NULL,
+	redirect_uris text,
+	grant_types varchar(255) DEFAULT '' NOT NULL,
+	scope varchar(255) DEFAULT '' NOT NULL,
+	token_endpoint_auth_method varchar(50) DEFAULT 'none' NOT NULL,
+	last_used int(11) unsigned DEFAULT '0' NOT NULL,
+
+	PRIMARY KEY (uid),
+	KEY parent (pid),
+	KEY client_id (client_id)
+);

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -10,6 +10,7 @@ CREATE TABLE tx_mcpserver_oauth_codes (
 	
 	code varchar(255) DEFAULT '' NOT NULL,
 	be_user_uid int(11) unsigned DEFAULT '0' NOT NULL,
+	client_id varchar(255) DEFAULT '' NOT NULL,
 	client_name varchar(255) DEFAULT '' NOT NULL,
 	pkce_challenge varchar(255) DEFAULT '' NOT NULL,
 	pkce_challenge_method varchar(10) DEFAULT 'S256' NOT NULL,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -36,6 +36,7 @@ CREATE TABLE tx_mcpserver_access_tokens (
 	
 	token varchar(255) DEFAULT '' NOT NULL,
 	be_user_uid int(11) unsigned DEFAULT '0' NOT NULL,
+	client_uid int(11) unsigned DEFAULT '0' NOT NULL,
 	client_name varchar(255) DEFAULT '' NOT NULL,
 	expires int(11) unsigned DEFAULT '0' NOT NULL,
 	last_used int(11) unsigned DEFAULT '0' NOT NULL,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -72,5 +72,5 @@ CREATE TABLE tx_mcpserver_oauth_clients (
 
 	PRIMARY KEY (uid),
 	KEY parent (pid),
-	KEY client_id (client_id)
+	UNIQUE KEY client_id (client_id)
 );


### PR DESCRIPTION
## Summary

This PR implements RFC 7591 OAuth Dynamic Client Registration for the MCP Server, replacing the hardcoded single-client approach with a flexible multi-client registration system. It introduces a new database table for storing registered OAuth clients, implements proper client validation and secret management, and adds comprehensive redirect URI matching logic including RFC 8252 loopback URI support.

## Key Changes

- **Dynamic Client Registration (RFC 7591)**
  - New `registerClient()` method that generates unique client IDs and optionally issues client secrets
  - Supports both public clients (PKCE-based, no secret) and confidential clients (with hashed secrets)
  - Validates and normalizes redirect URIs, rejecting invalid URLs and filtering the wildcard sentinel for dynamic registrations
  - Configurable token endpoint authentication methods (`none`, `client_secret_post`, `client_secret_basic`)

- **Client Lookup & Validation**
  - New `getClient()` method to retrieve registered client metadata by client_id
  - New `isRedirectUriAllowed()` method with exact matching and RFC 8252 §7.3 loopback URI port-agnostic matching
  - New `verifyClientSecret()` method for constant-time secret comparison using `hash_equals()`
  - Well-known client auto-seeding: the legacy `typo3-mcp-server` client is automatically created on first lookup if missing

- **Database Schema**
  - New `tx_mcpserver_oauth_clients` table storing client_id, hashed client_secret, name, redirect URIs (JSON), grant types (JSON), scope, and auth method
  - Indexed on `client_id` for efficient lookups

- **Token Endpoint Enhancements**
  - `exchangeCodeForToken()` now accepts optional `redirectUri` parameter and enforces RFC 6749 §4.1.3 redirect_uri matching
  - Client authentication via `verifyClientSecret()` with support for multiple auth methods
  - Proper error responses for invalid or mismatched clients

- **Authorization Endpoint Hardening**
  - Re-validates client and redirect_uri on approval form submission to prevent consent form bypass
  - Uses `getClient()` and `isRedirectUriAllowed()` for consistent validation

- **Upgrade Path**
  - New `SeedWellKnownOAuthClientUpgradeWizard` ensures backward compatibility by seeding the well-known client during upgrades
  - The well-known client uses the `*` sentinel to accept any redirect_uri, preserving legacy behavior for existing MCP clients

- **Comprehensive Test Coverage**
  - New `OAuthClientRegistrationTest` with 15 functional tests covering registration, secret handling, redirect URI validation, loopback matching, and token exchange flows

## Notable Implementation Details

- Client secrets are hashed with SHA-256 before storage; only the plain secret is returned once during registration
- Public clients (default for MCP) return `true` for `verifyClientSecret()` regardless of input, as they authenticate via PKCE
- Loopback URI matching allows port variation for localhost/127.0.0.1/::1 while preserving scheme and path requirements
- The well-known client is idempotent and self-healing: concurrent calls and missing tables are handled gracefully
- Invalid redirect URIs during registration throw `InvalidArgumentException` with descriptive messages

https://claude.ai/code/session_019dsyoNvsHp6UB4o8XjdCYc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth client registration with support for public and confidential clients.
  * Added client-aware authorization code and token handling, including redirect URI and PKCE validation.
  * Added HTTP Basic authentication support for token requests.
  * Added clearer token listings with client names and optional labels.
* **Bug Fixes**
  * Improved validation of unknown clients, invalid redirect URIs, and incorrect secrets.
  * Tokens are revoked when their associated client is deactivated.
* **Upgrade**
  * Added automatic setup of the default OAuth client during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->