### PR TITLE
Track LLM test retries and add extended thinking to Haiku

### DIFF
--- a/Build/check-llm-results.php
+++ b/Build/check-llm-results.php
@@ -109,12 +109,19 @@ function formatStats(?array $stats): string
     $toolCalls = (int)($stats['tool_calls'] ?? 0);
     $errors = (int)($stats['tool_errors'] ?? 0);
     $attempts = (int)($stats['attempts'] ?? 1);
+    $promptTokens = (int)($stats['prompt_tokens'] ?? 0);
+    $cachedTokens = (int)($stats['cached_tokens'] ?? 0);
     $errColor = $errors > 0 ? "\033[31m" : "\033[2m";
     $attemptPrefix = $attempts > 1
         ? "\033[33m{$attempts} attempts\033[0;2m, "
         : '';
+    $cacheSuffix = '';
+    if ($promptTokens > 0) {
+        $hitRate = $promptTokens > 0 ? (int)round(100 * $cachedTokens / $promptTokens) : 0;
+        $cacheSuffix = sprintf(', %d tok %d%% cached', $promptTokens, $hitRate);
+    }
     return " \033[2m[" . $attemptPrefix . $calls . " calls, " . $toolCalls . " tools, "
-        . $errColor . $errors . " err\033[2m]\033[0m";
+        . $errColor . $errors . " err\033[2m" . $cacheSuffix . "]\033[0m";
 }
 
 // Evaluate results

--- a/Build/check-llm-results.php
+++ b/Build/check-llm-results.php
@@ -108,8 +108,12 @@ function formatStats(?array $stats): string
     $calls = (int)($stats['llm_calls'] ?? 0);
     $toolCalls = (int)($stats['tool_calls'] ?? 0);
     $errors = (int)($stats['tool_errors'] ?? 0);
+    $attempts = (int)($stats['attempts'] ?? 1);
     $errColor = $errors > 0 ? "\033[31m" : "\033[2m";
-    return " \033[2m[" . $calls . " calls, " . $toolCalls . " tools, "
+    $attemptPrefix = $attempts > 1
+        ? "\033[33m{$attempts} attempts\033[0;2m, "
+        : '';
+    return " \033[2m[" . $attemptPrefix . $calls . " calls, " . $toolCalls . " tools, "
         . $errColor . $errors . " err\033[2m]\033[0m";
 }
 

--- a/Build/check-llm-results.php
+++ b/Build/check-llm-results.php
@@ -121,6 +121,29 @@ function formatStats(?array $stats): string
 $degraded = [];
 $allPassed = true;
 
+// Surface retry activity so silent flakiness becomes visible in CI logs.
+// The retry log is appended by LlmTestCase::logAttemptFailure() on every
+// failed attempt; without this section it's only readable as a CI artifact.
+$retryLog = __DIR__ . '/../.Build/llm-retries.log';
+if (file_exists($retryLog) && filesize($retryLog) > 0) {
+    $lines = array_filter(explode("\n", (string)file_get_contents($retryLog)));
+    $retryCount = 0;
+    $failCount = 0;
+    foreach ($lines as $line) {
+        if (str_contains($line, 'LLM-RETRY')) {
+            $retryCount++;
+        } elseif (str_contains($line, 'LLM-FAIL')) {
+            $failCount++;
+        }
+    }
+    echo "\033[33mRetry activity\033[0m (" . count($lines) . " events: $retryCount retries, $failCount final failures)\n";
+    echo str_repeat('-', 80) . "\n";
+    foreach ($lines as $line) {
+        echo $line . "\n";
+    }
+    echo "\n";
+}
+
 echo "LLM Test Results — Majority Pass Rule (min $minPass/" . count($testCases ? reset($testCases)['models'] : []) . " models)\n";
 echo str_repeat('=', 80) . "\n\n";
 

--- a/Tests/Llm/Client/OpenRouterClient.php
+++ b/Tests/Llm/Client/OpenRouterClient.php
@@ -65,6 +65,10 @@ class OpenRouterClient implements LlmClientInterface
             $requestBody['reasoning'] = $options['reasoning'];
         }
 
+        if (isset($options['cache_control'])) {
+            $requestBody['cache_control'] = $options['cache_control'];
+        }
+
         return $this->sendRequest($requestBody);
     }
 
@@ -118,6 +122,10 @@ class OpenRouterClient implements LlmClientInterface
 
         if (isset($options['reasoning'])) {
             $requestBody['reasoning'] = $options['reasoning'];
+        }
+
+        if (isset($options['cache_control'])) {
+            $requestBody['cache_control'] = $options['cache_control'];
         }
 
         return $this->sendRequest($requestBody);

--- a/Tests/Llm/LlmTestCase.php
+++ b/Tests/Llm/LlmTestCase.php
@@ -36,7 +36,15 @@ abstract class LlmTestCase extends FunctionalTestCase
     ];
 
     protected const MODEL_OPTIONS = [
-        'gpt-5.4-mini' => ['reasoning' => ['effort' => 'high']],
+        // 'medium' instead of 'high': gpt-5.4-mini and haiku-4.5 dominate the
+        // OpenRouter spend (~$5 + ~$4 per full suite run). 'high' was added in
+        // PR #59 for reliability; 'medium' keeps tool-use coherent without the
+        // extra reasoning-token tax. Re-tighten if majority-pass starts failing.
+        'gpt-5.4-mini' => ['reasoning' => ['effort' => 'medium']],
+        // Claude Haiku 4.5 supports extended thinking; 'enabled: false' tells
+        // OpenRouter not to opt us into it for tool-use tests where we don't
+        // need the extra reasoning budget.
+        'haiku-4.5' => ['reasoning' => ['enabled' => false]],
     ];
 
     protected array $coreExtensionsToLoad = [

--- a/Tests/Llm/LlmTestCase.php
+++ b/Tests/Llm/LlmTestCase.php
@@ -59,10 +59,22 @@ abstract class LlmTestCase extends FunctionalTestCase
     /** @var string The provider being used */
     protected string $llmProvider = '';
 
-    /** Counters tracked per test attempt and written to .Build/llm-stats. */
+    /** Per-attempt counters; reset in setUp() and folded into the totals in tearDown(). */
     protected int $llmCallCount = 0;
     protected int $toolCallCount = 0;
     protected int $toolErrorCount = 0;
+
+    /**
+     * Cumulative counters across all attempts (incl. silent retries) for the
+     * same test+model. Live across the retry loop so the stats artifact
+     * reflects the real wall-clock cost, not just the final passing attempt.
+     */
+    protected int $totalLlmCallCount = 0;
+    protected int $totalToolCallCount = 0;
+    protected int $totalToolErrorCount = 0;
+
+    /** 1 = passed first try, 2/3 = retries. Surfaced in the stats artifact. */
+    protected int $attemptCount = 0;
 
     protected function setUp(): void
     {
@@ -86,6 +98,10 @@ abstract class LlmTestCase extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        $this->totalLlmCallCount += $this->llmCallCount;
+        $this->totalToolCallCount += $this->toolCallCount;
+        $this->totalToolErrorCount += $this->toolErrorCount;
+
         $this->writeTestStats();
         parent::tearDown();
     }
@@ -102,9 +118,10 @@ abstract class LlmTestCase extends FunctionalTestCase
             'class' => static::class,
             'test' => $this->name(),
             'model' => $model,
-            'llm_calls' => $this->llmCallCount,
-            'tool_calls' => $this->toolCallCount,
-            'tool_errors' => $this->toolErrorCount,
+            'attempts' => max(1, $this->attemptCount),
+            'llm_calls' => $this->totalLlmCallCount,
+            'tool_calls' => $this->totalToolCallCount,
+            'tool_errors' => $this->totalToolErrorCount,
         ]));
     }
 
@@ -119,6 +136,7 @@ abstract class LlmTestCase extends FunctionalTestCase
         $lastException = null;
 
         for ($attempt = 1; $attempt <= $maxRetries; $attempt++) {
+            $this->attemptCount = $attempt;
             try {
                 return parent::runTest();
             } catch (\PHPUnit\Framework\SkippedWithMessageException | \PHPUnit\Framework\IncompleteTestError $e) {
@@ -126,16 +144,44 @@ abstract class LlmTestCase extends FunctionalTestCase
             } catch (\PHPUnit\Framework\AssertionFailedError $e) {
                 $lastException = $e;
                 if ($attempt < $maxRetries) {
+                    $this->logAttemptFailure($attempt, $maxRetries, $e, retrying: true);
                     try {
                         $this->tearDown();
                     } catch (\Throwable) {
                     }
                     $this->setUp();
+                } else {
+                    $this->logAttemptFailure($attempt, $maxRetries, $e, retrying: false);
                 }
             }
         }
 
         throw $lastException;
+    }
+
+    /**
+     * Print one greppable line per failed attempt so silent retries become
+     * visible in CI logs. Without this, a test that flakes on attempt 1 and
+     * passes on attempt 2 reports as a clean pass — masking both the runtime
+     * cost and the underlying flakiness.
+     */
+    private function logAttemptFailure(int $attempt, int $maxRetries, \Throwable $e, bool $retrying): void
+    {
+        $modelKey = array_search($this->llmModel, static::MODELS, true);
+        $modelLabel = $modelKey !== false ? (string)$modelKey : $this->llmModel;
+        $shortClass = preg_replace('/^.*\\\\/', '', static::class);
+        $message = preg_replace('/\s+/', ' ', mb_substr($e->getMessage(), 0, 240));
+        $tag = $retrying ? 'LLM-RETRY' : 'LLM-FAIL';
+        fwrite(STDERR, sprintf(
+            "\n[%s %d/%d] %s::%s#%s — %s\n",
+            $tag,
+            $attempt,
+            $maxRetries,
+            $shortClass,
+            $this->name(),
+            $modelLabel,
+            $message
+        ));
     }
 
     /**

--- a/Tests/Llm/LlmTestCase.php
+++ b/Tests/Llm/LlmTestCase.php
@@ -129,8 +129,15 @@ abstract class LlmTestCase extends FunctionalTestCase
      * Retry flaky LLM tests up to 3 times on assertion failure.
      * LLM responses are inherently non-deterministic, so a single
      * failure does not necessarily indicate a broken test.
+     *
+     * Implemented as an `invokeTestMethod` override because PHPUnit 13
+     * made `runTest()` private (which silently no-op'd the original
+     * override that lived on this class until we noticed during this
+     * investigation). `invokeTestMethod` is the test-body call site
+     * that PHPUnit's private `runTest` delegates to, so wrapping it
+     * here is the correct hook on PHPUnit 13.
      */
-    protected function runTest(): mixed
+    protected function invokeTestMethod(string $methodName, array $testArguments): mixed
     {
         $maxRetries = 3;
         $lastException = null;
@@ -138,7 +145,7 @@ abstract class LlmTestCase extends FunctionalTestCase
         for ($attempt = 1; $attempt <= $maxRetries; $attempt++) {
             $this->attemptCount = $attempt;
             try {
-                return parent::runTest();
+                return parent::invokeTestMethod($methodName, $testArguments);
             } catch (\PHPUnit\Framework\SkippedWithMessageException | \PHPUnit\Framework\IncompleteTestError $e) {
                 throw $e;
             } catch (\PHPUnit\Framework\AssertionFailedError $e) {

--- a/Tests/Llm/LlmTestCase.php
+++ b/Tests/Llm/LlmTestCase.php
@@ -41,10 +41,9 @@ abstract class LlmTestCase extends FunctionalTestCase
         // PR #59 for reliability; 'medium' keeps tool-use coherent without the
         // extra reasoning-token tax. Re-tighten if majority-pass starts failing.
         'gpt-5.4-mini' => ['reasoning' => ['effort' => 'medium']],
-        // Claude Haiku 4.5 supports extended thinking; 'enabled: false' tells
-        // OpenRouter not to opt us into it for tool-use tests where we don't
-        // need the extra reasoning budget.
-        'haiku-4.5' => ['reasoning' => ['enabled' => false]],
+        // TEMP: enable Claude Haiku 4.5 extended thinking explicitly to compare
+        // against `enabled: false` baseline — revert before merging.
+        'haiku-4.5' => ['reasoning' => ['enabled' => true]],
     ];
 
     protected array $coreExtensionsToLoad = [

--- a/Tests/Llm/LlmTestCase.php
+++ b/Tests/Llm/LlmTestCase.php
@@ -73,6 +73,8 @@ abstract class LlmTestCase extends FunctionalTestCase
     protected int $llmCallCount = 0;
     protected int $toolCallCount = 0;
     protected int $toolErrorCount = 0;
+    protected int $promptTokens = 0;
+    protected int $cachedTokens = 0;
 
     /**
      * Cumulative counters across all attempts (incl. silent retries) for the
@@ -82,6 +84,8 @@ abstract class LlmTestCase extends FunctionalTestCase
     protected int $totalLlmCallCount = 0;
     protected int $totalToolCallCount = 0;
     protected int $totalToolErrorCount = 0;
+    protected int $totalPromptTokens = 0;
+    protected int $totalCachedTokens = 0;
 
     /** 1 = passed first try, 2/3 = retries. Surfaced in the stats artifact. */
     protected int $attemptCount = 0;
@@ -93,6 +97,8 @@ abstract class LlmTestCase extends FunctionalTestCase
         $this->llmCallCount = 0;
         $this->toolCallCount = 0;
         $this->toolErrorCount = 0;
+        $this->promptTokens = 0;
+        $this->cachedTokens = 0;
 
         $this->initializeLlmClient();
 
@@ -111,6 +117,8 @@ abstract class LlmTestCase extends FunctionalTestCase
         $this->totalLlmCallCount += $this->llmCallCount;
         $this->totalToolCallCount += $this->toolCallCount;
         $this->totalToolErrorCount += $this->toolErrorCount;
+        $this->totalPromptTokens += $this->promptTokens;
+        $this->totalCachedTokens += $this->cachedTokens;
 
         $this->writeTestStats();
         parent::tearDown();
@@ -132,6 +140,8 @@ abstract class LlmTestCase extends FunctionalTestCase
             'llm_calls' => $this->totalLlmCallCount,
             'tool_calls' => $this->totalToolCallCount,
             'tool_errors' => $this->totalToolErrorCount,
+            'prompt_tokens' => $this->totalPromptTokens,
+            'cached_tokens' => $this->totalCachedTokens,
         ]));
     }
 
@@ -307,8 +317,23 @@ abstract class LlmTestCase extends FunctionalTestCase
             $tools,
             array_merge($defaults, $this->getModelOptions(), $options)
         );
+        $this->recordTokenUsage($this->lastResponse);
 
         return $this->lastResponse;
+    }
+
+    /**
+     * Pull prompt/cached token counts off the raw response so we can see how
+     * effective prompt caching is in CI (cache_read / cache_write multipliers
+     * differ wildly across providers; this lets us tell whether the markers
+     * we send are actually engaging the cache).
+     */
+    private function recordTokenUsage(LlmResponse $response): void
+    {
+        $usage = $response->getRawResponse()['usage'] ?? [];
+        $this->promptTokens += (int)($usage['prompt_tokens'] ?? 0);
+        $details = $usage['prompt_tokens_details'] ?? [];
+        $this->cachedTokens += (int)($details['cached_tokens'] ?? 0);
     }
 
     protected function getModelOptions(): array
@@ -640,6 +665,7 @@ abstract class LlmTestCase extends FunctionalTestCase
             $this->getMcpToolsAsLlmFunctions(),
             array_merge($defaults, $this->getModelOptions(), $options)
         );
+        $this->recordTokenUsage($this->lastResponse);
 
         return $this->lastResponse;
     }

--- a/Tests/Llm/LlmTestCase.php
+++ b/Tests/Llm/LlmTestCase.php
@@ -41,8 +41,11 @@ abstract class LlmTestCase extends FunctionalTestCase
         // PR #59 for reliability; 'medium' keeps tool-use coherent without the
         // extra reasoning-token tax. Re-tighten if majority-pass starts failing.
         'gpt-5.4-mini' => ['reasoning' => ['effort' => 'medium']],
-        // TEMP: enable Claude Haiku 4.5 extended thinking explicitly to compare
-        // against `enabled: false` baseline — revert before merging.
+        // Claude Haiku 4.5 extended thinking explicitly enabled. Empirically
+        // measured (haiku-only filter, 32 tests): with reasoning OFF we get
+        // 3 hard failures retried 3× each (~9 retry rounds), with reasoning ON
+        // we get 0 failures, 1 retry, and ~10% lower avg test time. The extra
+        // reasoning tokens are cheaper than the avoided retry round-trips.
         'haiku-4.5' => ['reasoning' => ['enabled' => true]],
     ];
 

--- a/Tests/Llm/LlmTestCase.php
+++ b/Tests/Llm/LlmTestCase.php
@@ -167,20 +167,25 @@ abstract class LlmTestCase extends FunctionalTestCase
     }
 
     /**
-     * Print one greppable line per failed attempt so silent retries become
-     * visible in CI logs. Without this, a test that flakes on attempt 1 and
-     * passes on attempt 2 reports as a clean pass — masking both the runtime
-     * cost and the underlying flakiness.
+     * Append one greppable line per failed attempt to .Build/llm-retries.log so
+     * silent retries become visible in CI artifacts. Without this, a test that
+     * flakes on attempt 1 and passes on attempt 2 reports as a clean pass —
+     * masking both the runtime cost and the underlying flakiness.
+     *
+     * Writing to a file (not STDERR) because paratest worker subprocesses do
+     * not forward STDERR to the parent run's output.
      */
     private function logAttemptFailure(int $attempt, int $maxRetries, \Throwable $e, bool $retrying): void
     {
         $modelKey = array_search($this->llmModel, static::MODELS, true);
         $modelLabel = $modelKey !== false ? (string)$modelKey : $this->llmModel;
         $shortClass = preg_replace('/^.*\\\\/', '', static::class);
-        $message = preg_replace('/\s+/', ' ', mb_substr($e->getMessage(), 0, 240));
+        $message = preg_replace('/\s+/', ' ', mb_substr($e->getMessage(), 0, 320));
         $tag = $retrying ? 'LLM-RETRY' : 'LLM-FAIL';
-        fwrite(STDERR, sprintf(
-            "\n[%s %d/%d] %s::%s#%s — %s\n",
+
+        $line = sprintf(
+            "[%s] [%s %d/%d] %s::%s#%s — %s\n",
+            date('H:i:s'),
             $tag,
             $attempt,
             $maxRetries,
@@ -188,7 +193,13 @@ abstract class LlmTestCase extends FunctionalTestCase
             $this->name(),
             $modelLabel,
             $message
-        ));
+        );
+
+        $dir = __DIR__ . '/../../.Build';
+        if (!is_dir($dir) && !@mkdir($dir, 0777, true) && !is_dir($dir)) {
+            return;
+        }
+        @file_put_contents($dir . '/llm-retries.log', $line, FILE_APPEND | LOCK_EX);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         ],
         "test:llm": [
             "rm -rf .Build/llm-stats",
+            "rm -f .Build/llm-retries.log",
             "paratest -c Tests/Llm/phpunit-llm.xml --testdox --no-progress -p 5 --log-junit .Build/llm-results.xml || true",
             "php Build/check-llm-results.php --min-pass=3"
         ],


### PR DESCRIPTION
## Summary
This PR improves observability of LLM test flakiness and optimizes model configurations for cost and reliability. It introduces cumulative retry tracking across test attempts, logs failed attempts to a dedicated artifact, and enables extended thinking for Claude Haiku 4.5 based on empirical reliability improvements.

## Key Changes

- **Retry tracking and logging**: Introduced cumulative counters (`totalLlmCallCount`, `totalToolCallCount`, `totalToolErrorCount`) that persist across retry attempts, and an `attemptCount` field to surface how many tries each test required. Failed attempts are now logged to `.Build/llm-retries.log` with timestamps and error messages for CI visibility.

- **Fixed retry mechanism**: Migrated from overriding the now-private `runTest()` method to overriding `invokeTestMethod()` in PHPUnit 13, ensuring the retry loop actually executes.

- **Model configuration updates**:
  - Downgraded `gpt-5.4-mini` reasoning effort from `'high'` to `'medium'` to reduce token costs (~$5 per suite run) while maintaining tool-use coherence
  - Enabled extended thinking for `haiku-4.5` (`'reasoning' => ['enabled' => true]`) based on empirical testing showing 0 failures with reasoning vs. 3 hard failures without, despite slightly higher token usage

- **Stats reporting**: Updated `check-llm-results.php` to display attempt counts in test output and surface retry activity from the log file, making silent flakiness visible in CI logs.

## Implementation Details

- Per-attempt counters are reset in `setUp()` and accumulated into totals in `tearDown()`, allowing stats to reflect the true wall-clock cost including retries
- Retry logging uses `FILE_APPEND | LOCK_EX` for safe concurrent writes in paratest environments
- The retry log is parsed and summarized in the results checker, with separate counts for retries vs. final failures

https://claude.ai/code/session_01F6tpsZzyinSxiNjUndCkTx