### PR TITLE
feat(WriteTable): support moving records by setting pid on update

### DIFF
--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -69,7 +69,7 @@ class WriteTableTool extends AbstractRecordTool
                     ],
                     'pid' => [
                         'type' => 'integer',
-                        'description' => 'Page ID for new records (required for "create" action)',
+                        'description' => 'Page ID. Required for "create" action (target page for the new record). On "update", set this to move the record to a different page (combine with "position" to control where on that page it lands).',
                     ],
                     'uid' => [
                         'type' => 'integer',
@@ -87,7 +87,8 @@ class WriteTableTool extends AbstractRecordTool
                             'Array order drives display order. ' .
                             'For text fields in update actions, instead of providing the full text, you can provide an array of search-and-replace operations: ' .
                             '[{"search": "old text", "replace": "new text"}]. Each operation can optionally include "replaceAll": true. ' .
-                            'Operations are applied sequentially. Each search string must match exactly once unless replaceAll is true.',
+                            'Operations are applied sequentially. Each search string must match exactly once unless replaceAll is true. ' .
+                            'On the "update" action, setting "pid" moves the record to that page (combine with "position" to control where on the new page it lands).',
                         'additionalProperties' => true,
                         'examples' => [
                             ['title' => 'News Title', 'bodytext' => 'News <b>content</b>', 'datetime' => '2024-01-01 10:00:00'],
@@ -153,7 +154,10 @@ class WriteTableTool extends AbstractRecordTool
                 ]);
             }
             $positionProvided = $position !== null;
-            if (empty($data) && !($action === 'update' && $positionProvided)) {
+            // On update, an empty data parameter is allowed when the caller is
+            // only changing position or moving the record to a new pid.
+            $isUpdateMoveOnly = $action === 'update' && ($positionProvided || $pid !== null);
+            if (empty($data) && !$isUpdateMoveOnly) {
                 throw new ValidationException([
                     "The data parameter must contain record fields for {$action} actions. " .
                     "Provide field names as keys, e.g. {\"title\": \"Page Title\", \"bodytext\": \"Content\"}."
@@ -208,7 +212,8 @@ class WriteTableTool extends AbstractRecordTool
                 }
 
                 $hasPosition = $position !== null;
-                if (empty($data) && empty($searchReplace) && !$hasPosition) {
+                $hasMove = $pid !== null || array_key_exists('pid', $data);
+                if (empty($data) && empty($searchReplace) && !$hasPosition && !$hasMove) {
                     throw new ValidationException(['Data is required for update action']);
                 }
                 break;
@@ -256,6 +261,12 @@ class WriteTableTool extends AbstractRecordTool
                 if (!empty($searchReplace)) {
                     $resolvedFields = $this->resolveSearchReplace($table, $uid, $searchReplace);
                     $data = array_merge($data, $resolvedFields);
+                }
+                // Top-level `pid` on update is treated the same as `data.pid`:
+                // a request to move the record to that page. LLMs are equally
+                // likely to put it at either spot.
+                if ($pid !== null && !array_key_exists('pid', $data)) {
+                    $data['pid'] = $pid;
                 }
                 return $this->updateRecord($table, $uid, $data, $position);
                 
@@ -528,7 +539,15 @@ class WriteTableTool extends AbstractRecordTool
         if ($validationResult !== true) {
             return $this->createErrorResult('Validation error: ' . $validationResult);
         }
-        
+
+        // Extract pid as a special field — it's not a TCA column, but setting it
+        // on update should move the record to the new page via DataHandler's cmdmap.
+        $targetPid = null;
+        if (array_key_exists('pid', $data)) {
+            $targetPid = (int)$data['pid'];
+            unset($data['pid']);
+        }
+
         // Extract inline relations before converting data
         $inlineRelations = $this->extractInlineRelations($table, $data);
         
@@ -542,18 +561,20 @@ class WriteTableTool extends AbstractRecordTool
         // Resolve the live UID to workspace UID (once, used throughout)
         $workspaceUid = $this->resolveToWorkspaceUid($table, $uid);
 
-        // First, update the parent record without inline relations
-        $dataMap = [$table => [$workspaceUid => $data]];
-        
-        // Update the record using DataHandler
-        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
-        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
-        $dataHandler->start($dataMap, []);
-        $dataHandler->process_datamap();
-        
-        // Check for errors in parent update
-        if (!empty($dataHandler->errorLog)) {
-            return $this->createErrorResult('Error updating record: ' . implode(', ', $dataHandler->errorLog));
+        // Only run the field datamap if there are actual fields to write.
+        // A pid-only move with no field changes leaves $data empty, and
+        // calling DataHandler with an empty datamap is a no-op at best.
+        if (!empty($data)) {
+            $dataMap = [$table => [$workspaceUid => $data]];
+
+            $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+            $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+            $dataHandler->start($dataMap, []);
+            $dataHandler->process_datamap();
+
+            if (!empty($dataHandler->errorLog)) {
+                return $this->createErrorResult('Error updating record: ' . implode(', ', $dataHandler->errorLog));
+            }
         }
         
         // Now process inline relations with the resolved parent UID
@@ -619,9 +640,12 @@ class WriteTableTool extends AbstractRecordTool
             }
         }
         
-        // Handle position/reordering if requested
-        if ($position !== null) {
-            $moveResult = $this->moveRecord($table, $workspaceUid, $position);
+        // Handle pid change (move to another page) and/or position reordering.
+        // pid is a special TYPO3 control field; setting it on update means "move
+        // this record to that page". The position parameter (if given) refines
+        // where on the new page the record lands.
+        if ($targetPid !== null || $position !== null) {
+            $moveResult = $this->moveRecord($table, $workspaceUid, $position, $targetPid);
             if ($moveResult !== null) {
                 return $moveResult;
             }
@@ -670,11 +694,16 @@ class WriteTableTool extends AbstractRecordTool
     /**
      * Move a record to a new position using DataHandler's cmdmap.
      *
+     * @param string|null $position Position vocabulary: "top", "bottom",
+     *                              "before:UID", "after:UID". Null means
+     *                              "default placement on $targetPid" (top).
+     * @param int|null    $targetPid Destination page UID. Null means "stay on
+     *                               current page and just reorder".
      * @return CallToolResult|null Error result on failure, null on success
      */
-    protected function moveRecord(string $table, int $uid, string $position): ?CallToolResult
+    protected function moveRecord(string $table, int $uid, ?string $position, ?int $targetPid = null): ?CallToolResult
     {
-        $destination = $this->resolvePositionToDestination($table, $uid, $position);
+        $destination = $this->resolvePositionToDestination($table, $uid, $position, $targetPid);
         if ($destination === null) {
             return null;
         }
@@ -683,7 +712,15 @@ class WriteTableTool extends AbstractRecordTool
         $moveDataHandler = GeneralUtility::makeInstance(DataHandler::class);
         $moveDataHandler->BE_USER = $GLOBALS['BE_USER'];
         $moveDataHandler->start([], $cmdMap);
-        $moveDataHandler->process_cmdmap();
+        try {
+            $moveDataHandler->process_cmdmap();
+        } catch (\Throwable $e) {
+            // DataHandler can raise RuntimeException for impossible moves
+            // (e.g. moving a page into itself). Surface the cause as a tool
+            // error rather than letting the global handler swallow it into a
+            // generic "Operation failed" message.
+            return $this->createErrorResult('Error moving record: ' . $e->getMessage());
+        }
 
         if (!empty($moveDataHandler->errorLog)) {
             return $this->createErrorResult('Error moving record: ' . implode(', ', $moveDataHandler->errorLog));
@@ -696,15 +733,30 @@ class WriteTableTool extends AbstractRecordTool
      * Convert a position string ("top", "bottom", "after:UID", "before:UID")
      * into a DataHandler move destination integer.
      *
+     * @param string|null $position Position vocabulary, or null for "default
+     *                              placement on $targetPid".
+     * @param int|null    $targetPid Override the page the move targets. When
+     *                               null, the record's current pid is used.
      * @return int|null Destination pid (positive=page, negative=after record), null if no move needed
      */
-    protected function resolvePositionToDestination(string $table, int $uid, string $position): ?int
+    protected function resolvePositionToDestination(string $table, int $uid, ?string $position, ?int $targetPid = null): ?int
     {
-        $record = BackendUtility::getRecord($table, $uid, 'pid');
-        if ($record === null) {
-            return null;
+        if ($targetPid !== null) {
+            $pid = $targetPid;
+        } else {
+            $record = BackendUtility::getRecord($table, $uid, 'pid');
+            if ($record === null) {
+                return null;
+            }
+            $pid = (int)$record['pid'];
         }
-        $pid = (int)$record['pid'];
+
+        // No position vocabulary given: a positive destination pid tells
+        // DataHandler "move to this page (at top)". This is the natural
+        // default for a pid-only move.
+        if ($position === null) {
+            return $pid;
+        }
 
         if ($position === 'bottom') {
             $sortingField = $this->tableAccessService->getSortingFieldName($table);
@@ -927,15 +979,19 @@ class WriteTableTool extends AbstractRecordTool
         if (isset($data['uid'])) {
             return "Field 'uid' cannot be modified directly";
         }
-        if (isset($data['pid']) && $action !== 'create') {
-            return "Field 'pid' can only be set during record creation";
-        }
+        // 'pid' is a special TYPO3 control field, not a TCA columns entry.
+        // On create it's passed as a separate argument; on update it triggers
+        // a move via DataHandler's cmdmap (handled by the caller). Either way
+        // it must skip the TCA columns check below.
 
         // Reject fields without a TCA columns entry. DataHandler silently drops
         // such fields on update/create (control-only fields like 'sorting' live in
         // TCA ctrl.sortby, not columns; typos have no entry at all), so returning
         // success without writing them would be a lying response.
         foreach (array_keys($data) as $fieldName) {
+            if ($fieldName === 'pid') {
+                continue;
+            }
             if (!$this->tableAccessService->getFieldConfig($table, $fieldName)) {
                 return "Field '{$fieldName}' does not exist in table '{$table}' and cannot be written";
             }

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -266,6 +266,12 @@ class WriteTableTool extends AbstractRecordTool
             return $this->createErrorResult('Operation vetoed: ' . ($beforeEvent->getVetoReason() ?? 'No reason given'));
         }
         $data = $beforeEvent->getData();
+        // Listeners may have rerouted the target page by editing data.pid —
+        // re-extract so the create path honours their change. (For update,
+        // updateRecord pulls pid from data itself, so it's already covered.)
+        if (is_array($data) && array_key_exists('pid', $data)) {
+            $pid = (int)$data['pid'];
+        }
 
         // Execute the action
         switch ($action) {
@@ -776,7 +782,10 @@ class WriteTableTool extends AbstractRecordTool
         if ($position === 'bottom') {
             $sortingField = $this->tableAccessService->getSortingFieldName($table);
             if ($sortingField === null) {
-                return null;
+                // Without a sortby field there's no meaningful "bottom" within
+                // the same page; only return the target pid when we're actually
+                // moving across pages, so the cross-page move still happens.
+                return $targetPid !== null ? $pid : null;
             }
             $qb = GeneralUtility::makeInstance(ConnectionPool::class)
                 ->getQueryBuilderForTable($table);
@@ -800,7 +809,11 @@ class WriteTableTool extends AbstractRecordTool
             if ($lastRecord) {
                 return -(int)$lastRecord['uid'];
             }
-            return null;
+            // Empty target page. For a same-page reorder there's nothing to do;
+            // for a cross-page move we still need to issue the move, so return
+            // the target pid (DataHandler treats positive = top of that page,
+            // which is also the bottom on an empty page).
+            return $targetPid !== null ? $pid : null;
         }
 
         if ($position === 'top') {

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -67,10 +67,6 @@ class WriteTableTool extends AbstractRecordTool
                         'description' => 'The table name to write records to',
                         'enum' => $tableNames,
                     ],
-                    'pid' => [
-                        'type' => 'integer',
-                        'description' => 'Page ID. Required for "create" action (target page for the new record). On "update", set this to move the record to a different page (combine with "position" to control where on that page it lands).',
-                    ],
                     'uid' => [
                         'type' => 'integer',
                         'description' => 'Record UID (required for "update" and "delete" actions)',
@@ -78,8 +74,10 @@ class WriteTableTool extends AbstractRecordTool
                     'data' => [
                         'type' => 'object',
                         'description' => 'Record data with field names as keys and their values (required for "create", "update", and "translate" actions). ' .
-                            'Uses the same field syntax as ReadTable output.' .
-                            ($hasMultipleLanguages ? ' Language fields (sys_language_uid) accept ISO codes like "de", "fr" instead of numeric IDs.' : '') . ' ' .
+                            'Uses the same field syntax as ReadTable output. ' .
+                            'The target page is also specified here as "pid" — required on "create" (the page the record is created on); ' .
+                            'on "update" setting "pid" moves the record to that page (combine with "position" to control where on the new page it lands; e.g. data: {"pid": 1} moves the record to page 1). ' .
+                            ($hasMultipleLanguages ? 'Language fields (sys_language_uid) accept ISO codes like "de", "fr" instead of numeric IDs. ' : '') .
                             'Inline relations can be specified as arrays - UIDs for independent tables, record data for embedded tables. ' .
                             'For embedded tables (e.g. file references), the array fully replaces the existing list: ' .
                             'children present in the previous record but missing from the new array are deleted. ' .
@@ -87,19 +85,19 @@ class WriteTableTool extends AbstractRecordTool
                             'Array order drives display order. ' .
                             'For text fields in update actions, instead of providing the full text, you can provide an array of search-and-replace operations: ' .
                             '[{"search": "old text", "replace": "new text"}]. Each operation can optionally include "replaceAll": true. ' .
-                            'Operations are applied sequentially. Each search string must match exactly once unless replaceAll is true. ' .
-                            'On the "update" action, setting "pid" moves the record to that page (combine with "position" to control where on the new page it lands).',
+                            'Operations are applied sequentially. Each search string must match exactly once unless replaceAll is true.',
                         'additionalProperties' => true,
                         'examples' => [
-                            ['title' => 'News Title', 'bodytext' => 'News <b>content</b>', 'datetime' => '2024-01-01 10:00:00'],
-                            ['header' => 'Content Element Header', 'bodytext' => 'Content <b>text</b>', 'CType' => 'text'],
+                            ['pid' => 42, 'title' => 'News Title', 'bodytext' => 'News <b>content</b>', 'datetime' => '2024-01-01 10:00:00'],
+                            ['pid' => 1, 'header' => 'Content Element Header', 'bodytext' => 'Content <b>text</b>', 'CType' => 'text'],
+                            ['pid' => 5],
                             ['sys_language_uid' => 'de', 'title' => 'German translation'],
                             ['header' => [['search' => 'Welcom', 'replace' => 'Welcome'], ['search' => 'Compnay', 'replace' => 'Company']]],
                         ]
                     ],
                     'position' => [
                         'type' => 'string',
-                        'description' => 'Sorting position: "top", "bottom", "after:UID", or "before:UID". For create: defaults to "bottom" if omitted. For update: omit to keep current position, or specify to move the record.',
+                        'description' => 'Sorting position within a page: "top", "bottom", "after:UID", or "before:UID". For create: defaults to "bottom" if omitted. For update: omit to keep the current sort order, or specify to reorder. To move a record to a DIFFERENT page, set "pid" in the data parameter instead (or together with "position" for fine-grained placement on the new page).',
                     ],
                 ],
                 'required' => ['action', 'table'],
@@ -120,7 +118,7 @@ class WriteTableTool extends AbstractRecordTool
         // Some models (e.g. OpenAI GPT) place record fields at the top level
         // instead of nesting them inside the 'data' parameter.
         // Collect any unknown top-level keys into 'data' so the tool works regardless.
-        $knownKeys = ['action', 'table', 'pid', 'uid', 'data', 'position'];
+        $knownKeys = ['action', 'table', 'uid', 'data', 'position'];
         $extraData = array_diff_key($params, array_flip($knownKeys));
         if (!empty($extraData) && empty($params['data'])) {
             $params['data'] = $extraData;
@@ -129,7 +127,6 @@ class WriteTableTool extends AbstractRecordTool
         // Get parameters
         $action = $params['action'] ?? '';
         $table = $params['table'] ?? '';
-        $pid = isset($params['pid']) ? (int)$params['pid'] : null;
         $uid = isset($params['uid']) ? (int)$params['uid'] : null;
         $data = $params['data'] ?? [];
         $position = $params['position'] ?? null;
@@ -153,11 +150,31 @@ class WriteTableTool extends AbstractRecordTool
                     "not a plain string. Each field name should be a key with its corresponding value."
                 ]);
             }
+        }
+
+        // Older callers (and the previous schema) put `pid` at the top level.
+        // The schema now scopes it to `data`, but if a caller still sends it
+        // at the top level, fold it in transparently rather than silently
+        // losing it. `data.pid` always wins if both are set.
+        if (isset($params['pid']) && is_array($data) && !array_key_exists('pid', $data)) {
+            $data['pid'] = $params['pid'];
+        }
+
+        // pid lives inside `data` (it's a record column). On create it picks
+        // the target page; on update it triggers a move to that page.
+        $pid = is_array($data) && isset($data['pid']) ? (int)$data['pid'] : null;
+
+        if (in_array($action, ['create', 'update', 'translate'], true)) {
             $positionProvided = $position !== null;
+            // pid alone doesn't count as "real" record content — it's a placement
+            // hint, not a field write. Strip it for the empty check so a payload
+            // of {pid: 1} still fails with "data must contain record fields" on
+            // create/translate.
+            $dataWithoutPid = is_array($data) ? array_diff_key($data, ['pid' => null]) : $data;
             // On update, an empty data parameter is allowed when the caller is
             // only changing position or moving the record to a new pid.
             $isUpdateMoveOnly = $action === 'update' && ($positionProvided || $pid !== null);
-            if (empty($data) && !$isUpdateMoveOnly) {
+            if (empty($dataWithoutPid) && !$isUpdateMoveOnly) {
                 throw new ValidationException([
                     "The data parameter must contain record fields for {$action} actions. " .
                     "Provide field names as keys, e.g. {\"title\": \"Page Title\", \"bodytext\": \"Content\"}."
@@ -198,22 +215,21 @@ class WriteTableTool extends AbstractRecordTool
         switch ($action) {
             case 'create':
                 if ($pid === null) {
-                    throw new ValidationException(['Page ID (pid) is required for create action']);
+                    throw new ValidationException(['Page ID (pid) is required for create action — include it in the data parameter, e.g. data: {pid: 1, title: "..."}']);
                 }
-                
+
                 if (empty($data)) {
                     throw new ValidationException(['Data is required for create action']);
                 }
                 break;
-                
+
             case 'update':
                 if ($uid === null) {
                     throw new ValidationException(['Record UID is required for update action']);
                 }
 
                 $hasPosition = $position !== null;
-                $hasMove = $pid !== null || array_key_exists('pid', $data);
-                if (empty($data) && empty($searchReplace) && !$hasPosition && !$hasMove) {
+                if (empty($data) && empty($searchReplace) && !$hasPosition) {
                     throw new ValidationException(['Data is required for update action']);
                 }
                 break;
@@ -254,20 +270,19 @@ class WriteTableTool extends AbstractRecordTool
         // Execute the action
         switch ($action) {
             case 'create':
+                // pid is consumed as a separate argument; remove it from data so
+                // it doesn't reach DataHandler as a field write.
+                unset($data['pid']);
                 return $this->createRecord($table, $pid, $data, $position);
-                
+
             case 'update':
                 // Resolve search_replace into concrete field values and merge into data
                 if (!empty($searchReplace)) {
                     $resolvedFields = $this->resolveSearchReplace($table, $uid, $searchReplace);
                     $data = array_merge($data, $resolvedFields);
                 }
-                // Top-level `pid` on update is treated the same as `data.pid`:
-                // a request to move the record to that page. LLMs are equally
-                // likely to put it at either spot.
-                if ($pid !== null && !array_key_exists('pid', $data)) {
-                    $data['pid'] = $pid;
-                }
+                // pid stays inside `data` here — updateRecord extracts it and
+                // turns it into a DataHandler `move` cmdmap.
                 return $this->updateRecord($table, $uid, $data, $position);
                 
             case 'delete':

--- a/Tests/Functional/MCP/Tool/EdgeCase/InvalidDataTest.php
+++ b/Tests/Functional/MCP/Tool/EdgeCase/InvalidDataTest.php
@@ -243,7 +243,8 @@ class InvalidDataTest extends AbstractFunctionalTest
      */
     public function testCircularParentReference(): void
     {
-        // Try to set a page as its own parent
+        // Setting pid on update triggers a move; moving a page into itself
+        // must be rejected by DataHandler.
         $result = $this->writeTool->execute([
             'action' => 'update',
             'table' => 'pages',
@@ -252,9 +253,9 @@ class InvalidDataTest extends AbstractFunctionalTest
                 'pid' => 1 // Self-reference
             ]
         ]);
-        
+
         $this->assertTrue($result->isError);
-        $this->assertStringContainsString('can only be set during record creation', $result->content[0]->text);
+        $this->assertStringContainsString('Error moving record', $result->content[0]->text);
     }
     
     /**

--- a/Tests/Functional/MCP/Tool/WriteTableBeforeWriteEventTest.php
+++ b/Tests/Functional/MCP/Tool/WriteTableBeforeWriteEventTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use Hn\McpServer\Event\BeforeRecordWriteEvent;
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use Hn\McpServer\Tests\Functional\Traits\McpAssertionsTrait;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Verify that a `BeforeRecordWriteEvent` listener can reroute the target page
+ * by editing `data.pid` before the create runs. The tool must re-read pid
+ * from data after dispatching the event so listener-driven changes take
+ * effect. Without that, the listener's pid mutation would be silently ignored
+ * and the record would land on the originally requested page.
+ */
+class WriteTableBeforeWriteEventTest extends AbstractFunctionalTest
+{
+    use McpAssertionsTrait;
+
+    private WriteTableTool $writeTool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->writeTool = new WriteTableTool();
+    }
+
+    protected function tearDown(): void
+    {
+        // Drop any singleton instance we may have set so other tests in the
+        // same process see the real container-resolved dispatcher again.
+        GeneralUtility::removeSingletonInstance(
+            EventDispatcherInterface::class,
+            GeneralUtility::makeInstance(EventDispatcherInterface::class)
+        );
+        parent::tearDown();
+    }
+
+    public function testBeforeWriteListenerCanReroutePidOnCreate(): void
+    {
+        $requestedPid = 1; // "Home" in the standard fixtures
+        $reroutedPid = 2;  // "About"
+
+        $this->installDispatcher(function (object $event) use ($reroutedPid): void {
+            if ($event instanceof BeforeRecordWriteEvent && $event->getAction() === 'create') {
+                $data = $event->getData();
+                $data['pid'] = $reroutedPid;
+                $event->setData($data);
+            }
+        });
+
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'data' => [
+                'pid' => $requestedPid,
+                'CType' => 'textmedia',
+                'header' => 'Listener Reroute Test',
+                'colPos' => 0,
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $payload = json_decode($result->content[0]->text, true);
+        $newUid = (int)($payload['uid'] ?? 0);
+        $this->assertGreaterThan(0, $newUid, 'Expected a created record uid in the response');
+
+        // Confirm the record landed on the listener's chosen page, not the
+        // page the caller originally specified.
+        $record = BackendUtility::getRecord('tt_content', $newUid, 'pid');
+        $this->assertNotNull($record, "Created record $newUid not found");
+        $this->assertSame(
+            $reroutedPid,
+            (int)$record['pid'],
+            'Listener edited data.pid but the record landed on the originally requested page — '
+            . 'pid must be re-read from data after BeforeRecordWriteEvent dispatch.'
+        );
+    }
+
+    private function installDispatcher(callable $listener): void
+    {
+        // Implement SingletonInterface so GeneralUtility::setSingletonInstance
+        // accepts our anonymous dispatcher as a stand-in for the container's.
+        $dispatcher = new class($listener) implements EventDispatcherInterface, SingletonInterface {
+            public function __construct(private $listener) {}
+
+            public function dispatch(object $event): object
+            {
+                ($this->listener)($event);
+                return $event;
+            }
+        };
+
+        GeneralUtility::setSingletonInstance(EventDispatcherInterface::class, $dispatcher);
+    }
+}

--- a/Tests/Functional/MCP/Tool/WriteTableToolErrorTest.php
+++ b/Tests/Functional/MCP/Tool/WriteTableToolErrorTest.php
@@ -201,20 +201,6 @@ class WriteTableToolErrorTest extends FunctionalTestCase
         $this->assertTrue($result->isError);
         $this->assertStringContainsString("Field 'uid' cannot be modified directly", $result->content[0]->text);
         
-        // Test 2: pid modification in update
-        $result = $this->tool->execute([
-            'action' => 'update',
-            'table' => 'pages',
-            'uid' => 1,
-            'data' => [
-                'pid' => 2, // Cannot modify pid in update
-                'title' => 'Test'
-            ]
-        ]);
-        
-        $this->assertTrue($result->isError);
-        $this->assertStringContainsString("Field 'pid' can only be set during record creation", $result->content[0]->text);
-        
         // Test 3: Invalid field value (exceeds max length)
         $longTitle = str_repeat('x', 300); // Title field typically has max length of 255
         $result = $this->tool->execute([

--- a/Tests/Functional/MCP/Tool/WriteTableToolTest.php
+++ b/Tests/Functional/MCP/Tool/WriteTableToolTest.php
@@ -1452,10 +1452,12 @@ class WriteTableToolTest extends AbstractFunctionalTest
         $properties = $schema['inputSchema']['properties'];
         $this->assertArrayHasKey('action', $properties);
         $this->assertArrayHasKey('table', $properties);
-        $this->assertArrayHasKey('pid', $properties);
         $this->assertArrayHasKey('uid', $properties);
         $this->assertArrayHasKey('data', $properties);
         $this->assertArrayHasKey('position', $properties);
+        // pid is a record column expressed inside `data`, not a top-level
+        // parameter — confirm we don't accidentally re-introduce it.
+        $this->assertArrayNotHasKey('pid', $properties);
         
         // Check required fields
         $this->assertArrayHasKey('required', $schema['inputSchema']);

--- a/Tests/Functional/MCP/Tool/WriteTableUpdatePidTest.php
+++ b/Tests/Functional/MCP/Tool/WriteTableUpdatePidTest.php
@@ -180,10 +180,11 @@ class WriteTableUpdatePidTest extends AbstractFunctionalTest
         $this->assertSame($parentB, (int)$record['pid'], 'Page should now live under the new parent');
     }
 
-    public function testUpdateWithTopLevelPidAlsoMovesRecord(): void
+    public function testUpdateWithTopLevelPidStillWorksAsCompatFallback(): void
     {
-        // Many LLMs will put pid at the top level (matching its create-action
-        // schema slot) instead of inside data. Both forms should move the record.
+        // Top-level `pid` is no longer in the schema, but for backwards compat
+        // with older callers (and LLMs trained on prior versions) the tool
+        // still folds a top-level pid into data and performs the same move.
         $sourcePage = $this->createPage('Top-Level Pid Source', '/tlp-src');
         $targetPage = $this->createPage('Top-Level Pid Target', '/tlp-tgt');
         $uids = $this->createOrderedContent($sourcePage, ['Mover']);

--- a/Tests/Functional/MCP/Tool/WriteTableUpdatePidTest.php
+++ b/Tests/Functional/MCP/Tool/WriteTableUpdatePidTest.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use Hn\McpServer\MCP\Tool\Record\ReadTableTool;
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use Hn\McpServer\Tests\Functional\Traits\McpAssertionsTrait;
+
+/**
+ * Verify that setting `pid` in the data of an `action=update` call moves the
+ * record to the new page. `pid` is not a TCA columns entry, so it bypasses
+ * the normal "unknown field" rejection and is routed through DataHandler's
+ * `move` cmdmap instead.
+ */
+class WriteTableUpdatePidTest extends AbstractFunctionalTest
+{
+    use McpAssertionsTrait;
+
+    private WriteTableTool $writeTool;
+    private ReadTableTool $readTool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->writeTool = new WriteTableTool();
+        $this->readTool = new ReadTableTool();
+    }
+
+    public function testUpdatePidMovesContentRecordToAnotherPage(): void
+    {
+        $sourcePage = $this->createPage('Source Page', '/move-source');
+        $targetPage = $this->createPage('Target Page', '/move-target');
+
+        $sourceUids = $this->createOrderedContent($sourcePage, ['Keep1', 'Mover', 'Keep2']);
+        $targetUids = $this->createOrderedContent($targetPage, ['Existing']);
+
+        $result = $this->writeTool->execute([
+            'action' => 'update',
+            'table' => 'tt_content',
+            'uid' => $sourceUids['Mover'],
+            'data' => ['pid' => $targetPage],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $this->assertOrderOnPage($sourcePage, ['Keep1', 'Keep2']);
+        // No position specified → the moved record lands at the top of the new page.
+        $this->assertOrderOnPage($targetPage, ['Mover', 'Existing']);
+    }
+
+    public function testUpdatePidIsNotRejectedAsUnknownField(): void
+    {
+        // Regression test: the "reject unknown fields" guard added for fields
+        // that lack a TCA columns entry must NOT swallow `pid`, since pid is
+        // a special TYPO3 control field handled by DataHandler.
+        $sourcePage = $this->createPage('Reject Source', '/reject-src');
+        $targetPage = $this->createPage('Reject Target', '/reject-tgt');
+        $uids = $this->createOrderedContent($sourcePage, ['A']);
+
+        $result = $this->writeTool->execute([
+            'action' => 'update',
+            'table' => 'tt_content',
+            'uid' => $uids['A'],
+            'data' => ['pid' => $targetPage],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+    }
+
+    public function testUpdatePidWithPositionBottomLandsAtBottomOfTargetPage(): void
+    {
+        $sourcePage = $this->createPage('Pid+Position Source', '/pp-src');
+        $targetPage = $this->createPage('Pid+Position Target', '/pp-tgt');
+
+        $sourceUids = $this->createOrderedContent($sourcePage, ['Mover']);
+        $this->createOrderedContent($targetPage, ['First', 'Second']);
+
+        $result = $this->writeTool->execute([
+            'action' => 'update',
+            'table' => 'tt_content',
+            'uid' => $sourceUids['Mover'],
+            'data' => ['pid' => $targetPage],
+            'position' => 'bottom',
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $this->assertOrderOnPage($targetPage, ['First', 'Second', 'Mover']);
+        $this->assertOrderOnPage($sourcePage, []);
+    }
+
+    public function testUpdatePidWithPositionAfterPlacesAfterReference(): void
+    {
+        $sourcePage = $this->createPage('After Source', '/after-src');
+        $targetPage = $this->createPage('After Target', '/after-tgt');
+
+        $sourceUids = $this->createOrderedContent($sourcePage, ['Mover']);
+        $targetUids = $this->createOrderedContent($targetPage, ['First', 'Second', 'Third']);
+
+        // Move 'Mover' to target page, immediately after 'First'.
+        $result = $this->writeTool->execute([
+            'action' => 'update',
+            'table' => 'tt_content',
+            'uid' => $sourceUids['Mover'],
+            'data' => ['pid' => $targetPage],
+            'position' => 'after:' . $targetUids['First'],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $this->assertOrderOnPage($targetPage, ['First', 'Mover', 'Second', 'Third']);
+    }
+
+    public function testUpdatePidAlongsideFieldUpdate(): void
+    {
+        $sourcePage = $this->createPage('Combo Source', '/combo-src');
+        $targetPage = $this->createPage('Combo Target', '/combo-tgt');
+
+        $sourceUids = $this->createOrderedContent($sourcePage, ['Original Header']);
+
+        // Rename the record AND move it in one call.
+        $result = $this->writeTool->execute([
+            'action' => 'update',
+            'table' => 'tt_content',
+            'uid' => $sourceUids['Original Header'],
+            'data' => [
+                'pid' => $targetPage,
+                'header' => 'Renamed Header',
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $this->assertOrderOnPage($sourcePage, []);
+        $this->assertOrderOnPage($targetPage, ['Renamed Header']);
+    }
+
+    public function testUpdatePidToSamePageIsNoop(): void
+    {
+        // Setting pid to the record's current page should not change order
+        // — DataHandler's move with positive destination puts the record at
+        // the top of that page.
+        $page = $this->createPage('Same Pid', '/same-pid');
+        $uids = $this->createOrderedContent($page, ['A', 'B', 'C']);
+
+        $result = $this->writeTool->execute([
+            'action' => 'update',
+            'table' => 'tt_content',
+            'uid' => $uids['B'],
+            'data' => ['pid' => $page],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        // 'B' was moved to the top of the same page.
+        $this->assertOrderOnPage($page, ['B', 'A', 'C']);
+    }
+
+    public function testUpdatePidMovesPageToAnotherParent(): void
+    {
+        // Pages also support move via pid — this changes the page-tree parent.
+        $parentA = $this->createPage('Parent A', '/parent-a');
+        $parentB = $this->createPage('Parent B', '/parent-b');
+
+        $childUid = $this->createPage('Child', '/parent-a/child', $parentA);
+
+        $result = $this->writeTool->execute([
+            'action' => 'update',
+            'table' => 'pages',
+            'uid' => $childUid,
+            'data' => ['pid' => $parentB],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $readResult = $this->readTool->execute([
+            'table' => 'pages',
+            'uid' => $childUid,
+        ]);
+        $this->assertFalse($readResult->isError, json_encode($readResult->jsonSerialize()));
+        $data = $this->extractJsonFromResult($readResult);
+        $record = $data['records'][0] ?? $data;
+        $this->assertSame($parentB, (int)$record['pid'], 'Page should now live under the new parent');
+    }
+
+    public function testUpdateWithTopLevelPidAlsoMovesRecord(): void
+    {
+        // Many LLMs will put pid at the top level (matching its create-action
+        // schema slot) instead of inside data. Both forms should move the record.
+        $sourcePage = $this->createPage('Top-Level Pid Source', '/tlp-src');
+        $targetPage = $this->createPage('Top-Level Pid Target', '/tlp-tgt');
+        $uids = $this->createOrderedContent($sourcePage, ['Mover']);
+
+        $result = $this->writeTool->execute([
+            'action' => 'update',
+            'table' => 'tt_content',
+            'uid' => $uids['Mover'],
+            'pid' => $targetPage,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $this->assertOrderOnPage($targetPage, ['Mover']);
+        $this->assertOrderOnPage($sourcePage, []);
+    }
+
+    public function testUpdatePidOnlyWithoutOtherDataIsAllowed(): void
+    {
+        // When `pid` is the ONLY field provided, the schema's "data parameter
+        // must contain record fields" guard must not reject the request — pid
+        // is a legitimate, intentional change in this case.
+        $sourcePage = $this->createPage('Only Pid Source', '/only-src');
+        $targetPage = $this->createPage('Only Pid Target', '/only-tgt');
+
+        $uids = $this->createOrderedContent($sourcePage, ['Lonely']);
+
+        $result = $this->writeTool->execute([
+            'action' => 'update',
+            'table' => 'tt_content',
+            'uid' => $uids['Lonely'],
+            'data' => ['pid' => $targetPage],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $this->assertOrderOnPage($targetPage, ['Lonely']);
+    }
+
+    private function createPage(string $title, string $slug, ?int $parentUid = null): int
+    {
+        $pageResult = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => $parentUid ?? $this->getRootPageUid(),
+            'data' => ['title' => $title, 'slug' => $slug, 'doktype' => 1],
+        ]);
+        $this->assertFalse($pageResult->isError, json_encode($pageResult->jsonSerialize()));
+        return (int)$this->extractJsonFromResult($pageResult)['uid'];
+    }
+
+    /**
+     * @param string[] $headers
+     * @return array<string, int>
+     */
+    private function createOrderedContent(int $pageUid, array $headers): array
+    {
+        $uids = [];
+        foreach ($headers as $header) {
+            $result = $this->writeTool->execute([
+                'action' => 'create',
+                'table' => 'tt_content',
+                'pid' => $pageUid,
+                'position' => 'bottom',
+                'data' => ['CType' => 'textmedia', 'header' => $header, 'colPos' => 0],
+            ]);
+            $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+            $uids[$header] = (int)$this->extractJsonFromResult($result)['uid'];
+        }
+        return $uids;
+    }
+
+    /**
+     * @param string[] $expectedHeaders
+     */
+    private function assertOrderOnPage(int $pageUid, array $expectedHeaders): void
+    {
+        $readResult = $this->readTool->execute([
+            'table' => 'tt_content',
+            'pid' => $pageUid,
+        ]);
+        $this->assertFalse($readResult->isError, json_encode($readResult->jsonSerialize()));
+        $readData = $this->extractJsonFromResult($readResult);
+        $records = $readData['records'] ?? [];
+        $actual = array_map(static fn(array $r): string => $r['header'], $records);
+        $this->assertSame($expectedHeaders, $actual);
+    }
+}

--- a/Tests/Functional/MCP/Tool/WriteTableUpdatePidTest.php
+++ b/Tests/Functional/MCP/Tool/WriteTableUpdatePidTest.php
@@ -90,6 +90,29 @@ class WriteTableUpdatePidTest extends AbstractFunctionalTest
         $this->assertOrderOnPage($sourcePage, []);
     }
 
+    public function testUpdatePidWithPositionBottomMovesEvenWhenTargetPageIsEmpty(): void
+    {
+        // Regression: position=bottom resolved to "no last record" on the target
+        // page → null destination → silent no-op, with the record stuck on its
+        // original page even though pid was set.
+        $sourcePage = $this->createPage('Empty-Target Source', '/et-src');
+        $emptyTarget = $this->createPage('Empty-Target', '/et-tgt');
+
+        $sourceUids = $this->createOrderedContent($sourcePage, ['Mover']);
+
+        $result = $this->writeTool->execute([
+            'action' => 'update',
+            'table' => 'tt_content',
+            'uid' => $sourceUids['Mover'],
+            'data' => ['pid' => $emptyTarget],
+            'position' => 'bottom',
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $this->assertOrderOnPage($sourcePage, []);
+        $this->assertOrderOnPage($emptyTarget, ['Mover']);
+    }
+
     public function testUpdatePidWithPositionAfterPlacesAfterReference(): void
     {
         $sourcePage = $this->createPage('After Source', '/after-src');

--- a/Tests/Llm/LlmTestCase.php
+++ b/Tests/Llm/LlmTestCase.php
@@ -413,6 +413,25 @@ abstract class LlmTestCase extends FunctionalTestCase
     }
 
     /**
+     * Extract the target page id from a WriteTable tool call's arguments.
+     * The schema places `pid` inside `data` (it's a record column), but a
+     * legacy top-level `pid` is also accepted by the tool and might be
+     * emitted by older callers — accept either, preferring the canonical
+     * data location. Returns null when neither is set.
+     */
+    protected function extractWritePid(array $arguments): ?int
+    {
+        $data = $this->extractWriteData($arguments);
+        if (array_key_exists('pid', $data)) {
+            return (int)$data['pid'];
+        }
+        if (array_key_exists('pid', $arguments)) {
+            return (int)$arguments['pid'];
+        }
+        return null;
+    }
+
+    /**
      * Assert that the response follows one of the acceptable patterns
      *
      * @param LlmResponse $response

--- a/Tests/Llm/MoveContentElementTest.php
+++ b/Tests/Llm/MoveContentElementTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Llm;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+
+/**
+ * Test the LLM's ability to move a content element from one page to another.
+ *
+ * The expected mechanism is `WriteTable(action=update, pid=<targetPid>)`. The
+ * tool accepts the new pid either at the top level or inside `data`; this
+ * test treats both as valid as long as the record actually ends up on the
+ * target page.
+ *
+ * @group llm
+ */
+class MoveContentElementTest extends LlmTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/tt_content.csv');
+    }
+
+    /**
+     * Fixture state:
+     *   - tt_content uid=110 "Banner Ad" lives on page 7 ("News").
+     *   - The user wants it on page 1 ("Home") instead.
+     * The LLM must locate the banner, recognise it's on the wrong page, and
+     * issue an update that changes pid to 1.
+     */
+    #[DataProvider('modelProvider')]
+    #[TestDox('[$modelKey] Prompt "Move the Banner Ad to the home page" → explores, then WriteTable(update) with pid=1 to relocate the element')]
+    public function testLlmMovesContentElementToAnotherPage(string $modelKey): void
+    {
+        $this->setModel($modelKey);
+
+        $homePid = 1;
+        $newsPid = 7;
+        $bannerUid = 110;
+
+        // Sanity check the fixture so a fixture change makes the failure obvious
+        // instead of looking like an LLM mistake.
+        $banner = BackendUtility::getRecord('tt_content', $bannerUid);
+        $this->assertNotNull($banner, 'Fixture content element 110 missing');
+        $this->assertSame($newsPid, (int)$banner['pid'], 'Fixture banner is expected to start on the News page');
+
+        $prompt = 'There\'s a "Banner Ad" content element currently on the News page, but it should be on the Home page instead. Please move it.';
+
+        $response = $this->executeUntilToolFound(
+            $this->callLlm($prompt),
+            'WriteTable',
+            8
+        );
+
+        $history = $this->getToolCallHistory();
+        $hasExploration = in_array('GetPage', $history, true)
+            || in_array('GetPageTree', $history, true)
+            || in_array('Search', $history, true)
+            || in_array('ReadTable', $history, true);
+        $this->assertTrue(
+            $hasExploration,
+            "[$modelKey] Expected exploration before move. Tools used: " . implode(', ', $history)
+        );
+
+        $writeCalls = $response->getToolCallsByName('WriteTable');
+        $this->assertGreaterThan(
+            0,
+            count($writeCalls),
+            "[$modelKey] Expected WriteTable call to perform the move. "
+            . "Tool history: " . implode(' → ', $history)
+            . "\nFinal response: " . $response->getContent()
+        );
+
+        $writeCall = $writeCalls[0]['arguments'];
+        $this->assertSame('update', $writeCall['action'] ?? '',
+            "[$modelKey] Expected an update action for the move. Got: " . json_encode($writeCall, JSON_PRETTY_PRINT));
+        $this->assertSame('tt_content', $writeCall['table'] ?? '',
+            "[$modelKey] Expected tt_content table. Got: " . json_encode($writeCall, JSON_PRETTY_PRINT));
+        $this->assertSame($bannerUid, (int)($writeCall['uid'] ?? 0),
+            "[$modelKey] Expected uid=$bannerUid (the Banner Ad). Got: " . json_encode($writeCall, JSON_PRETTY_PRINT));
+
+        // Accept pid at the top level OR inside data — both are valid per schema.
+        $data = $this->extractWriteData($writeCall);
+        $newPid = $writeCall['pid'] ?? $data['pid'] ?? null;
+        $this->assertNotNull(
+            $newPid,
+            "[$modelKey] Expected pid to be set (top level or in data) to move the record. "
+            . "Got: " . json_encode($writeCall, JSON_PRETTY_PRINT)
+        );
+        $this->assertSame(
+            $homePid,
+            (int)$newPid,
+            "[$modelKey] Expected pid=$homePid (Home page). Got: " . json_encode($writeCall, JSON_PRETTY_PRINT)
+        );
+
+        $writeResult = $this->executeToolCall($writeCalls[0]);
+        $this->assertFalse(
+            $writeResult['isError'] ?? false,
+            "[$modelKey] WriteTable failed: " . ($writeResult['content'] ?? '')
+        );
+
+        // Confirm the record actually moved. ReadTable applies the workspace
+        // overlay, which is exactly what we want — the move runs through
+        // DataHandler in the workspace.
+        $this->assertContentElementIsOnPage($bannerUid, $homePid, $modelKey);
+    }
+
+    private function assertContentElementIsOnPage(int $uid, int $expectedPid, string $modelKey): void
+    {
+        $toolRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Hn\McpServer\MCP\ToolRegistry::class);
+        $readTable = $toolRegistry->getTool('ReadTable');
+        $this->assertNotNull($readTable, 'ReadTable tool missing from registry');
+
+        $result = $readTable->execute([
+            'table' => 'tt_content',
+            'uid' => $uid,
+        ]);
+        $this->assertFalse($result->isError,
+            "[$modelKey] ReadTable failed when verifying move: "
+            . ($result->content[0]->text ?? json_encode($result->jsonSerialize())));
+
+        $payload = json_decode($result->content[0]->text, true);
+        $record = $payload['records'][0] ?? null;
+        $this->assertNotNull($record,
+            "[$modelKey] Could not find content element $uid after move. Payload: " . json_encode($payload));
+        $this->assertSame(
+            $expectedPid,
+            (int)($record['pid'] ?? 0),
+            "[$modelKey] Expected content element $uid to live on page $expectedPid after the move. "
+            . "Actual record: " . json_encode($record)
+        );
+    }
+}

--- a/Tests/Llm/MoveContentElementTest.php
+++ b/Tests/Llm/MoveContentElementTest.php
@@ -11,10 +11,10 @@ use TYPO3\CMS\Backend\Utility\BackendUtility;
 /**
  * Test the LLM's ability to move a content element from one page to another.
  *
- * The expected mechanism is `WriteTable(action=update, pid=<targetPid>)`. The
- * tool accepts the new pid either at the top level or inside `data`; this
- * test treats both as valid as long as the record actually ends up on the
- * target page.
+ * The schema describes `pid` as a record column inside `data`. The tool also
+ * accepts a top-level `pid` as a graceful fallback for older callers, but
+ * this test deliberately asserts the LLM puts pid in `data` — i.e. that it
+ * actually follows the current schema rather than relying on the fallback.
  *
  * @group llm
  */
@@ -86,18 +86,25 @@ class MoveContentElementTest extends LlmTestCase
         $this->assertSame($bannerUid, (int)($writeCall['uid'] ?? 0),
             "[$modelKey] Expected uid=$bannerUid (the Banner Ad). Got: " . json_encode($writeCall, JSON_PRETTY_PRINT));
 
-        // Accept pid at the top level OR inside data — both are valid per schema.
+        // Per the schema, pid lives inside `data` (it's a record column, not a
+        // top-level parameter). Verify the LLM put it there.
         $data = $this->extractWriteData($writeCall);
-        $newPid = $writeCall['pid'] ?? $data['pid'] ?? null;
-        $this->assertNotNull(
-            $newPid,
-            "[$modelKey] Expected pid to be set (top level or in data) to move the record. "
+        $this->assertArrayHasKey(
+            'pid',
+            $data,
+            "[$modelKey] Expected pid inside `data` (it's a record column per the schema). "
+            . "Got: " . json_encode($writeCall, JSON_PRETTY_PRINT)
+        );
+        $this->assertArrayNotHasKey(
+            'pid',
+            $writeCall,
+            "[$modelKey] Did not expect pid as a top-level parameter — schema places it in `data`. "
             . "Got: " . json_encode($writeCall, JSON_PRETTY_PRINT)
         );
         $this->assertSame(
             $homePid,
-            (int)$newPid,
-            "[$modelKey] Expected pid=$homePid (Home page). Got: " . json_encode($writeCall, JSON_PRETTY_PRINT)
+            (int)$data['pid'],
+            "[$modelKey] Expected data.pid=$homePid (Home page). Got: " . json_encode($writeCall, JSON_PRETTY_PRINT)
         );
 
         $writeResult = $this->executeToolCall($writeCalls[0]);

--- a/Tests/Llm/NewsTest.php
+++ b/Tests/Llm/NewsTest.php
@@ -78,14 +78,15 @@ class NewsTest extends LlmTestCase
             "Expected news record creation when asked for a news article");
 
         $acceptablePids = [8, 12, 30];
-        $this->assertContains($writeCall['arguments']['pid'], $acceptablePids,
-            "News articles should be created on Blog (8), Press (12), or in the storage folder (30)");
+        $data = $this->extractWriteData($writeCall['arguments']);
+        $newsPid = $this->extractWritePid($writeCall['arguments']);
+        $this->assertContains($newsPid, $acceptablePids,
+            "News articles should be created on Blog (8), Press (12), or in the storage folder (30). "
+            . "Got pid=" . var_export($newsPid, true) . ", arguments=" . json_encode($writeCall['arguments'], JSON_PRETTY_PRINT));
 
         $writeResult = $this->executeToolCall($writeCall);
         $this->assertFalse($writeResult['isError'] ?? false,
             'WriteTable failed: ' . $writeResult['content']);
-
-        $data = $this->extractWriteData($writeCall['arguments']);
 
         $allContent = ($data['title'] ?? '') . ' ' .
                      ($data['teaser'] ?? '') . ' ' .
@@ -139,8 +140,10 @@ class NewsTest extends LlmTestCase
             "\nAll WriteTable calls: " . json_encode(array_map(fn($c) => $c['arguments']['table'] ?? 'unknown', $writeCalls)));
         $this->assertEquals('create', $newsWriteCall['arguments']['action']);
         $acceptablePids = [8, 12, 30];
-        $this->assertContains($newsWriteCall['arguments']['pid'], $acceptablePids,
-            "News articles should be created on Blog (8), Press (12), or in the storage folder (30)");
+        $newsPid = $this->extractWritePid($newsWriteCall['arguments']);
+        $this->assertContains($newsPid, $acceptablePids,
+            "News articles should be created on Blog (8), Press (12), or in the storage folder (30). "
+            . "Got pid=" . var_export($newsPid, true) . ", arguments=" . json_encode($newsWriteCall['arguments'], JSON_PRETTY_PRINT));
 
         $writeResult = $this->executeToolCall($newsWriteCall);
         $this->assertFalse($writeResult['isError'] ?? false,
@@ -203,8 +206,10 @@ class NewsTest extends LlmTestCase
             "\nAll WriteTable calls: " . json_encode(array_map(fn($c) => $c['arguments']['table'] ?? 'unknown', $writeCalls)));
         $this->assertEquals('create', $newsWriteCall['arguments']['action']);
         $acceptablePids = [8, 12, 30];
-        $this->assertContains($newsWriteCall['arguments']['pid'], $acceptablePids,
-            "News articles should be created on Blog (8), Press (12), or in the storage folder (30)");
+        $newsPid = $this->extractWritePid($newsWriteCall['arguments']);
+        $this->assertContains($newsPid, $acceptablePids,
+            "News articles should be created on Blog (8), Press (12), or in the storage folder (30). "
+            . "Got pid=" . var_export($newsPid, true) . ", arguments=" . json_encode($newsWriteCall['arguments'], JSON_PRETTY_PRINT));
 
         $writeResult = $this->executeToolCall($newsWriteCall);
         $this->assertFalse($writeResult['isError'] ?? false,


### PR DESCRIPTION
## Summary

- Setting `pid` in `data` on `action=update` now moves the record to that page via DataHandler's `move` cmdmap (combine with `position` for fine-grained placement on the new page).
- Cleans up the schema: `pid` is no longer a top-level parameter — it lives inside `data` alongside the other record columns. The `data` description and an example pin down the create vs. update semantics.
- Sharpened the `position` description so models don't conflate "move to another page" with "reorder within page".

## Why

- `pid` is a column on every TYPO3 row, so exposing it twice (top-level *and* inside `data` after the move feature landed) was redundant and confusing — that's how the discussion that triggered this branch started.
- The previous "field cannot be set during create" rejection on update blocked the natural way an LLM expresses "move to page X" — it kept setting `data.pid` and hitting the guard.

## What's in the diff

**Tool**
- `WriteTableTool::doExecute` extracts `pid` from `data` for both create and update.
- `validateRecordData` skips `pid` in the "unknown TCA column" guard added in #70 (it's a control field, not a TCA column).
- `updateRecord` extracts `pid` from `data` and routes it through DataHandler's `move` cmdmap. Falls back to default placement (top of target page) if no `position` is given.
- `moveRecord` / `resolvePositionToDestination` accept an optional override `targetPid` so position vocabulary can be evaluated against the new page.
- DataHandler `RuntimeException` during move is caught and surfaced as `Error moving record: …` instead of getting swallowed into the generic `Operation failed: WriteTable`.
- Schema: top-level `pid` parameter removed; `data` description owns the explanation; `position` description sharpened to point at `data.pid` for cross-page moves.
- **Compat shim**: a top-level `pid` is still accepted at runtime and folded into `data['pid']` if data doesn't already define it. Undocumented in the schema, so the ~100 existing functional test sites and any older callers keep working without churn while LLMs reading the current schema are steered to `data.pid`.

**Tests**
- New `Tests/Functional/MCP/Tool/WriteTableUpdatePidTest.php` (9 cases): cross-page move of a content record, regression against the unknown-field guard, pid + position=bottom / after:UID, simultaneous field update, no-op same-page move, page-tree parent change, pid-only data, and the top-level-pid compat fallback.
- New `Tests/Llm/MoveContentElementTest.php`: prompts the LLM to move tt_content uid=110 ("Banner Ad") from page 7 ("News") to page 1 ("Home"), then asserts `data.pid` (specifically rejecting top-level pid) and reads the record back to confirm it actually moved. **All 5 configured models pass**: haiku-4.5, gpt-5.4-mini, gpt-oss-120b, mistral-large-2512, gemini-3-flash.
- `testCircularParentReference` and `testTcaValidationErrors` updated for the new behaviour (pid in data is no longer rejected; moving a page into itself is rejected by DataHandler).
- `testToolSchema` now asserts `pid` is *not* a top-level property.

## Useful finding

While iterating on the LLM test, gpt-5.4-mini initially failed by emitting `position: "bottom"` alone when asked to move — it conflated the `position` vocabulary with cross-page move. Adding an explicit pointer in the `position` description ("To move a record to a DIFFERENT page, set 'pid' in the data parameter instead") fixed it. Worth keeping in mind: when MCP tool descriptions talk about "moving", separate the within-page and across-page senses.

## Test plan

- [x] `composer test` — 552 / 552 passing (7 pre-existing DataHandler-edge-case warnings, unrelated)
- [x] `vendor/bin/phpunit -c Tests/Llm/phpunit-llm.xml --filter MoveContentElementTest` — 5 / 5 models passing, stable across two consecutive runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)