### PR TITLE
Fix schema field discovery for foreign-type tables and sys_file

### DIFF
--- a/Classes/EventListener/FileEnrichmentListener.php
+++ b/Classes/EventListener/FileEnrichmentListener.php
@@ -62,6 +62,19 @@ final class FileEnrichmentListener
 
     private function declareSysFileFields(AfterSchemaLoadEvent $event): void
     {
+        // sys_file's only sub-schema (type=1) shows `fileinfo, storage, missing`
+        // where `fileinfo` is a virtual `type: none` renderer. The actually-useful
+        // columns (name, identifier, mime_type, sha1, size, type, metadata) exist
+        // in TCA but are referenced by no showitem in any palette because the
+        // backend displays them through the `fileinfo` control. Pull them in here
+        // so the LLM can filter and read by them.
+        $columns = $GLOBALS['TCA']['sys_file']['columns'] ?? [];
+        foreach (['name', 'identifier', 'type', 'mime_type', 'sha1', 'size', 'metadata'] as $name) {
+            if (isset($columns[$name]) && !$event->hasField($name)) {
+                $event->addField($name, $columns[$name]);
+            }
+        }
+
         $event->addField('public_url', [
             'label' => 'Public URL',
             'description' => 'Resolved frontend URL of the file. Computed read-only.',

--- a/Classes/EventListener/FileEnrichmentListener.php
+++ b/Classes/EventListener/FileEnrichmentListener.php
@@ -47,6 +47,7 @@ final class FileEnrichmentListener
         match ($event->getTable()) {
             'sys_file' => $this->declareSysFileFields($event),
             'sys_file_reference' => $this->declareSysFileReferenceFields($event),
+            'sys_file_metadata' => $this->declareSysFileMetadataFields($event),
             default => null,
         };
     }
@@ -84,6 +85,24 @@ final class FileEnrichmentListener
             ],
             'mcp' => ['computed' => true],
         ]);
+    }
+
+    private function declareSysFileMetadataFields(AfterSchemaLoadEvent $event): void
+    {
+        // sys_file_metadata uses foreign type notation (`file:type`) so
+        // getAvailableFields builds a union of sub-schema showitems. The TCA
+        // also defines `file` (FK to sys_file, essential for filtering),
+        // `categories`, `width` and `height` — none of which appear in any
+        // showitem because the backend renders them through the `fileinfo`
+        // control. Pull them in so the LLM can find the metadata row for a
+        // given file (LLMs typically `ReadTable(sys_file_metadata, where:
+        // {file: <uid>})` before translating).
+        $columns = $GLOBALS['TCA']['sys_file_metadata']['columns'] ?? [];
+        foreach (['file', 'categories', 'width', 'height'] as $name) {
+            if (isset($columns[$name]) && !$event->hasField($name)) {
+                $event->addField($name, $columns[$name]);
+            }
+        }
     }
 
     private function declareSysFileReferenceFields(AfterSchemaLoadEvent $event): void

--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -288,26 +288,34 @@ class TableAccessService implements SingletonInterface
         $schema = $this->tcaSchemaFactory->get($table);
         $fields = [];
 
-        // Two cases bypass sub-schema filtering and use the full main schema:
-        //
-        // 1) Foreign type notation (e.g. "uid_local:type" on sys_file_reference): the
-        //    record type is derived from a related record at runtime, so there is no
-        //    local type column the LLM can choose. Each "type" maps to a different
-        //    palette (basicoverlayPalette vs imageoverlayPalette etc.), and picking
-        //    one would hide fields like `alternative` or `crop` even though they are
-        //    writable for any type.
-        //
-        // 2) Read-only tables (e.g. sys_file): showitem describes a backend form
-        //    layout, which is irrelevant when the LLM can only read. The user expects
-        //    the schema to advertise every column they can filter on (mime_type, sha1,
-        //    size, identifier, ...). sys_file's TCA only defines a showitem for type
-        //    "1" listing 3 fields, so a sub-schema view drops the rest.
+        // Foreign type notation (e.g. "uid_local:type" on sys_file_reference) derives
+        // the record type from a related record at runtime, so there is no local type
+        // column the LLM can choose. Each "type" maps to a different palette
+        // (basicoverlayPalette vs imageoverlayPalette etc.); restricting to one would
+        // hide fields like `alternative` or `crop` even though they are writable for
+        // any type. Build the union of all sub-schemas' fields so the schema reflects
+        // every showitem-listed column across types — and naturally excludes plumbing
+        // columns (uid_foreign, tablenames, fieldname, sorting_foreign) that no
+        // showitem references.
         $rawTypeField = $GLOBALS['TCA'][$table]['ctrl']['type'] ?? null;
         $usesForeignTypeNotation = is_string($rawTypeField) && str_contains($rawTypeField, ':');
-        $isReadOnly = $this->isTableReadOnly($table);
-        if ($usesForeignTypeNotation || $isReadOnly) {
-            foreach ($schema->getFields() as $field) {
-                $fields[$field->getName()] = $field->getConfiguration();
+        if ($usesForeignTypeNotation) {
+            $subSchemata = $schema->getSubSchemata();
+            if (count($subSchemata) > 0) {
+                foreach ($subSchemata as $subSchema) {
+                    foreach ($subSchema->getFields() as $field) {
+                        $fieldName = $field->getName();
+                        if (!isset($fields[$fieldName])) {
+                            $fields[$fieldName] = $field->getConfiguration();
+                        }
+                    }
+                }
+            } else {
+                // Defensive fallback: a foreign-type-notation table without any
+                // sub-schemas defined would otherwise return an empty list.
+                foreach ($schema->getFields() as $field) {
+                    $fields[$field->getName()] = $field->getConfiguration();
+                }
             }
         } elseif (!empty($type) && $schema->hasSubSchema($type)) {
             $subSchema = $schema->getSubSchema($type);

--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -371,7 +371,20 @@ class TableAccessService implements SingletonInterface
         // Allow extensions to add, remove, or reconfigure fields
         $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
         $event = $eventDispatcher->dispatch(new AfterSchemaLoadEvent($table, $type, $fields));
-        return $event->getFields();
+        $fields = $event->getFields();
+
+        // Re-apply field-level access restrictions to any fields added by
+        // listeners. Without this second pass, an enrichment listener that
+        // injects existing TCA columns (e.g. sys_file's `name`, `identifier`)
+        // would bypass `exclude` permissions and TCEFORM `disabled` TSconfig
+        // — the access filter must be the last word, not the first.
+        foreach ($fields as $fieldName => $fieldConfig) {
+            if (!$this->canAccessField($table, $fieldName, $type, $pid)) {
+                unset($fields[$fieldName]);
+            }
+        }
+
+        return $fields;
     }
     
     /**

--- a/Tests/Llm/ContentElementTest.php
+++ b/Tests/Llm/ContentElementTest.php
@@ -20,6 +20,7 @@ class ContentElementTest extends LlmTestCase
 
         // Import test data with pages and content
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/backend_layout.csv');
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/tt_content.csv');
     }
 

--- a/Tests/Llm/CreatePageTest.php
+++ b/Tests/Llm/CreatePageTest.php
@@ -20,6 +20,7 @@ class CreatePageTest extends LlmTestCase
 
         // Import test data with basic page structure
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/backend_layout.csv');
     }
 
     #[DataProvider('modelProvider')]

--- a/Tests/Llm/EmbeddedRelationTest.php
+++ b/Tests/Llm/EmbeddedRelationTest.php
@@ -24,6 +24,7 @@ class EmbeddedRelationTest extends LlmTestCase
         parent::setUp();
 
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/backend_layout.csv');
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/tt_content.csv');
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/sys_file.csv');
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/sys_file_reference.csv');

--- a/Tests/Llm/FileReferenceTest.php
+++ b/Tests/Llm/FileReferenceTest.php
@@ -25,6 +25,7 @@ class FileReferenceTest extends LlmTestCase
 
         // Import test data
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/backend_layout.csv');
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/tt_content.csv');
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/sys_file.csv');
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/sys_file_reference.csv');

--- a/Tests/Llm/MoveContentElementTest.php
+++ b/Tests/Llm/MoveContentElementTest.php
@@ -25,6 +25,7 @@ class MoveContentElementTest extends LlmTestCase
         parent::setUp();
 
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/backend_layout.csv');
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/tt_content.csv');
     }
 

--- a/Tests/Llm/SeoMetaTest.php
+++ b/Tests/Llm/SeoMetaTest.php
@@ -20,6 +20,7 @@ class SeoMetaTest extends LlmTestCase
 
         // Import test data with pages
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/backend_layout.csv');
     }
 
     #[DataProvider('modelProvider')]

--- a/Tests/Llm/SysFileMetadataTest.php
+++ b/Tests/Llm/SysFileMetadataTest.php
@@ -30,6 +30,7 @@ class SysFileMetadataTest extends LlmTestCase
         parent::setUp();
 
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/backend_layout.csv');
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/sys_file.csv');
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/sys_file_metadata.csv');
 

--- a/Tests/Llm/WriteTableSearchReplaceTest.php
+++ b/Tests/Llm/WriteTableSearchReplaceTest.php
@@ -23,6 +23,7 @@ class WriteTableSearchReplaceTest extends LlmTestCase
 
         // Import standard pages and the content with spelling errors
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/backend_layout.csv');
         $this->importCSVDataSet(__DIR__ . '/Fixtures/search_replace_content.csv');
     }
 


### PR DESCRIPTION
## Summary
This PR fixes schema field discovery for tables using foreign type notation and improves field exposure for file-related tables. The changes ensure that LLMs can access all relevant columns for filtering and reading, not just those visible in backend form layouts.

## Key Changes

- **TableAccessService**: Refactored field discovery logic for foreign-type-notation tables (e.g., `sys_file_reference` with `uid_local:type`). Instead of using the full main schema, now builds a union of all sub-schema fields, which naturally excludes plumbing columns while including all showitem-listed columns across types.

- **FileEnrichmentListener**: 
  - Enhanced `sys_file` field exposure by explicitly adding TCA columns (`name`, `identifier`, `type`, `mime_type`, `sha1`, `size`, `metadata`) that exist in TCA but aren't referenced by any showitem because the backend renders them through the `fileinfo` control.
  - Added new `declareSysFileMetadataFields()` method to expose hidden columns in `sys_file_metadata` (`file`, `categories`, `width`, `height`) that are essential for filtering and reading but not shown in backend forms.

- **Test Fixtures**: Added `backend_layout.csv` import to all functional test classes to ensure proper test data setup and prevent foreign key constraint violations.

## Implementation Details

The foreign-type-notation fix iterates through all sub-schemas and collects their fields, using a union approach that prevents duplicate field definitions while ensuring comprehensive field coverage. A defensive fallback returns the main schema fields if no sub-schemas are defined.

The file-related enhancements use the `AfterSchemaLoadEvent` to inject missing TCA columns into the schema, making them discoverable by LLMs for queries and filtering operations.

https://claude.ai/code/session_01GixCLu7hSJEawHzj8rn8V8