### PR TITLE
Fix TSconfig resolution to use actual page context instead of pid=0

### DIFF
--- a/Classes/MCP/Tool/Record/GetTableSchemaTool.php
+++ b/Classes/MCP/Tool/Record/GetTableSchemaTool.php
@@ -6,7 +6,6 @@ namespace Hn\McpServer\MCP\Tool\Record;
 
 use Mcp\Types\CallToolResult;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
 use Hn\McpServer\Utility\TcaFormattingUtility;
 use Hn\McpServer\Service\TableAccessService;
 
@@ -41,6 +40,12 @@ class GetTableSchemaTool extends AbstractRecordTool
                             'If omitted, shows fields for the first available type and lists all available types. ' .
                             'Call again with a different type to see its fields. Types may be filtered by backend TSconfig (some types hidden from the list).',
                     ],
+                    'pid' => [
+                        'type' => 'integer',
+                        'description' => 'Page ID to resolve TSconfig context against. Different pages may allow different record types ' .
+                            'or hide different fields based on page TSconfig. Pass the page where the record will live to get an accurate schema. ' .
+                            'If omitted, the first configured site\'s root page is used so project-wide TSconfig is still applied.',
+                    ],
                 ],
                 'required' => ['table'],
             ],
@@ -57,24 +62,25 @@ class GetTableSchemaTool extends AbstractRecordTool
     protected function doExecute(array $params): CallToolResult
     {
         $table = $params['table'] ?? '';
-        
+
         if (empty($table)) {
             throw new \InvalidArgumentException('Table parameter is required');
         }
-        
+
         // Validate table access using TableAccessService
         $this->ensureTableAccess($table, 'read');
-        
+
         $filterType = $params['type'] ?? '';
-        
-        $result = $this->generateTableSchema($table, $filterType);
+        $pid = isset($params['pid']) ? (int)$params['pid'] : null;
+
+        $result = $this->generateTableSchema($table, $filterType, $pid);
         return $this->createSuccessResult($result);
     }
-    
+
     /**
      * Generate a table schema as text
      */
-    protected function generateTableSchema(string $table, string $filterType = ''): string
+    protected function generateTableSchema(string $table, string $filterType = '', ?int $pid = null): string
     {
         $result = "";
         
@@ -118,24 +124,17 @@ class GetTableSchemaTool extends AbstractRecordTool
         
         $result .= "\n\n";
         
-        // Get the type field using TableAccessService
-        $typeField = $this->tableAccessService->getTypeFieldName($table);
-        $excludeTypes = !empty($typeField) ? $this->getRemovedTypesByTSconfig($table, $typeField) : [];
-        
-        // Get available types using TableAccessService
-        $types = $this->tableAccessService->getAvailableTypes($table);
-        
-        // Apply label translations and exclusions
+        // Get available types using TableAccessService. The service runs the
+        // FormDataCompiler pipeline internally so TCEFORM removeItems / addItems
+        // and TCEMAIN.disableCTypes are already applied at the resolved pid.
+        $types = $this->tableAccessService->getAvailableTypes($table, $pid);
+
+        // Apply label translations
         $processedTypes = [];
         foreach ($types as $value => $label) {
-            // Skip excluded types
-            if (in_array($value, $excludeTypes)) {
-                continue;
-            }
-            
             $processedTypes[$value] = TableAccessService::translateLabel($label);
         }
-        
+
         $types = $processedTypes;
         
         // If no types are available after filtering, show an error
@@ -185,8 +184,10 @@ class GetTableSchemaTool extends AbstractRecordTool
         $result .= "FIELDS:\n";
         $result .= "-------\n";
         
-        // Get available fields using TableAccessService (includes access control)
-        $availableFields = $this->tableAccessService->getAvailableFields($table, $filterType);
+        // Get available fields using TableAccessService (includes access control).
+        // Pass the pid so TCEFORM.[table].[field].disabled is resolved at the
+        // correct page context.
+        $availableFields = $this->tableAccessService->getAvailableFields($table, $filterType, $pid);
         
         if (empty($availableFields)) {
             $result .= "No accessible fields defined for this type.\n";
@@ -293,7 +294,7 @@ class GetTableSchemaTool extends AbstractRecordTool
                             $tabContent .= "    " . $prefix . $paletteFieldName . " (" . $fieldLabel . "): " . $fieldType;
 
                             // Add field details inline
-                            $this->addFieldDetailsInline($tabContent, $fieldConfig, $paletteFieldName, $table, $filterType);
+                            $this->addFieldDetailsInline($tabContent, $fieldConfig, $paletteFieldName, $table, $filterType, $pid);
                             $tabContent .= "\n";
                         }
                     }
@@ -312,7 +313,7 @@ class GetTableSchemaTool extends AbstractRecordTool
                         $tabContent .= "    - " . $fieldName . " (" . $fieldLabel . "): " . $fieldType;
 
                         // Add field details inline
-                        $this->addFieldDetailsInline($tabContent, $fieldConfig, $fieldName, $table, $filterType);
+                        $this->addFieldDetailsInline($tabContent, $fieldConfig, $fieldName, $table, $filterType, $pid);
                         $tabContent .= "\n";
                     }
                 }
@@ -359,7 +360,7 @@ class GetTableSchemaTool extends AbstractRecordTool
                 $result .= "    - " . $fieldName . " (" . $fieldLabel . "): " . $fieldType;
 
                 // Add field details inline
-                $this->addFieldDetailsInline($result, $fieldConfig, $fieldName, $table, $filterType);
+                $this->addFieldDetailsInline($result, $fieldConfig, $fieldName, $table, $filterType, $pid);
                 $result .= "\n";
             }
         }
@@ -383,7 +384,7 @@ class GetTableSchemaTool extends AbstractRecordTool
     /**
      * Add field details inline
      */
-    protected function addFieldDetailsInline(string &$result, array $fieldConfig, string $fieldName, string $table, string $filterType = ''): void
+    protected function addFieldDetailsInline(string &$result, array $fieldConfig, string $fieldName, string $table, string $filterType = '', ?int $pid = null): void
     {
         // Handle both flattened (from TcaSchemaFactory) and nested (traditional TCA) structures
         $config = $fieldConfig['config'] ?? $fieldConfig;
@@ -395,7 +396,7 @@ class GetTableSchemaTool extends AbstractRecordTool
             $this->addFlexFormIdentifiers($result, $config, $table, $fieldName, $filterType);
         } else {
             // For other field types, use the TcaFormattingUtility
-            TcaFormattingUtility::addFieldDetailsInline($result, $config, $fieldName, $table);
+            TcaFormattingUtility::addFieldDetailsInline($result, $config, $fieldName, $table, $pid);
         }
     }
     
@@ -457,37 +458,4 @@ class GetTableSchemaTool extends AbstractRecordTool
     }
     
     
-    /**
-     * Get types that are removed by TSconfig
-     * This uses the same logic as TcaSelectItems to determine which types are restricted
-     */
-    protected function getRemovedTypesByTSconfig(string $table, string $typeField): array
-    {
-        if (empty($table) || empty($typeField)) {
-            return [];
-        }
-        
-        $removedTypes = [];
-        
-        // Get TSconfig for the current page
-        $TSconfig = BackendUtility::getPagesTSconfig(0);
-        
-        // Check TCEFORM.[table].[field].removeItems
-        $fieldTSconfig = $TSconfig['TCEFORM.'][$table . '.'][$typeField . '.']['removeItems'] ?? '';
-        if (!empty($fieldTSconfig)) {
-            $removedTypes = GeneralUtility::trimExplode(',', $fieldTSconfig, true);
-        }
-        
-        // For tt_content, also check TCEMAIN.table.tt_content.disableCTypes
-        if ($table === 'tt_content' && $typeField === 'CType') {
-            $disableCTypes = $TSconfig['TCEMAIN.']['table.']['tt_content.']['disableCTypes'] ?? '';
-            if (!empty($disableCTypes)) {
-                $disabledTypes = GeneralUtility::trimExplode(',', $disableCTypes, true);
-                $removedTypes = array_merge($removedTypes, $disabledTypes);
-            }
-        }
-        
-        return $removedTypes;
-    }
-
 }

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -949,6 +949,30 @@ class WriteTableTool extends AbstractRecordTool
             $mergedRecord = array_merge($data, ['pid' => $pid]);
         }
 
+        // Effective pid for TSconfig context (page where the record will live)
+        $effectivePid = isset($mergedRecord['pid']) ? (int)$mergedRecord['pid'] : 0;
+        if ($effectivePid < 0) {
+            // Negative pid in DataHandler datamap means "after this record uid";
+            // resolve to the referenced record's actual page id.
+            $refRecord = BackendUtility::getRecord($table, abs($effectivePid), 'pid');
+            $effectivePid = $refRecord['pid'] ?? 0;
+        }
+
+        // tt_content additionally honours TCEMAIN.table.tt_content.disableCTypes.
+        // FormDataCompiler doesn't apply this — it's used by the New Content
+        // Element Wizard — so reject those values explicitly so the LLM gets a
+        // clear error instead of a silent success.
+        if ($table === 'tt_content' && isset($data['CType'])) {
+            $TSconfig = BackendUtility::getPagesTSconfig($this->tableAccessService->resolveTSconfigPid($effectivePid));
+            $disableCTypes = $TSconfig['TCEMAIN.']['table.']['tt_content.']['disableCTypes'] ?? '';
+            if (!empty($disableCTypes)) {
+                $disabled = GeneralUtility::trimExplode(',', $disableCTypes, true);
+                if (in_array((string)$data['CType'], $disabled, true)) {
+                    return "Field 'CType' value '{$data['CType']}' is disabled by TCEMAIN.table.tt_content.disableCTypes for this page";
+                }
+            }
+        }
+
         // Validate and convert field values
         foreach ($data as $fieldName => $value) {
             $fieldConfig = $this->tableAccessService->getFieldConfig($table, $fieldName);
@@ -957,7 +981,7 @@ class WriteTableTool extends AbstractRecordTool
             }
 
             // Check if field is accessible (filters out inaccessible inline relations)
-            if (!$this->tableAccessService->canAccessField($table, $fieldName)) {
+            if (!$this->tableAccessService->canAccessField($table, $fieldName, '', $effectivePid)) {
                 return "Field '{$fieldName}' is not accessible";
             }
 
@@ -1024,7 +1048,7 @@ class WriteTableTool extends AbstractRecordTool
         }
         
         // Get available fields for this record type
-        $availableFields = $this->tableAccessService->getAvailableFields($table, $recordType);
+        $availableFields = $this->tableAccessService->getAvailableFields($table, $recordType, $effectivePid);
         
         // The type field itself should always be available if it exists
         if ($typeField) {

--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -12,6 +12,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Schema\Capability\TcaSchemaCapability;
 use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
+use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -27,6 +28,7 @@ class TableAccessService implements SingletonInterface
     protected TcaSchemaFactory $tcaSchemaFactory;
     protected ?array $additionalReadOnlyTables = null;
     protected ?array $additionalStandaloneTables = null;
+    protected ?int $cachedDefaultTSconfigPid = null;
 
     public function __construct()
     {
@@ -268,12 +270,13 @@ class TableAccessService implements SingletonInterface
     
     /**
      * Get available fields for a table and type
-     * 
+     *
      * @param string $table Table name
      * @param string $type Record type (optional)
+     * @param int|null $pid Page id for TSconfig-based field visibility (null → first site root)
      * @return array Field configuration
      */
-    public function getAvailableFields(string $table, string $type = ''): array
+    public function getAvailableFields(string $table, string $type = '', ?int $pid = null): array
     {
         $this->validateTableAccess($table);
 
@@ -352,7 +355,7 @@ class TableAccessService implements SingletonInterface
 
         // Apply field-level access restrictions
         foreach ($fields as $fieldName => $fieldConfig) {
-            if (!$this->canAccessField($table, $fieldName, $type)) {
+            if (!$this->canAccessField($table, $fieldName, $type, $pid)) {
                 unset($fields[$fieldName]);
             }
         }
@@ -661,14 +664,51 @@ class TableAccessService implements SingletonInterface
     }
     
     /**
+     * Resolve a representative page id for TSconfig lookups.
+     *
+     * TYPO3 page TSconfig is merged along the rootline. Calling
+     * BackendUtility::getPagesTSconfig(0) yields an empty rootline and silently
+     * skips TSconfig defined on actual pages (sys_template, page properties,
+     * site config). When callers don't know which page they're operating on,
+     * fall back to the first configured site's root page so project-wide
+     * TSconfig is still applied. Caches the resolved id on the instance to
+     * avoid repeated SiteFinder lookups within a request.
+     */
+    public function resolveTSconfigPid(?int $pid = null): int
+    {
+        if ($pid !== null && $pid > 0) {
+            return $pid;
+        }
+        if ($this->cachedDefaultTSconfigPid !== null) {
+            return $this->cachedDefaultTSconfigPid;
+        }
+        $resolved = 0;
+        try {
+            $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+            foreach ($siteFinder->getAllSites() as $site) {
+                $rootPageId = $site->getRootPageId();
+                if ($rootPageId > 0) {
+                    $resolved = $rootPageId;
+                    break;
+                }
+            }
+        } catch (\Throwable) {
+            // No sites configured — fall back to 0.
+        }
+        $this->cachedDefaultTSconfigPid = $resolved;
+        return $resolved;
+    }
+
+    /**
      * Check if a specific field can be accessed
      *
      * @param string $table Table name
      * @param string $fieldName Field name
      * @param string $type Record type (optional, for type-specific TSconfig)
+     * @param int|null $pid Page id for TSconfig context (null → first site root)
      * @return bool
      */
-    public function canAccessField(string $table, string $fieldName, string $type = ''): bool
+    public function canAccessField(string $table, string $fieldName, string $type = '', ?int $pid = null): bool
     {
         $fieldConfig = $GLOBALS['TCA'][$table]['columns'][$fieldName] ?? [];
 
@@ -691,8 +731,10 @@ class TableAccessService implements SingletonInterface
             }
         }
 
-        // Check TSconfig field visibility (applies to all users including admins)
-        $TSconfig = BackendUtility::getPagesTSconfig(0);
+        // Check TSconfig field visibility (applies to all users including admins).
+        // Resolve TSconfig at a real page id — page 0 has no rootline so it
+        // misses TSconfig defined on sys_template / page records / site config.
+        $TSconfig = BackendUtility::getPagesTSconfig($this->resolveTSconfigPid($pid));
 
         // Check if field is globally disabled via TCEFORM.[table].[field].disabled
         $fieldDisabled = $TSconfig['TCEFORM.'][$table . '.'][$fieldName . '.']['disabled'] ?? '';
@@ -1003,8 +1045,11 @@ class TableAccessService implements SingletonInterface
     
     /**
      * Get available types for a table
+     *
+     * @param string $table Table name
+     * @param int|null $pid Page id for TSconfig context (null → first site root)
      */
-    public function getAvailableTypes(string $table): array
+    public function getAvailableTypes(string $table, ?int $pid = null): array
     {
         $typeField = $this->getTypeFieldName($table);
         if (!$typeField) {
@@ -1018,17 +1063,45 @@ class TableAccessService implements SingletonInterface
         }
 
         $typeConfig = $GLOBALS['TCA'][$table]['columns'][$typeField]['config'] ?? [];
-        $items = $typeConfig['items'] ?? [];
-        
-        // Use the shared parseSelectItems method
-        $parsed = $this->parseSelectItems($items);
-        
-        // Convert to the expected format (value => label)
-        $types = [];
-        foreach ($parsed['values'] as $value) {
-            $types[$value] = $parsed['labels'][$value] ?? $value;
+
+        // Prefer TYPO3's full FormDataCompiler pipeline so TSconfig
+        // addItems / removeItems / keepItems and itemsProcFunc all run. This
+        // requires a real pid to build a rootline from — fall back to the
+        // first site's root page when no context was supplied.
+        $resolverPid = $this->resolveTSconfigPid($pid);
+        $resolver = GeneralUtility::makeInstance(SelectItemResolver::class);
+        $resolved = $resolver->resolveSelectItems($table, $typeField, ['pid' => $resolverPid]);
+
+        if ($resolved !== null && !empty($resolved['values'])) {
+            $types = [];
+            foreach ($resolved['values'] as $value) {
+                $types[$value] = $resolved['labels'][$value] ?? $value;
+            }
+        } else {
+            // Fallback: static TCA items only (used when FormDataCompiler fails,
+            // e.g. tables not registered with the Form Engine).
+            $items = $typeConfig['items'] ?? [];
+            $parsed = $this->parseSelectItems($items);
+            $types = [];
+            foreach ($parsed['values'] as $value) {
+                $types[$value] = $parsed['labels'][$value] ?? $value;
+            }
         }
-        
+
+        // tt_content also honours TCEMAIN.table.tt_content.disableCTypes,
+        // which the New Content Element Wizard reads but FormDataCompiler
+        // does not apply. Filter it here so the schema matches what the
+        // wizard would show.
+        if ($table === 'tt_content' && $typeField === 'CType') {
+            $TSconfig = BackendUtility::getPagesTSconfig($resolverPid);
+            $disableCTypes = $TSconfig['TCEMAIN.']['table.']['tt_content.']['disableCTypes'] ?? '';
+            if (!empty($disableCTypes)) {
+                foreach (GeneralUtility::trimExplode(',', $disableCTypes, true) as $disabled) {
+                    unset($types[$disabled]);
+                }
+            }
+        }
+
         return $types;
     }
     

--- a/Classes/Utility/TcaFormattingUtility.php
+++ b/Classes/Utility/TcaFormattingUtility.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hn\McpServer\Utility;
 
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
@@ -24,8 +25,9 @@ class TcaFormattingUtility
      * @param array $config The field configuration
      * @param string $fieldName Optional field name for special handling
      * @param string $table Optional table name for authMode filtering
+     * @param int|null $pid Optional page id for TSconfig context (filters select items via FormDataCompiler)
      */
-    public static function addFieldDetailsInline(string &$result, $config, string $fieldName = '', string $table = ''): void
+    public static function addFieldDetailsInline(string &$result, $config, string $fieldName = '', string $table = '', ?int $pid = null): void
     {
         // Get the field type
         $type = $config['type'] ?? '';
@@ -85,11 +87,13 @@ class TcaFormattingUtility
                     $result .= " [MM table: " . $config['MM'] . "]";
                 }
 
-                // Resolve select options using FormDataCompiler (handles static items, foreign_table, itemsProcFunc, TSconfig)
+                // Resolve select options using FormDataCompiler (handles static items, foreign_table, itemsProcFunc, TSconfig).
+                // Pass the pid context so TSconfig defined on real pages (rootline) is applied — vanillaUid=0 misses it.
                 $resolved = null;
                 if (!empty($table) && !empty($fieldName)) {
                     $resolver = GeneralUtility::makeInstance(SelectItemResolver::class);
-                    $resolved = $resolver->resolveSelectItems($table, $fieldName);
+                    $resolverPid = GeneralUtility::makeInstance(TableAccessService::class)->resolveTSconfigPid($pid);
+                    $resolved = $resolver->resolveSelectItems($table, $fieldName, ['pid' => $resolverPid]);
                 }
 
                 if ($resolved !== null && !empty($resolved['values'])) {
@@ -98,6 +102,10 @@ class TcaFormattingUtility
                     $beUser = $GLOBALS['BE_USER'] ?? null;
                     $isAdmin = $beUser && $beUser->isAdmin();
 
+                    // tt_content.CType also honours TCEMAIN.disableCTypes, which
+                    // FormDataCompiler doesn't apply.
+                    $disabledCTypes = self::getDisabledCTypes($table, $fieldName, $resolverPid ?? 0);
+
                     $options = [];
                     foreach ($resolved['values'] as $value) {
                         // Filter by authMode for non-admin users
@@ -105,6 +113,10 @@ class TcaFormattingUtility
                             if (!$beUser->checkAuthMode($table, $fieldName, $value)) {
                                 continue;
                             }
+                        }
+
+                        if (in_array((string)$value, $disabledCTypes, true)) {
+                            continue;
                         }
 
                         $label = $resolved['labels'][$value] ?? '';
@@ -125,6 +137,7 @@ class TcaFormattingUtility
                     $hasAuthMode = !empty($config['authMode']);
                     $beUser = $GLOBALS['BE_USER'] ?? null;
                     $isAdmin = $beUser && $beUser->isAdmin();
+                    $disabledCTypes = self::getDisabledCTypes($table, $fieldName, $tableAccessService->resolveTSconfigPid($pid));
 
                     $options = [];
                     foreach ($parsed['values'] as $value) {
@@ -135,6 +148,9 @@ class TcaFormattingUtility
                             if (!$beUser->checkAuthMode($table, $fieldName, $value)) {
                                 continue;
                             }
+                        }
+                        if (in_array((string)$value, $disabledCTypes, true)) {
+                            continue;
                         }
                         $label = $parsed['labels'][$value] ?? '';
                         if ($label) {
@@ -220,6 +236,24 @@ class TcaFormattingUtility
         if (isset($config['default']) && $type !== 'check') {
             $result .= " [Default: " . $config['default'] . "]";
         }
+    }
+
+    /**
+     * Resolve TCEMAIN.table.tt_content.disableCTypes for tt_content.CType.
+     * FormDataCompiler doesn't apply this — it's read by the New Content Element
+     * Wizard — so callers must filter manually to match what TYPO3 would show.
+     */
+    protected static function getDisabledCTypes(string $table, string $fieldName, int $pid): array
+    {
+        if ($table !== 'tt_content' || $fieldName !== 'CType') {
+            return [];
+        }
+        $TSconfig = BackendUtility::getPagesTSconfig($pid);
+        $disableCTypes = $TSconfig['TCEMAIN.']['table.']['tt_content.']['disableCTypes'] ?? '';
+        if (empty($disableCTypes)) {
+            return [];
+        }
+        return GeneralUtility::trimExplode(',', $disableCTypes, true);
     }
 
     /**

--- a/Tests/Functional/MCP/Tool/CTypeTSconfigTest.php
+++ b/Tests/Functional/MCP/Tool/CTypeTSconfigTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use Hn\McpServer\MCP\Tool\Record\GetTableSchemaTool;
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use Hn\McpServer\Service\TableAccessService;
+use Mcp\Types\TextContent;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Tests that page-level TSconfig (TCEFORM.tt_content.CType.removeItems and
+ * TCEMAIN.table.tt_content.disableCTypes) actually filters CType options for
+ * both schema display and write validation.
+ *
+ * Regression test: previously TSconfig was resolved at pid=0, which has no
+ * rootline, so any TSconfig defined on a page record was silently ignored.
+ */
+class CTypeTSconfigTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/mcp_server',
+    ];
+
+    protected GetTableSchemaTool $schemaTool;
+    protected WriteTableTool $writeTool;
+    protected TableAccessService $tableAccessService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/pages.csv');
+
+        // Set page TSconfig on the root page so descendants inherit it.
+        // This is the same mechanism real projects use; defaultPageTSconfig
+        // (the GLOBALS-based v13 mechanism) was removed in TYPO3 14.
+        GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('pages')
+            ->update('pages', [
+                'TSconfig' => "TCEFORM.tt_content.CType.removeItems = text, header\n"
+                    . "TCEMAIN.table.tt_content.disableCTypes = bullets",
+            ], ['uid' => 1]);
+
+        $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('en');
+
+        $this->schemaTool = GeneralUtility::makeInstance(GetTableSchemaTool::class);
+        $this->writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+        $this->tableAccessService = GeneralUtility::makeInstance(TableAccessService::class);
+    }
+
+    public function testGetAvailableTypesAppliesRemoveItemsAtPid(): void
+    {
+        $types = $this->tableAccessService->getAvailableTypes('tt_content', 1);
+
+        $this->assertArrayNotHasKey('text', $types, 'CType "text" should be removed by TSconfig');
+        $this->assertArrayNotHasKey('header', $types, 'CType "header" should be removed by TSconfig');
+        $this->assertArrayHasKey('textmedia', $types, 'CType "textmedia" should still be available');
+    }
+
+    public function testGetAvailableTypesAppliesDisableCTypesAtPid(): void
+    {
+        $types = $this->tableAccessService->getAvailableTypes('tt_content', 1);
+
+        $this->assertArrayNotHasKey(
+            'bullets',
+            $types,
+            'CType "bullets" should be filtered by TCEMAIN.disableCTypes'
+        );
+    }
+
+    public function testSchemaToolHidesRemovedCTypesInOptionsWhenPidProvided(): void
+    {
+        $result = $this->schemaTool->execute([
+            'table' => 'tt_content',
+            'type' => 'textmedia',
+            'pid' => 2,
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $this->assertInstanceOf(TextContent::class, $result->content[0]);
+        $content = $result->content[0]->text;
+
+        // Find the line that introduces the CType field — it carries the
+        // [Options: ...] block listing allowed values. Removed CTypes must not appear.
+        $ctypeLine = null;
+        foreach (preg_split('/\r?\n/', $content) as $line) {
+            if (preg_match('/(^|\W)CType\b/', $line) && str_contains($line, '[Options:')) {
+                $ctypeLine = $line;
+                break;
+            }
+        }
+        $this->assertNotNull($ctypeLine, 'Could not locate CType field line in schema output: ' . $content);
+
+        // Each option is rendered as "<value> (<label>)" — match value boundaries
+        // to avoid false positives like "textmedia" matching "text".
+        $this->assertDoesNotMatchRegularExpression('/\btext\s*\(/', $ctypeLine, 'Removed CType "text" leaked into Options list: ' . $ctypeLine);
+        $this->assertDoesNotMatchRegularExpression('/\bheader\s*\(/', $ctypeLine, 'Removed CType "header" leaked into Options list: ' . $ctypeLine);
+        $this->assertDoesNotMatchRegularExpression('/\bbullets\s*\(/', $ctypeLine, 'disableCTypes value "bullets" leaked into Options list: ' . $ctypeLine);
+        $this->assertStringContainsString('textmedia', $ctypeLine, 'Allowed CType "textmedia" missing from Options: ' . $ctypeLine);
+    }
+
+    public function testSchemaToolReturnsErrorWhenRequestingRemovedType(): void
+    {
+        $result = $this->schemaTool->execute([
+            'table' => 'tt_content',
+            'type' => 'text',
+            'pid' => 2,
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $content = $result->content[0]->text;
+
+        // When the requested type is filtered out, the tool emits an ERROR text
+        // listing the still-available types.
+        $this->assertStringContainsString('ERROR', $content);
+        $this->assertStringContainsString("'text'", $content);
+    }
+
+    public function testWriteRejectsRemovedCType(): void
+    {
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Should be rejected',
+                'bodytext' => 'because text is removed by TSconfig',
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'Creating a tt_content with a removed CType must fail');
+        $content = $result->content[0]->text;
+        $this->assertStringContainsString('CType', $content);
+    }
+
+    public function testWriteRejectsDisabledCType(): void
+    {
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'bullets',
+                'header' => 'Should be rejected',
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'Creating a tt_content with a disabled CType must fail');
+        $content = $result->content[0]->text;
+        $this->assertStringContainsString('disableCTypes', $content);
+    }
+
+    public function testWriteAcceptsAllowedCType(): void
+    {
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'textmedia',
+                'header' => 'Allowed',
+            ],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where TSconfig-based field and type filtering was being resolved at pid=0, which has no rootline and therefore silently ignored any TSconfig defined on actual page records, sys_template, or site configuration. The fix ensures TSconfig is resolved at the appropriate page context throughout the codebase.

## Key Changes

- **TableAccessService**: 
  - Added `resolveTSconfigPid()` method to determine the appropriate page ID for TSconfig lookups, falling back to the first configured site's root page when no explicit context is provided
  - Updated `getAvailableFields()`, `canAccessField()`, and `getAvailableTypes()` to accept an optional `$pid` parameter for TSconfig context
  - Modified `getAvailableTypes()` to use `SelectItemResolver` with proper pid context so TCEFORM removeItems/addItems are applied
  - Added explicit filtering of `TCEMAIN.table.tt_content.disableCTypes` in `getAvailableTypes()` since FormDataCompiler doesn't apply this setting

- **GetTableSchemaTool**:
  - Added `pid` parameter to the tool schema to allow callers to specify the page context
  - Updated `generateTableSchema()` to accept and pass through the pid parameter
  - Removed the now-redundant `getRemovedTypesByTSconfig()` method since filtering is now handled by `TableAccessService.getAvailableTypes()`
  - Updated all field detail generation calls to pass the pid context

- **TcaFormattingUtility**:
  - Updated `addFieldDetailsInline()` to accept optional `$pid` parameter
  - Modified select item resolution to use proper TSconfig context via `resolveTSconfigPid()`
  - Added `getDisabledCTypes()` helper method to filter out disabled CTypes in both FormDataCompiler and static item paths

- **WriteTableTool**:
  - Added explicit validation of `TCEMAIN.table.tt_content.disableCTypes` before allowing record creation
  - Updated field access checks to use the effective page ID where the record will be created
  - Properly resolves negative pids (insert-after references) to their actual page context

- **Tests**:
  - Added comprehensive functional test `CTypeTSconfigTest` covering:
    - TCEFORM.tt_content.CType.removeItems filtering
    - TCEMAIN.table.tt_content.disableCTypes filtering
    - Schema generation respects TSconfig at the specified page
    - Write operations reject disabled/removed types with appropriate error messages
    - Allowed types are still accepted

## Implementation Details

The fix uses TYPO3's `SiteFinder` to locate the first configured site's root page as a fallback when no explicit page context is provided. This ensures project-wide TSconfig (defined on root page records or site configuration) is still applied even when callers don't know which specific page they're operating on. The resolved pid is cached on the service instance to avoid repeated lookups within a single request.

For `tt_content.CType` specifically, the code now explicitly applies `TCEMAIN.table.tt_content.disableCTypes` filtering since TYPO3's FormDataCompiler doesn't handle this setting (it's only used by the New Content Element Wizard).

https://claude.ai/code/session_01DaVxL4KLe4hN7eUCdRKAon