### PR TITLE
Fix ReadTable uid filter for non-workspace tables in workspace context

### DIFF
--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -251,37 +251,7 @@ class ReadTableTool extends AbstractRecordTool
         // Filter by uid(s) if specified. Single int and array are normalised
         // to a list — IN(...) handles both cases identically.
         if ($uids !== null) {
-            if ($uids === []) {
-                // The caller passed a uid filter, but every value was
-                // non-positive after sanitisation. Match nothing.
-                $queryBuilder->andWhere('1 = 0');
-            } else {
-                $currentWorkspace = $GLOBALS['BE_USER']->workspace ?? 0;
-                if ($currentWorkspace > 0) {
-                    // In workspace context, match either the live uid or the
-                    // overlay's t3ver_oid. WorkspaceDeletePlaceholderRestriction
-                    // handles delete placeholders.
-                    $queryBuilder->andWhere(
-                        $queryBuilder->expr()->or(
-                            $queryBuilder->expr()->in(
-                                'uid',
-                                $queryBuilder->createNamedParameter($uids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
-                            ),
-                            $queryBuilder->expr()->in(
-                                't3ver_oid',
-                                $queryBuilder->createNamedParameter($uids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
-                            )
-                        )
-                    );
-                } else {
-                    $queryBuilder->andWhere(
-                        $queryBuilder->expr()->in(
-                            'uid',
-                            $queryBuilder->createNamedParameter($uids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
-                        )
-                    );
-                }
-            }
+            $this->applyUidFilter($queryBuilder, $table, $uids);
         }
 
         // Apply custom condition if specified
@@ -346,32 +316,7 @@ class ReadTableTool extends AbstractRecordTool
         }
 
         if ($uids !== null) {
-            if ($uids === []) {
-                $countQueryBuilder->andWhere('1 = 0');
-            } else {
-                $currentWorkspace = $GLOBALS['BE_USER']->workspace ?? 0;
-                if ($currentWorkspace > 0) {
-                    $countQueryBuilder->andWhere(
-                        $countQueryBuilder->expr()->or(
-                            $countQueryBuilder->expr()->in(
-                                'uid',
-                                $countQueryBuilder->createNamedParameter($uids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
-                            ),
-                            $countQueryBuilder->expr()->in(
-                                't3ver_oid',
-                                $countQueryBuilder->createNamedParameter($uids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
-                            )
-                        )
-                    );
-                } else {
-                    $countQueryBuilder->andWhere(
-                        $countQueryBuilder->expr()->in(
-                            'uid',
-                            $countQueryBuilder->createNamedParameter($uids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
-                        )
-                    );
-                }
-            }
+            $this->applyUidFilter($countQueryBuilder, $table, $uids);
         }
 
         if (!empty($condition)) {
@@ -429,6 +374,52 @@ class ReadTableTool extends AbstractRecordTool
             'offset' => $offset,
             'hasMore' => ($offset + count($records)) < $totalCount,
         ];
+    }
+
+    /**
+     * Apply the uid filter to a QueryBuilder.
+     *
+     * In a workspace, a logical record may be addressed either by its live
+     * uid or by a workspace overlay row whose `t3ver_oid` points at that
+     * live uid. We OR both sides so a uid lookup hits new-in-workspace
+     * placeholders too. That OR branch only makes sense — and only compiles —
+     * on workspace-capable tables; for tables without versioningWS the
+     * t3ver_oid column doesn't exist, so we fall back to a plain uid IN(...).
+     */
+    protected function applyUidFilter(QueryBuilder $queryBuilder, string $table, array $uids): void
+    {
+        if ($uids === []) {
+            // Caller passed a uid filter, but every value was non-positive
+            // after sanitisation. Match nothing.
+            $queryBuilder->andWhere('1 = 0');
+            return;
+        }
+
+        $isWorkspaceCapable = !empty($GLOBALS['TCA'][$table]['ctrl']['versioningWS'] ?? false);
+        $currentWorkspace = (int)($GLOBALS['BE_USER']->workspace ?? 0);
+
+        if ($currentWorkspace > 0 && $isWorkspaceCapable) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->or(
+                    $queryBuilder->expr()->in(
+                        'uid',
+                        $queryBuilder->createNamedParameter($uids, Connection::PARAM_INT_ARRAY)
+                    ),
+                    $queryBuilder->expr()->in(
+                        't3ver_oid',
+                        $queryBuilder->createNamedParameter($uids, Connection::PARAM_INT_ARRAY)
+                    )
+                )
+            );
+            return;
+        }
+
+        $queryBuilder->andWhere(
+            $queryBuilder->expr()->in(
+                'uid',
+                $queryBuilder->createNamedParameter($uids, Connection::PARAM_INT_ARRAY)
+            )
+        );
     }
 
     /**

--- a/Tests/Functional/MCP/Tool/ReadTableNonWorkspaceTableTest.php
+++ b/Tests/Functional/MCP/Tool/ReadTableNonWorkspaceTableTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use Hn\McpServer\Event\BeforeRecordReadEvent;
+use Hn\McpServer\MCP\Tool\Record\ReadTableTool;
+use Hn\McpServer\Service\WorkspaceContextService;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Verify that ReadTable works on non-workspace tables that are exposed
+ * via additionalReadOnlyTables (e.g. sys_file) even while the backend user
+ * is operating inside a workspace.
+ *
+ * Regression: when the user was in a workspace, ReadTable's uid filter
+ * referenced the workspace-only column t3ver_oid via an OR clause. For
+ * tables without versioningWS that column does not exist, so MySQL/MariaDB
+ * aborted the query with "Unknown column 't3ver_oid'", surfaced to the
+ * caller as "Failed to count record" / "Failed to select record".
+ *
+ * The generated SQL is asserted here — SQLite's "double-quoted identifier
+ * falls back to string literal" quirk would otherwise hide the missing
+ * column on the functional test database and let the broken SQL execute.
+ */
+class ReadTableNonWorkspaceTableTest extends AbstractFunctionalTest
+{
+    private ReadTableTool $readTool;
+    private WorkspaceContextService $workspaceService;
+    private EventDispatcherInterface $originalDispatcher;
+    private CapturingEventDispatcher $capturingDispatcher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->readTool = new ReadTableTool();
+        $this->workspaceService = GeneralUtility::makeInstance(WorkspaceContextService::class);
+
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/sys_file.csv');
+
+        $this->originalDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        $this->capturingDispatcher = new CapturingEventDispatcher($this->originalDispatcher);
+        GeneralUtility::setSingletonInstance(EventDispatcherInterface::class, $this->capturingDispatcher);
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::setSingletonInstance(EventDispatcherInterface::class, $this->originalDispatcher);
+        parent::tearDown();
+    }
+
+    public function testReadNonWorkspaceTableByUidInWorkspaceContextProducesNoWorkspaceColumnsInSql(): void
+    {
+        $this->workspaceService->switchToOptimalWorkspace($GLOBALS['BE_USER']);
+        $this->assertGreaterThan(
+            0,
+            $GLOBALS['BE_USER']->workspace,
+            'Test prerequisite: backend user must be inside a workspace.'
+        );
+
+        $result = $this->readTool->execute([
+            'table' => 'sys_file',
+            'uid' => 1,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $captured = $this->capturingDispatcher->capturedSqlForTable('sys_file');
+        $this->assertArrayHasKey('count', $captured, 'Count query should have been dispatched.');
+        $this->assertArrayHasKey('select', $captured, 'Select query should have been dispatched.');
+
+        foreach ($captured as $type => $sql) {
+            $this->assertStringNotContainsString(
+                't3ver_oid',
+                $sql,
+                "The {$type} query against a non-workspace table must not reference t3ver_oid; "
+                . "this column does not exist on sys_file and the reference breaks MySQL/MariaDB. SQL: {$sql}"
+            );
+            $this->assertStringNotContainsString('t3ver_wsid', $sql, "Got SQL: {$sql}");
+            $this->assertStringNotContainsString('t3ver_state', $sql, "Got SQL: {$sql}");
+        }
+    }
+
+    public function testReadNonWorkspaceTableByUidInWorkspaceContextReturnsRecord(): void
+    {
+        $this->workspaceService->switchToOptimalWorkspace($GLOBALS['BE_USER']);
+        $this->assertGreaterThan(0, $GLOBALS['BE_USER']->workspace);
+
+        $result = $this->readTool->execute([
+            'table' => 'sys_file',
+            'uid' => 1,
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $payload = json_decode($result->content[0]->text, true);
+        $this->assertSame(1, $payload['total']);
+        $this->assertCount(1, $payload['records']);
+        $this->assertSame(1, $payload['records'][0]['uid']);
+    }
+
+    public function testReadNonWorkspaceTableByMultipleUidsInWorkspaceContextReturnsRecords(): void
+    {
+        $this->workspaceService->switchToOptimalWorkspace($GLOBALS['BE_USER']);
+        $this->assertGreaterThan(0, $GLOBALS['BE_USER']->workspace);
+
+        $result = $this->readTool->execute([
+            'table' => 'sys_file',
+            'uid' => [1, 3],
+        ]);
+
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $payload = json_decode($result->content[0]->text, true);
+        $this->assertSame(2, $payload['total']);
+        $uids = array_column($payload['records'], 'uid');
+        sort($uids);
+        $this->assertSame([1, 3], $uids);
+    }
+}
+
+/**
+ * Test-only PSR-14 dispatcher decorator that records the SQL emitted on
+ * every BeforeRecordReadEvent, then forwards the event to the real
+ * dispatcher so production listeners (mount restrictions, etc.) still run.
+ */
+final class CapturingEventDispatcher implements EventDispatcherInterface, SingletonInterface
+{
+    /** @var array<string, array<string, string>> Keyed by table → query type → SQL */
+    private array $sqlByTable = [];
+
+    public function __construct(private readonly EventDispatcherInterface $inner) {}
+
+    public function dispatch(object $event): object
+    {
+        if ($event instanceof BeforeRecordReadEvent) {
+            $this->sqlByTable[$event->getTable()][$event->getQueryType()] = $event->getQueryBuilder()->getSQL();
+        }
+        return $this->inner->dispatch($event);
+    }
+
+    /** @return array<string, string> */
+    public function capturedSqlForTable(string $table): array
+    {
+        return $this->sqlByTable[$table] ?? [];
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a regression where ReadTable would fail when querying non-workspace tables (like `sys_file`) while a backend user is operating in a workspace context. The tool was unconditionally referencing the `t3ver_oid` column in an OR clause, which doesn't exist on tables without `versioningWS` enabled, causing MySQL/MariaDB to abort with "Unknown column" errors.

## Changes
- **Extracted uid filter logic** into a new `applyUidFilter()` method in `ReadTableTool` to eliminate code duplication between the main query and count query
- **Added workspace capability check** that inspects `$GLOBALS['TCA'][$table]['ctrl']['versioningWS']` before referencing workspace-specific columns
- **Conditional workspace handling**: Only applies the `t3ver_oid` OR clause for workspace-capable tables; falls back to plain `uid IN(...)` for non-workspace tables
- **Added comprehensive test coverage** with `ReadTableNonWorkspaceTableTest` that:
  - Verifies SQL queries don't reference workspace columns for non-workspace tables
  - Confirms records are correctly returned when querying by single and multiple uids
  - Uses a custom event dispatcher to capture and assert the generated SQL

## Implementation Details
The fix checks the TCA configuration at query time to determine if a table supports versioning. This allows the same ReadTable tool to safely handle both workspace-capable tables (like `pages`, `tt_content`) and non-workspace tables (like `sys_file`) regardless of the current user's workspace context.

https://claude.ai/code/session_01A8eL3TqwkzT8sikK9brbW6