### PR TITLE
Add LLM benchmark tracking with Google Sheets integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,3 +132,12 @@ jobs:
 
       - name: Check majority pass rule
         run: php Build/check-llm-results.php --min-pass=3
+
+      - name: Publish LLM stats to Google Sheet
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        env:
+          LLM_STATS_SHEET_URL: ${{ secrets.LLM_STATS_SHEET_URL }}
+          LLM_STATS_SHEET_TOKEN: ${{ secrets.LLM_STATS_SHEET_TOKEN }}
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: php Build/post-llm-stats.php

--- a/Build/llm-stats-apps-script.gs
+++ b/Build/llm-stats-apps-script.gs
@@ -1,0 +1,243 @@
+/**
+ * Google Apps Script — LLM stats ingest + shields.io endpoint.
+ *
+ * This file is the source of truth, committed for transparency.
+ * To deploy:
+ *
+ *   1. Create a Google Sheet titled "TYPO3 MCP Server — LLM Stats".
+ *      Add tabs named "Runs" and "Summary".
+ *   2. Extensions → Apps Script → paste the contents of this file.
+ *   3. Project Settings → Script Properties → add INGEST_TOKEN with a
+ *      random secret (e.g. `openssl rand -hex 24`).
+ *   4. Deploy → New deployment → Web app:
+ *        - Execute as: Me
+ *        - Who has access: Anyone
+ *      Copy the deployment URL ending in /exec.
+ *   5. Sheet → Share → "Anyone with the link: Viewer" so README links work.
+ *   6. Add GitHub Actions secrets:
+ *        - LLM_STATS_SHEET_URL   = the /exec URL
+ *        - LLM_STATS_SHEET_TOKEN = the same token as INGEST_TOKEN
+ *
+ * Endpoints exposed by doGet:
+ *   ?model=<key>          → shields.io endpoint JSON (latest pass-rate)
+ *   ?format=table         → markdown table of all model summaries
+ *   (no params)           → JSON map of model → { passed, total, percent }
+ */
+
+const RUNS_SHEET_NAME = 'Runs';
+const SUMMARY_SHEET_NAME = 'Summary';
+
+const RUNS_HEADERS = [
+  'timestamp', 'commit', 'branch', 'run_url',
+  'class', 'test', 'model', 'status',
+  'duration', 'llm_calls', 'tool_calls', 'tool_errors',
+];
+
+const SUMMARY_HEADERS = ['model', 'passed', 'total', 'percent', 'last_run', 'last_commit'];
+
+/* ------------------------------------------------------------------ Ingest */
+
+function doPost(e) {
+  const expected = PropertiesService.getScriptProperties().getProperty('INGEST_TOKEN');
+  const auth = (e.parameter && e.parameter.token)
+    || (e.postData && e.postData.contents && extractBearer_(e));
+  if (!expected || auth !== expected) {
+    return jsonResponse_({ error: 'unauthorized' }, 401);
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(e.postData.contents);
+  } catch (err) {
+    return jsonResponse_({ error: 'invalid json' }, 400);
+  }
+
+  const records = Array.isArray(payload.records) ? payload.records : [];
+  if (records.length === 0) {
+    return jsonResponse_({ inserted: 0 });
+  }
+
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const runs = ensureSheet_(ss, RUNS_SHEET_NAME, RUNS_HEADERS);
+
+  const rows = records.map(r => [
+    payload.timestamp || new Date().toISOString(),
+    payload.commit || '',
+    payload.branch || '',
+    payload.run_url || '',
+    r.class || '',
+    r.test || '',
+    r.model || '',
+    r.status || '',
+    r.duration ?? '',
+    r.llm_calls ?? '',
+    r.tool_calls ?? '',
+    r.tool_errors ?? '',
+  ]);
+  runs.getRange(runs.getLastRow() + 1, 1, rows.length, RUNS_HEADERS.length).setValues(rows);
+
+  recomputeSummary_(ss);
+
+  return jsonResponse_({ inserted: rows.length });
+}
+
+function extractBearer_(e) {
+  // Apps Script doesn't expose request headers directly; we accept the token
+  // either via `?token=` or via a JSON body field `_token` as fallbacks.
+  try {
+    const body = JSON.parse(e.postData.contents);
+    return body._token || null;
+  } catch (err) {
+    return null;
+  }
+}
+
+/* ------------------------------------------------------------------ Read */
+
+function doGet(e) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const summary = readSummary_(ss);
+
+  if (e.parameter && e.parameter.model) {
+    const row = summary[e.parameter.model];
+    if (!row) {
+      return jsonResponse_({
+        schemaVersion: 1,
+        label: e.parameter.model,
+        message: 'no data',
+        color: 'lightgrey',
+      });
+    }
+    return jsonResponse_({
+      schemaVersion: 1,
+      label: e.parameter.model,
+      message: row.percent + '%',
+      color: badgeColor_(row.percent),
+    });
+  }
+
+  if (e.parameter && e.parameter.format === 'table') {
+    const lines = ['| Model | Passed | Total | % |', '|---|---|---|---|'];
+    Object.keys(summary).sort().forEach(model => {
+      const r = summary[model];
+      lines.push(`| ${model} | ${r.passed} | ${r.total} | ${r.percent}% |`);
+    });
+    return ContentService.createTextOutput(lines.join('\n'))
+      .setMimeType(ContentService.MimeType.TEXT);
+  }
+
+  return jsonResponse_(summary);
+}
+
+function badgeColor_(percent) {
+  if (percent >= 90) return 'brightgreen';
+  if (percent >= 75) return 'green';
+  if (percent >= 60) return 'yellow';
+  if (percent >= 40) return 'orange';
+  return 'red';
+}
+
+/* ------------------------------------------------------------------ Summary */
+
+function recomputeSummary_(ss) {
+  const runs = ss.getSheetByName(RUNS_SHEET_NAME);
+  if (!runs || runs.getLastRow() < 2) return;
+
+  const data = runs.getRange(2, 1, runs.getLastRow() - 1, RUNS_HEADERS.length).getValues();
+
+  // Find the most recent timestamp; the "current" pass-rate uses only the
+  // latest run (so a flaky historical model doesn't poison the badge).
+  let latestRun = '';
+  for (const row of data) {
+    const ts = String(row[0]);
+    if (ts > latestRun) latestRun = ts;
+  }
+
+  const perModel = {}; // model => { passed, total, last_commit }
+  for (const row of data) {
+    if (String(row[0]) !== latestRun) continue;
+    const model = String(row[6]);
+    const status = String(row[7]);
+    if (status === 'SKIP') continue;
+    if (!perModel[model]) {
+      perModel[model] = { passed: 0, total: 0, last_commit: String(row[1]) };
+    }
+    perModel[model].total += 1;
+    if (status === 'PASS') perModel[model].passed += 1;
+  }
+
+  const summary = ensureSheet_(ss, SUMMARY_SHEET_NAME, SUMMARY_HEADERS);
+  if (summary.getLastRow() > 1) {
+    summary.getRange(2, 1, summary.getLastRow() - 1, SUMMARY_HEADERS.length).clearContent();
+  }
+
+  const rows = Object.keys(perModel).sort().map(model => {
+    const r = perModel[model];
+    const percent = r.total === 0 ? 0 : Math.round((r.passed / r.total) * 100);
+    return [model, r.passed, r.total, percent, latestRun, r.last_commit];
+  });
+  if (rows.length > 0) {
+    summary.getRange(2, 1, rows.length, SUMMARY_HEADERS.length).setValues(rows);
+  }
+}
+
+function readSummary_(ss) {
+  const sheet = ss.getSheetByName(SUMMARY_SHEET_NAME);
+  if (!sheet || sheet.getLastRow() < 2) return {};
+  const data = sheet.getRange(2, 1, sheet.getLastRow() - 1, SUMMARY_HEADERS.length).getValues();
+  const out = {};
+  for (const row of data) {
+    out[String(row[0])] = {
+      passed: Number(row[1]),
+      total: Number(row[2]),
+      percent: Number(row[3]),
+      last_run: String(row[4]),
+      last_commit: String(row[5]),
+    };
+  }
+  return out;
+}
+
+/* ------------------------------------------------------------------ Helpers */
+
+function ensureSheet_(ss, name, headers) {
+  let sheet = ss.getSheetByName(name);
+  if (!sheet) {
+    sheet = ss.insertSheet(name);
+    sheet.getRange(1, 1, 1, headers.length).setValues([headers]).setFontWeight('bold');
+    sheet.setFrozenRows(1);
+  } else if (sheet.getLastRow() === 0) {
+    sheet.getRange(1, 1, 1, headers.length).setValues([headers]).setFontWeight('bold');
+    sheet.setFrozenRows(1);
+  }
+  return sheet;
+}
+
+function jsonResponse_(obj, _status) {
+  // Apps Script web apps can't set HTTP status, but shields.io and the
+  // ingester only care about the body. Errors are conveyed in `error`.
+  return ContentService.createTextOutput(JSON.stringify(obj))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+
+/* ------------------------------------------------------------------ Tests */
+
+function testIngest_() {
+  const sample = {
+    postData: {
+      contents: JSON.stringify({
+        _token: PropertiesService.getScriptProperties().getProperty('INGEST_TOKEN'),
+        timestamp: new Date().toISOString(),
+        commit: 'deadbeef',
+        branch: 'main',
+        run_url: 'https://example.invalid/run/1',
+        records: [
+          { class: 'X', test: 'testA', model: 'haiku-4.5', status: 'PASS', llm_calls: 3, tool_calls: 5, tool_errors: 0 },
+          { class: 'X', test: 'testA', model: 'gpt-5.4-mini', status: 'FAIL', llm_calls: 4, tool_calls: 6, tool_errors: 1 },
+        ],
+      }),
+    },
+    parameter: {},
+  };
+  Logger.log(doPost(sample).getContent());
+}

--- a/Build/llm-stats-apps-script.gs
+++ b/Build/llm-stats-apps-script.gs
@@ -72,7 +72,7 @@ function doGet(e) {
   const lastRow = sheet.getRange(sheet.getLastRow(), 1, 1, headers.length).getValues()[0];
   const total = Number(lastRow[headers.indexOf('total')] || 0);
 
-  if (e.parameter && e.parameter.model) {
+  if (e && e.parameter && e.parameter.model) {
     const model = e.parameter.model;
     const idx = headers.indexOf(model);
     if (idx === -1 || lastRow[idx] === '') {

--- a/Build/llm-stats-apps-script.gs
+++ b/Build/llm-stats-apps-script.gs
@@ -97,9 +97,13 @@ function doGet(e) {
     run_url: lastRow[3],
     total,
     models: {},
+    percentages: {},
   };
   for (let i = BASE_HEADERS.length; i < headers.length; i++) {
-    if (lastRow[i] !== '') out.models[headers[i]] = Number(lastRow[i]);
+    if (lastRow[i] === '') continue;
+    const passed = Number(lastRow[i]);
+    out.models[headers[i]] = passed;
+    out.percentages[headers[i]] = total === 0 ? 0 : Math.round((passed / total) * 100);
   }
   return jsonResponse_(out);
 }

--- a/Build/llm-stats-apps-script.gs
+++ b/Build/llm-stats-apps-script.gs
@@ -1,242 +1,149 @@
 /**
- * Google Apps Script — LLM stats ingest + shields.io endpoint.
+ * Google Apps Script — LLM benchmark ingest + shields.io endpoint.
  *
- * This file is the source of truth, committed for transparency.
- * To deploy:
+ * Schema: one row per CI run.
+ *   timestamp | branch | commit | run_url | total | <model_1> | <model_2> | ...
  *
- *   1. Create a Google Sheet titled "TYPO3 MCP Server — LLM Stats".
- *      Add tabs named "Runs" and "Summary".
- *   2. Extensions → Apps Script → paste the contents of this file.
- *   3. Project Settings → Script Properties → add INGEST_TOKEN with a
- *      random secret (e.g. `openssl rand -hex 24`).
- *   4. Deploy → New deployment → Web app:
- *        - Execute as: Me
- *        - Who has access: Anyone
- *      Copy the deployment URL ending in /exec.
- *   5. Sheet → Share → "Anyone with the link: Viewer" so README links work.
- *   6. Add GitHub Actions secrets:
- *        - LLM_STATS_SHEET_URL   = the /exec URL
- *        - LLM_STATS_SHEET_TOKEN = the same token as INGEST_TOKEN
+ * Model columns are added on demand: when a payload references a model
+ * not yet in the header row, a new column is appended. Each model column
+ * holds that model's PASS count for the run; `total` is the number of
+ * distinct test methods executed (skipped-by-all are excluded).
  *
- * Endpoints exposed by doGet:
- *   ?model=<key>          → shields.io endpoint JSON (latest pass-rate)
- *   ?format=table         → markdown table of all model summaries
- *   (no params)           → JSON map of model → { passed, total, percent }
+ * Deployment:
+ *   1. Create a Google Sheet titled "TYPO3 MCP Server — LLM Benchmark".
+ *   2. Extensions → Apps Script → paste this file.
+ *   3. Project Settings → Script Properties → INGEST_TOKEN = <random secret>.
+ *   4. Deploy → New deployment → Web app, "Execute as: Me",
+ *      "Who has access: Anyone". Copy the /exec URL.
+ *   5. Sheet → Share → "Anyone with the link: Viewer".
+ *   6. GitHub Actions secrets:
+ *        LLM_STATS_SHEET_URL   = the /exec URL
+ *        LLM_STATS_SHEET_TOKEN = INGEST_TOKEN value
  */
 
-const RUNS_SHEET_NAME = 'Runs';
-const SUMMARY_SHEET_NAME = 'Summary';
-
-const RUNS_HEADERS = [
-  'timestamp', 'commit', 'branch', 'run_url',
-  'class', 'test', 'model', 'status',
-  'duration', 'llm_calls', 'tool_calls', 'tool_errors',
-];
-
-const SUMMARY_HEADERS = ['model', 'passed', 'total', 'percent', 'last_run', 'last_commit'];
-
-/* ------------------------------------------------------------------ Ingest */
+const SHEET_NAME = 'Runs';
+const BASE_HEADERS = ['timestamp', 'branch', 'commit', 'run_url', 'total'];
 
 function doPost(e) {
   const expected = PropertiesService.getScriptProperties().getProperty('INGEST_TOKEN');
-  const auth = (e.parameter && e.parameter.token)
-    || (e.postData && e.postData.contents && extractBearer_(e));
-  if (!expected || auth !== expected) {
-    return jsonResponse_({ error: 'unauthorized' }, 401);
-  }
-
   let payload;
   try {
     payload = JSON.parse(e.postData.contents);
   } catch (err) {
-    return jsonResponse_({ error: 'invalid json' }, 400);
+    return jsonResponse_({ error: 'invalid json' });
+  }
+  if (!expected || payload._token !== expected) {
+    return jsonResponse_({ error: 'unauthorized' });
   }
 
-  const records = Array.isArray(payload.records) ? payload.records : [];
-  if (records.length === 0) {
-    return jsonResponse_({ inserted: 0 });
+  const sheet = ensureSheet_();
+  const headers = readHeaders_(sheet);
+
+  const models = payload.models || {};
+  for (const name of Object.keys(models)) {
+    if (headers.indexOf(name) === -1) {
+      sheet.getRange(1, headers.length + 1)
+        .setValue(name)
+        .setFontWeight('bold');
+      headers.push(name);
+    }
   }
 
-  const ss = SpreadsheetApp.getActiveSpreadsheet();
-  const runs = ensureSheet_(ss, RUNS_SHEET_NAME, RUNS_HEADERS);
+  const row = new Array(headers.length).fill('');
+  row[0] = payload.timestamp ? new Date(payload.timestamp) : new Date();
+  row[1] = payload.branch || '';
+  row[2] = payload.commit || '';
+  row[3] = payload.run_url || '';
+  row[4] = Number(payload.total || 0);
+  for (const [name, passed] of Object.entries(models)) {
+    row[headers.indexOf(name)] = Number(passed);
+  }
+  sheet.appendRow(row);
 
-  const rows = records.map(r => [
-    payload.timestamp || new Date().toISOString(),
-    payload.commit || '',
-    payload.branch || '',
-    payload.run_url || '',
-    r.class || '',
-    r.test || '',
-    r.model || '',
-    r.status || '',
-    r.duration ?? '',
-    r.llm_calls ?? '',
-    r.tool_calls ?? '',
-    r.tool_errors ?? '',
-  ]);
-  runs.getRange(runs.getLastRow() + 1, 1, rows.length, RUNS_HEADERS.length).setValues(rows);
-
-  recomputeSummary_(ss);
-
-  return jsonResponse_({ inserted: rows.length });
+  return jsonResponse_({ ok: true, row: sheet.getLastRow() });
 }
-
-function extractBearer_(e) {
-  // Apps Script doesn't expose request headers directly; we accept the token
-  // either via `?token=` or via a JSON body field `_token` as fallbacks.
-  try {
-    const body = JSON.parse(e.postData.contents);
-    return body._token || null;
-  } catch (err) {
-    return null;
-  }
-}
-
-/* ------------------------------------------------------------------ Read */
 
 function doGet(e) {
-  const ss = SpreadsheetApp.getActiveSpreadsheet();
-  const summary = readSummary_(ss);
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(SHEET_NAME);
+  if (!sheet || sheet.getLastRow() < 2) {
+    return jsonResponse_({ error: 'no data' });
+  }
+  const headers = readHeaders_(sheet);
+  const lastRow = sheet.getRange(sheet.getLastRow(), 1, 1, headers.length).getValues()[0];
+  const total = Number(lastRow[headers.indexOf('total')] || 0);
 
   if (e.parameter && e.parameter.model) {
-    const row = summary[e.parameter.model];
-    if (!row) {
+    const model = e.parameter.model;
+    const idx = headers.indexOf(model);
+    if (idx === -1 || lastRow[idx] === '') {
       return jsonResponse_({
-        schemaVersion: 1,
-        label: e.parameter.model,
-        message: 'no data',
-        color: 'lightgrey',
+        schemaVersion: 1, label: model, message: 'no data', color: 'lightgrey',
       });
     }
+    const passed = Number(lastRow[idx]);
+    const percent = total === 0 ? 0 : Math.round((passed / total) * 100);
     return jsonResponse_({
       schemaVersion: 1,
-      label: e.parameter.model,
-      message: row.percent + '%',
-      color: badgeColor_(row.percent),
+      label: model,
+      message: `${passed}/${total}`,
+      color: badgeColor_(percent),
     });
   }
 
-  if (e.parameter && e.parameter.format === 'table') {
-    const lines = ['| Model | Passed | Total | % |', '|---|---|---|---|'];
-    Object.keys(summary).sort().forEach(model => {
-      const r = summary[model];
-      lines.push(`| ${model} | ${r.passed} | ${r.total} | ${r.percent}% |`);
-    });
-    return ContentService.createTextOutput(lines.join('\n'))
-      .setMimeType(ContentService.MimeType.TEXT);
+  const out = {
+    timestamp: lastRow[0],
+    branch: lastRow[1],
+    commit: lastRow[2],
+    run_url: lastRow[3],
+    total,
+    models: {},
+  };
+  for (let i = BASE_HEADERS.length; i < headers.length; i++) {
+    if (lastRow[i] !== '') out.models[headers[i]] = Number(lastRow[i]);
   }
-
-  return jsonResponse_(summary);
+  return jsonResponse_(out);
 }
 
-function badgeColor_(percent) {
-  if (percent >= 90) return 'brightgreen';
-  if (percent >= 75) return 'green';
-  if (percent >= 60) return 'yellow';
-  if (percent >= 40) return 'orange';
-  return 'red';
-}
-
-/* ------------------------------------------------------------------ Summary */
-
-function recomputeSummary_(ss) {
-  const runs = ss.getSheetByName(RUNS_SHEET_NAME);
-  if (!runs || runs.getLastRow() < 2) return;
-
-  const data = runs.getRange(2, 1, runs.getLastRow() - 1, RUNS_HEADERS.length).getValues();
-
-  // Find the most recent timestamp; the "current" pass-rate uses only the
-  // latest run (so a flaky historical model doesn't poison the badge).
-  let latestRun = '';
-  for (const row of data) {
-    const ts = String(row[0]);
-    if (ts > latestRun) latestRun = ts;
-  }
-
-  const perModel = {}; // model => { passed, total, last_commit }
-  for (const row of data) {
-    if (String(row[0]) !== latestRun) continue;
-    const model = String(row[6]);
-    const status = String(row[7]);
-    if (status === 'SKIP') continue;
-    if (!perModel[model]) {
-      perModel[model] = { passed: 0, total: 0, last_commit: String(row[1]) };
-    }
-    perModel[model].total += 1;
-    if (status === 'PASS') perModel[model].passed += 1;
-  }
-
-  const summary = ensureSheet_(ss, SUMMARY_SHEET_NAME, SUMMARY_HEADERS);
-  if (summary.getLastRow() > 1) {
-    summary.getRange(2, 1, summary.getLastRow() - 1, SUMMARY_HEADERS.length).clearContent();
-  }
-
-  const rows = Object.keys(perModel).sort().map(model => {
-    const r = perModel[model];
-    const percent = r.total === 0 ? 0 : Math.round((r.passed / r.total) * 100);
-    return [model, r.passed, r.total, percent, latestRun, r.last_commit];
-  });
-  if (rows.length > 0) {
-    summary.getRange(2, 1, rows.length, SUMMARY_HEADERS.length).setValues(rows);
-  }
-}
-
-function readSummary_(ss) {
-  const sheet = ss.getSheetByName(SUMMARY_SHEET_NAME);
-  if (!sheet || sheet.getLastRow() < 2) return {};
-  const data = sheet.getRange(2, 1, sheet.getLastRow() - 1, SUMMARY_HEADERS.length).getValues();
-  const out = {};
-  for (const row of data) {
-    out[String(row[0])] = {
-      passed: Number(row[1]),
-      total: Number(row[2]),
-      percent: Number(row[3]),
-      last_run: String(row[4]),
-      last_commit: String(row[5]),
-    };
-  }
-  return out;
-}
-
-/* ------------------------------------------------------------------ Helpers */
-
-function ensureSheet_(ss, name, headers) {
-  let sheet = ss.getSheetByName(name);
-  if (!sheet) {
-    sheet = ss.insertSheet(name);
-    sheet.getRange(1, 1, 1, headers.length).setValues([headers]).setFontWeight('bold');
-    sheet.setFrozenRows(1);
-  } else if (sheet.getLastRow() === 0) {
-    sheet.getRange(1, 1, 1, headers.length).setValues([headers]).setFontWeight('bold');
+function ensureSheet_() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName(SHEET_NAME);
+  if (!sheet) sheet = ss.insertSheet(SHEET_NAME);
+  if (sheet.getLastRow() === 0) {
+    sheet.getRange(1, 1, 1, BASE_HEADERS.length)
+      .setValues([BASE_HEADERS])
+      .setFontWeight('bold');
     sheet.setFrozenRows(1);
   }
   return sheet;
 }
 
-function jsonResponse_(obj, _status) {
-  // Apps Script web apps can't set HTTP status, but shields.io and the
-  // ingester only care about the body. Errors are conveyed in `error`.
-  return ContentService.createTextOutput(JSON.stringify(obj))
+function readHeaders_(sheet) {
+  return sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0].map(String);
+}
+
+function badgeColor_(p) {
+  if (p >= 90) return 'brightgreen';
+  if (p >= 75) return 'green';
+  if (p >= 60) return 'yellow';
+  if (p >= 40) return 'orange';
+  return 'red';
+}
+
+function jsonResponse_(obj) {
+  return ContentService
+    .createTextOutput(JSON.stringify(obj))
     .setMimeType(ContentService.MimeType.JSON);
 }
 
-/* ------------------------------------------------------------------ Tests */
-
 function testIngest_() {
   const sample = {
-    postData: {
-      contents: JSON.stringify({
-        _token: PropertiesService.getScriptProperties().getProperty('INGEST_TOKEN'),
-        timestamp: new Date().toISOString(),
-        commit: 'deadbeef',
-        branch: 'main',
-        run_url: 'https://example.invalid/run/1',
-        records: [
-          { class: 'X', test: 'testA', model: 'haiku-4.5', status: 'PASS', llm_calls: 3, tool_calls: 5, tool_errors: 0 },
-          { class: 'X', test: 'testA', model: 'gpt-5.4-mini', status: 'FAIL', llm_calls: 4, tool_calls: 6, tool_errors: 1 },
-        ],
-      }),
-    },
+    postData: { contents: JSON.stringify({
+      _token: PropertiesService.getScriptProperties().getProperty('INGEST_TOKEN'),
+      timestamp: new Date().toISOString(),
+      branch: 'main', commit: 'deadbeef', run_url: 'https://example.invalid/run/1',
+      total: 20,
+      models: { 'haiku-4.5': 18, 'gpt-5.4-mini': 14 },
+    })},
     parameter: {},
   };
   Logger.log(doPost(sample).getContent());

--- a/Build/post-llm-stats.php
+++ b/Build/post-llm-stats.php
@@ -1,0 +1,164 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Post LLM test results to a Google Sheet via an Apps Script web app.
+ *
+ * Reads .Build/llm-results.xml plus per-test stats from .Build/llm-stats/,
+ * builds a flat list of { run × test × model } records, and POSTs them as
+ * JSON. The Apps Script (see Build/llm-stats-apps-script.gs) appends rows
+ * and recomputes a per-model summary used by the README badge endpoint.
+ *
+ * Required env vars:
+ *   LLM_STATS_SHEET_URL    Apps Script web app deployment URL (.../exec)
+ *   LLM_STATS_SHEET_TOKEN  Shared bearer token; must match INGEST_TOKEN
+ *
+ * Optional env vars (set automatically by GitHub Actions):
+ *   GITHUB_SHA, GITHUB_REF_NAME, GITHUB_RUN_URL
+ *
+ * Usage:
+ *   php Build/post-llm-stats.php
+ *   php Build/post-llm-stats.php --dry-run
+ *   php Build/post-llm-stats.php --xml=path/to/results.xml
+ */
+
+$xmlPath = __DIR__ . '/../.Build/llm-results.xml';
+$dryRun  = false;
+
+foreach ($argv as $arg) {
+    if ($arg === '--dry-run') {
+        $dryRun = true;
+    }
+    if (str_starts_with($arg, '--xml=')) {
+        $xmlPath = substr($arg, strlen('--xml='));
+    }
+}
+
+if (!file_exists($xmlPath)) {
+    fwrite(STDERR, "JUnit XML not found: $xmlPath\n");
+    exit(2);
+}
+
+$xml = simplexml_load_file($xmlPath);
+if ($xml === false) {
+    fwrite(STDERR, "Failed to parse JUnit XML: $xmlPath\n");
+    exit(2);
+}
+
+$records = [];
+if ($xml->getName() === 'testsuite') {
+    collectFromSuite($xml, $records);
+} else {
+    foreach ($xml->testsuite as $suite) {
+        collectFromSuite($suite, $records);
+    }
+}
+
+if ($records === []) {
+    fwrite(STDERR, "No test cases found in JUnit XML — nothing to post.\n");
+    exit(0);
+}
+
+$payload = [
+    'timestamp' => gmdate('c'),
+    'commit'    => getenv('GITHUB_SHA') ?: '',
+    'branch'    => getenv('GITHUB_REF_NAME') ?: '',
+    'run_url'   => getenv('GITHUB_RUN_URL') ?: '',
+    'records'   => $records,
+];
+
+if ($dryRun) {
+    echo json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+    fwrite(STDERR, sprintf("[dry-run] %d records would be posted.\n", count($records)));
+    exit(0);
+}
+
+$url   = getenv('LLM_STATS_SHEET_URL');
+$token = getenv('LLM_STATS_SHEET_TOKEN');
+if (!$url || !$token) {
+    fwrite(STDERR, "LLM_STATS_SHEET_URL or LLM_STATS_SHEET_TOKEN not set — skipping publish.\n");
+    exit(0);
+}
+
+// Apps Script web apps can't read request headers, so the token rides in
+// the JSON body. Apps Script also follows a 302 from /exec → googleusercontent
+// for the actual response, hence FOLLOWLOCATION.
+$payload['_token'] = $token;
+
+$ch = curl_init($url);
+curl_setopt_array($ch, [
+    CURLOPT_POST           => true,
+    CURLOPT_POSTFIELDS     => json_encode($payload, JSON_UNESCAPED_SLASHES),
+    CURLOPT_HTTPHEADER     => ['Content-Type: application/json'],
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_FOLLOWLOCATION => true,
+    CURLOPT_TIMEOUT        => 30,
+]);
+
+$response = curl_exec($ch);
+$status   = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+$err      = curl_error($ch);
+curl_close($ch);
+
+if ($response === false) {
+    fwrite(STDERR, "curl error: $err\n");
+    exit(1);
+}
+
+if ($status < 200 || $status >= 300) {
+    fwrite(STDERR, "Apps Script returned HTTP $status: $response\n");
+    exit(1);
+}
+
+echo "Published " . count($records) . " records to Google Sheet (HTTP $status).\n";
+exit(0);
+
+function collectFromSuite(SimpleXMLElement $suite, array &$records): void
+{
+    foreach ($suite->testsuite as $child) {
+        collectFromSuite($child, $records);
+    }
+    foreach ($suite->testcase as $testcase) {
+        $name  = (string)$testcase['name'];
+        $class = (string)$testcase['class'];
+
+        $model    = 'unknown';
+        $baseName = $name;
+        if (preg_match('/^(.+)#(.+)$/', $name, $m)) {
+            $baseName = $m[1];
+            $model    = $m[2];
+        } elseif (preg_match('/^(.+) with data set "(.+)"$/', $name, $m)) {
+            $baseName = $m[1];
+            $model    = $m[2];
+        }
+
+        $failed  = isset($testcase->failure) || isset($testcase->error);
+        $skipped = isset($testcase->skipped);
+        $status  = $failed ? 'FAIL' : ($skipped ? 'SKIP' : 'PASS');
+
+        $stats = loadTestStats($class, $baseName, $model);
+
+        $records[] = [
+            'class'       => $class,
+            'test'        => $baseName,
+            'model'       => $model,
+            'status'      => $status,
+            'duration'    => (float)($testcase['time'] ?? 0),
+            'llm_calls'   => $stats['llm_calls']   ?? null,
+            'tool_calls'  => $stats['tool_calls']  ?? null,
+            'tool_errors' => $stats['tool_errors'] ?? null,
+        ];
+    }
+}
+
+function loadTestStats(string $class, string $baseName, string $model): ?array
+{
+    $statsDir = __DIR__ . '/../.Build/llm-stats';
+    $modelKey = $model === 'unknown' ? '' : $model;
+    $file     = $statsDir . '/' . sha1($class . '::' . $baseName . '::' . $modelKey) . '.json';
+    if (!file_exists($file)) {
+        return null;
+    }
+    $data = json_decode((string)file_get_contents($file), true);
+    return is_array($data) ? $data : null;
+}

--- a/Build/post-llm-stats.php
+++ b/Build/post-llm-stats.php
@@ -2,12 +2,13 @@
 <?php
 
 /**
- * Post LLM test results to a Google Sheet via an Apps Script web app.
+ * Aggregate LLM test results into a one-row-per-run benchmark record and
+ * post it to a Google Sheet via an Apps Script web app.
  *
- * Reads .Build/llm-results.xml plus per-test stats from .Build/llm-stats/,
- * builds a flat list of { run × test × model } records, and POSTs them as
- * JSON. The Apps Script (see Build/llm-stats-apps-script.gs) appends rows
- * and recomputes a per-model summary used by the README badge endpoint.
+ * The sheet schema is: timestamp, branch, commit, run_url, total, <one
+ * column per model with that model's pass count>. Model columns are added
+ * dynamically as new models appear. Per-test detail is intentionally not
+ * stored — drill into the GitHub Actions run for that.
  *
  * Required env vars:
  *   LLM_STATS_SHEET_URL    Apps Script web app deployment URL (.../exec)
@@ -45,31 +46,36 @@ if ($xml === false) {
     exit(2);
 }
 
-$records = [];
+$tests        = []; // baseName => true if executed in at least one model
+$modelPasses  = []; // model => int (PASS count)
+
 if ($xml->getName() === 'testsuite') {
-    collectFromSuite($xml, $records);
+    collectFromSuite($xml, $tests, $modelPasses);
 } else {
     foreach ($xml->testsuite as $suite) {
-        collectFromSuite($suite, $records);
+        collectFromSuite($suite, $tests, $modelPasses);
     }
 }
 
-if ($records === []) {
-    fwrite(STDERR, "No test cases found in JUnit XML — nothing to post.\n");
+$total = count(array_filter($tests));
+if ($total === 0) {
+    fwrite(STDERR, "No executed tests found in JUnit XML — nothing to post.\n");
     exit(0);
 }
 
+ksort($modelPasses);
+
 $payload = [
     'timestamp' => gmdate('c'),
-    'commit'    => getenv('GITHUB_SHA') ?: '',
     'branch'    => getenv('GITHUB_REF_NAME') ?: '',
+    'commit'    => getenv('GITHUB_SHA') ?: '',
     'run_url'   => getenv('GITHUB_RUN_URL') ?: '',
-    'records'   => $records,
+    'total'     => $total,
+    'models'    => $modelPasses,
 ];
 
 if ($dryRun) {
     echo json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
-    fwrite(STDERR, sprintf("[dry-run] %d records would be posted.\n", count($records)));
     exit(0);
 }
 
@@ -81,8 +87,8 @@ if (!$url || !$token) {
 }
 
 // Apps Script web apps can't read request headers, so the token rides in
-// the JSON body. Apps Script also follows a 302 from /exec → googleusercontent
-// for the actual response, hence FOLLOWLOCATION.
+// the JSON body. /exec returns 302 to googleusercontent for the response,
+// hence FOLLOWLOCATION.
 $payload['_token'] = $token;
 
 $ch = curl_init($url);
@@ -110,13 +116,13 @@ if ($status < 200 || $status >= 300) {
     exit(1);
 }
 
-echo "Published " . count($records) . " records to Google Sheet (HTTP $status).\n";
+echo "Published run with $total tests across " . count($modelPasses) . " models (HTTP $status).\n";
 exit(0);
 
-function collectFromSuite(SimpleXMLElement $suite, array &$records): void
+function collectFromSuite(SimpleXMLElement $suite, array &$tests, array &$modelPasses): void
 {
     foreach ($suite->testsuite as $child) {
-        collectFromSuite($child, $records);
+        collectFromSuite($child, $tests, $modelPasses);
     }
     foreach ($suite->testcase as $testcase) {
         $name  = (string)$testcase['name'];
@@ -134,31 +140,13 @@ function collectFromSuite(SimpleXMLElement $suite, array &$records): void
 
         $failed  = isset($testcase->failure) || isset($testcase->error);
         $skipped = isset($testcase->skipped);
-        $status  = $failed ? 'FAIL' : ($skipped ? 'SKIP' : 'PASS');
 
-        $stats = loadTestStats($class, $baseName, $model);
+        $key = $class . '::' . $baseName;
+        $tests[$key] = ($tests[$key] ?? false) || !$skipped;
 
-        $records[] = [
-            'class'       => $class,
-            'test'        => $baseName,
-            'model'       => $model,
-            'status'      => $status,
-            'duration'    => (float)($testcase['time'] ?? 0),
-            'llm_calls'   => $stats['llm_calls']   ?? null,
-            'tool_calls'  => $stats['tool_calls']  ?? null,
-            'tool_errors' => $stats['tool_errors'] ?? null,
-        ];
+        $modelPasses[$model] = $modelPasses[$model] ?? 0;
+        if (!$failed && !$skipped) {
+            $modelPasses[$model]++;
+        }
     }
-}
-
-function loadTestStats(string $class, string $baseName, string $model): ?array
-{
-    $statsDir = __DIR__ . '/../.Build/llm-stats';
-    $modelKey = $model === 'unknown' ? '' : $model;
-    $file     = $statsDir . '/' . sha1($class . '::' . $baseName . '::' . $modelKey) . '.json';
-    if (!file_exists($file)) {
-        return null;
-    }
-    $data = json_decode((string)file_get_contents($file), true);
-    return is_array($data) ? $data : null;
 }

--- a/Build/post-llm-stats.php
+++ b/Build/post-llm-stats.php
@@ -116,7 +116,18 @@ if ($status < 200 || $status >= 300) {
     exit(1);
 }
 
-echo "Published run with $total tests across " . count($modelPasses) . " models (HTTP $status).\n";
+// Apps Script always responds 200 even for auth/parse failures, so the body
+// is the real signal. Require an explicit `ok: true` to declare success.
+$decoded = json_decode((string)$response, true);
+if (!is_array($decoded) || empty($decoded['ok'])) {
+    $detail = is_array($decoded) && isset($decoded['error'])
+        ? $decoded['error']
+        : substr((string)$response, 0, 200);
+    fwrite(STDERR, "Apps Script reported failure: $detail\n");
+    exit(1);
+}
+
+echo "Published run with $total tests across " . count($modelPasses) . " models (row {$decoded['row']}).\n";
 exit(0);
 
 function collectFromSuite(SimpleXMLElement $suite, array &$tests, array &$modelPasses): void

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ All these operations happen safely in workspaces, giving you full control to rev
 
 While there are a lot of automated tests, and even some [LLM test](Tests/Llm/README.md), TYPO3 instances are widely different and Language Models are also widely different. Feel free to [create issues here on GitHub](https://github.com/logiscape/mcp-sdk-php/issues) or [share experiences in the typo3-core-ai channel](https://typo3.slack.com/archives/C091M0M7BL6). 
 
+### Tested LLMs
+
+The [LLM test suite](Tests/Llm/README.md) runs every model below against the extension on every merge to `main`, and pushes the results to a public Google Sheet. Once the Sheet is deployed (see [Build/llm-stats-apps-script.gs](Build/llm-stats-apps-script.gs)), uncomment the block below and replace `SHEET_DEPLOY_ID` / `SHEET_PUBLIC_URL` to surface live shields.io badges that link to the run-by-run history.
+
+<!-- Tested-LLMs badges — uncomment and fill in after first deploy:
+[![haiku-4.5](https://img.shields.io/endpoint?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec%3Fmodel%3Dhaiku-4.5&label=haiku-4.5)](SHEET_PUBLIC_URL)
+[![gpt-5.4-mini](https://img.shields.io/endpoint?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec%3Fmodel%3Dgpt-5.4-mini&label=gpt-5.4-mini)](SHEET_PUBLIC_URL)
+[![gpt-oss-120b](https://img.shields.io/endpoint?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec%3Fmodel%3Dgpt-oss-120b&label=gpt-oss-120b)](SHEET_PUBLIC_URL)
+[![mistral-large-2512](https://img.shields.io/endpoint?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec%3Fmodel%3Dmistral-large-2512&label=mistral-large-2512)](SHEET_PUBLIC_URL)
+[![gemini-3-flash](https://img.shields.io/endpoint?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec%3Fmodel%3Dgemini-3-flash&label=gemini-3-flash)](SHEET_PUBLIC_URL)
+-->
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -49,12 +49,14 @@ While there are a lot of automated tests, and even some [LLM test](Tests/Llm/REA
 
 The [LLM test suite](Tests/Llm/README.md) runs every model below against the extension on every merge to `main`, and pushes the results to a public Google Sheet. Once the Sheet is deployed (see [Build/llm-stats-apps-script.gs](Build/llm-stats-apps-script.gs)), uncomment the block below and replace `SHEET_DEPLOY_ID` / `SHEET_PUBLIC_URL` to surface live shields.io badges that link to the run-by-run history.
 
-<!-- Tested-LLMs badges — uncomment and fill in after first deploy:
-[![haiku-4.5](https://img.shields.io/endpoint?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec%3Fmodel%3Dhaiku-4.5&label=haiku-4.5)](SHEET_PUBLIC_URL)
-[![gpt-5.4-mini](https://img.shields.io/endpoint?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec%3Fmodel%3Dgpt-5.4-mini&label=gpt-5.4-mini)](SHEET_PUBLIC_URL)
-[![gpt-oss-120b](https://img.shields.io/endpoint?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec%3Fmodel%3Dgpt-oss-120b&label=gpt-oss-120b)](SHEET_PUBLIC_URL)
-[![mistral-large-2512](https://img.shields.io/endpoint?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec%3Fmodel%3Dmistral-large-2512&label=mistral-large-2512)](SHEET_PUBLIC_URL)
-[![gemini-3-flash](https://img.shields.io/endpoint?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec%3Fmodel%3Dgemini-3-flash&label=gemini-3-flash)](SHEET_PUBLIC_URL)
+<!-- Tested-LLMs badges — uncomment and fill in after first deploy.
+     All badges hit one Apps Script JSON URL (cached by shields.io) and
+     pull each model's percentage via JSONPath. `&suffix=%25` adds the % sign.
+[![haiku-4.5](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec&query=%24.percentages%5B%22haiku-4.5%22%5D&suffix=%25&label=haiku-4.5)](SHEET_PUBLIC_URL)
+[![gpt-5.4-mini](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec&query=%24.percentages%5B%22gpt-5.4-mini%22%5D&suffix=%25&label=gpt-5.4-mini)](SHEET_PUBLIC_URL)
+[![gpt-oss-120b](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec&query=%24.percentages%5B%22gpt-oss-120b%22%5D&suffix=%25&label=gpt-oss-120b)](SHEET_PUBLIC_URL)
+[![mistral-large-2512](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec&query=%24.percentages%5B%22mistral-large-2512%22%5D&suffix=%25&label=mistral-large-2512)](SHEET_PUBLIC_URL)
+[![gemini-3-flash](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec&query=%24.percentages%5B%22gemini-3-flash%22%5D&suffix=%25&label=gemini-3-flash)](SHEET_PUBLIC_URL)
 -->
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ AI assistants to safely view and manipulate TYPO3 pages and records through TYPO
 
 **All content changes are automatically queued in TYPO3 workspaces**, making it completely safe for AI assistants to create, update, and modify content without immediately affecting your live website. Changes require explicit publishing to become visible to site visitors.
 
+## 🧪 Continuously Tested With Real LLMs
+
+Every push to `main` runs a benchmark that has the latest models from **Anthropic, OpenAI, Mistral, and Google** actually use this MCP to perform real TYPO3 tasks. That's how we stay vendor-independent and prove the tool descriptions convey what they claim across very different prompting styles — your AI assistant of choice should just work, not only ours. Click any badge for the full run-by-run history.
+
+[
+![haiku-4.5](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FAKfycbwyS4NavPMDQWbQQYCh3uKA4zJ5C8sxggxTZQQPdgjXOZ7Vt4BpUd5mzWdsWMqjzniI%2Fexec&query=%24.percentages%5B%22haiku-4.5%22%5D&suffix=%25&label=haiku-4.5)
+![gpt-5.4-mini](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FAKfycbwyS4NavPMDQWbQQYCh3uKA4zJ5C8sxggxTZQQPdgjXOZ7Vt4BpUd5mzWdsWMqjzniI%2Fexec&query=%24.percentages%5B%22gpt-5.4-mini%22%5D&suffix=%25&label=gpt-5.4-mini)
+![gpt-oss-120b](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FAKfycbwyS4NavPMDQWbQQYCh3uKA4zJ5C8sxggxTZQQPdgjXOZ7Vt4BpUd5mzWdsWMqjzniI%2Fexec&query=%24.percentages%5B%22gpt-oss-120b%22%5D&suffix=%25&label=gpt-oss-120b)
+![mistral-large-2512](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FAKfycbwyS4NavPMDQWbQQYCh3uKA4zJ5C8sxggxTZQQPdgjXOZ7Vt4BpUd5mzWdsWMqjzniI%2Fexec&query=%24.percentages%5B%22mistral-large-2512%22%5D&suffix=%25&label=mistral-large-2512)
+![gemini-3-flash](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FAKfycbwyS4NavPMDQWbQQYCh3uKA4zJ5C8sxggxTZQQPdgjXOZ7Vt4BpUd5mzWdsWMqjzniI%2Fexec&query=%24.percentages%5B%22gemini-3-flash%22%5D&suffix=%25&label=gemini-3-flash)
+](https://docs.google.com/spreadsheets/d/18jL34ymMaUfoCtL32FauPu3n0cTbBTLKuVO7dmGSAS4/edit?usp=sharing)
+
 ## What Can You Do?
 
 With the TYPO3 MCP Server, your AI assistant can help you:
@@ -43,21 +55,7 @@ All these operations happen safely in workspaces, giving you full control to rev
 | **Fileadmin Support**      | ❌ Missing       | Not yet implemented                                                                                           |
 | **Workspace Selection**    | ❌ Missing       | Currently uses the first writable workspace of the user                                                       |
 
-While there are a lot of automated tests, and even some [LLM test](Tests/Llm/README.md), TYPO3 instances are widely different and Language Models are also widely different. Feel free to [create issues here on GitHub](https://github.com/logiscape/mcp-sdk-php/issues) or [share experiences in the typo3-core-ai channel](https://typo3.slack.com/archives/C091M0M7BL6). 
-
-### Tested LLMs
-
-The [LLM test suite](Tests/Llm/README.md) runs every model below against the extension on every merge to `main`, and pushes the results to a public Google Sheet. Once the Sheet is deployed (see [Build/llm-stats-apps-script.gs](Build/llm-stats-apps-script.gs)), uncomment the block below and replace `SHEET_DEPLOY_ID` / `SHEET_PUBLIC_URL` to surface live shields.io badges that link to the run-by-run history.
-
-<!-- Tested-LLMs badges — uncomment and fill in after first deploy.
-     All badges hit one Apps Script JSON URL (cached by shields.io) and
-     pull each model's percentage via JSONPath. `&suffix=%25` adds the % sign.
-[![haiku-4.5](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec&query=%24.percentages%5B%22haiku-4.5%22%5D&suffix=%25&label=haiku-4.5)](SHEET_PUBLIC_URL)
-[![gpt-5.4-mini](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec&query=%24.percentages%5B%22gpt-5.4-mini%22%5D&suffix=%25&label=gpt-5.4-mini)](SHEET_PUBLIC_URL)
-[![gpt-oss-120b](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec&query=%24.percentages%5B%22gpt-oss-120b%22%5D&suffix=%25&label=gpt-oss-120b)](SHEET_PUBLIC_URL)
-[![mistral-large-2512](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec&query=%24.percentages%5B%22mistral-large-2512%22%5D&suffix=%25&label=mistral-large-2512)](SHEET_PUBLIC_URL)
-[![gemini-3-flash](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FSHEET_DEPLOY_ID%2Fexec&query=%24.percentages%5B%22gemini-3-flash%22%5D&suffix=%25&label=gemini-3-flash)](SHEET_PUBLIC_URL)
--->
+While there are a lot of automated tests, TYPO3 instances are widely different and Language Models are also widely different. Feel free to [create issues here on GitHub](https://github.com/logiscape/mcp-sdk-php/issues) or [share experiences in the typo3-core-ai channel](https://typo3.slack.com/archives/C091M0M7BL6). 
 
 ## Installation
 


### PR DESCRIPTION
## Summary
This PR adds infrastructure to track LLM test results over time by publishing benchmark data to a Google Sheet, with support for generating shields.io badges to display live pass rates.

## Key Changes

- **Google Apps Script (`Build/llm-stats-apps-script.gs`)**: New web app that serves as the backend for LLM stats collection
  - `doPost()`: Ingests benchmark payloads with token authentication, dynamically adds model columns as new models appear
  - `doGet()`: Serves both detailed JSON (all models from latest run) and shields.io badge format (single model pass rate)
  - `ensureSheet_()`: Initializes the "Runs" sheet with base headers (timestamp, branch, commit, run_url, total)
  - Badge color coding based on pass percentage (90%+ brightgreen, 75%+ green, 60%+ yellow, 40%+ orange, <40% red)

- **PHP ingest script (`Build/post-llm-stats.php`)**: Parses JUnit XML test results and publishes aggregated stats
  - Extracts model names from test case names (format: `testName#modelName` or `testName with data set "modelName"`)
  - Counts total executed tests (excluding skipped-by-all) and per-model pass counts
  - Posts JSON payload to Apps Script endpoint with token authentication
  - Supports `--dry-run` and `--xml=` flags for testing
  - Gracefully skips publishing if environment variables are not configured

- **GitHub Actions workflow (`tests.yml`)**: New step to publish LLM stats after successful test runs
  - Runs only on `main` branch pushes
  - Continues on error to prevent workflow failure if publishing fails
  - Passes GitHub Actions context (run URL, commit, branch) to the ingest script

- **README.md**: Added "Tested LLMs" section with template for shields.io badges
  - Includes commented-out badge examples for haiku-4.5, gpt-5.4-mini, gpt-oss-120b, mistral-large-2512, and gemini-3-flash
  - Instructions for deploying the Apps Script and uncommenting badges after setup

## Implementation Details

- Token-based authentication: the ingest token is stored in Apps Script Script Properties and validated on each POST
- Dynamic schema: model columns are added to the sheet on-demand when new models appear in payloads
- Efficient badge generation: shields.io uses JSONPath to extract percentages from a single cached endpoint response
- Test deduplication: a test is counted in `total` only if executed by at least one model (skipped-by-all tests excluded)
- Deployment instructions included in the Apps Script file header for easy setup

https://claude.ai/code/session_018cW9kxxbzHToTBwPwDK4ri