### PR TITLE
Replace deprecated FlexFormService with FlexFormTools

### DIFF
--- a/Classes/MCP/Tool/Record/GetFlexFormSchemaTool.php
+++ b/Classes/MCP/Tool/Record/GetFlexFormSchemaTool.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hn\McpServer\MCP\Tool\Record;
 
 use Mcp\Types\CallToolResult;
-use TYPO3\CMS\Core\Service\FlexFormService;
+use TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Hn\McpServer\Utility\TcaFormattingUtility;
 use Hn\McpServer\Service\TableAccessService;
@@ -691,13 +691,13 @@ class GetFlexFormSchemaTool extends AbstractRecordTool
                 if (file_exists($file)) {
                     $content = file_get_contents($file);
                     if (!empty($content)) {
-                        $flexFormService = GeneralUtility::makeInstance(FlexFormService::class);
-                        return $flexFormService->convertFlexFormContentToArray($content);
+                        $flexFormTools = GeneralUtility::makeInstance(FlexFormTools::class);
+                        return $flexFormTools->convertFlexFormContentToArray($content);
                     }
                 }
             } elseif (is_string($flexFormDS)) {
-                $flexFormService = GeneralUtility::makeInstance(FlexFormService::class);
-                return $flexFormService->convertFlexFormContentToArray($flexFormDS);
+                $flexFormTools = GeneralUtility::makeInstance(FlexFormTools::class);
+                return $flexFormTools->convertFlexFormContentToArray($flexFormDS);
             } elseif (is_array($flexFormDS)) {
                 return $flexFormDS;
             }

--- a/Classes/MCP/Tool/Record/GetFlexFormSchemaTool.php
+++ b/Classes/MCP/Tool/Record/GetFlexFormSchemaTool.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Hn\McpServer\MCP\Tool\Record;
 
 use Mcp\Types\CallToolResult;
-use TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Hn\McpServer\Utility\TcaFormattingUtility;
 use Hn\McpServer\Service\TableAccessService;
@@ -691,13 +690,13 @@ class GetFlexFormSchemaTool extends AbstractRecordTool
                 if (file_exists($file)) {
                     $content = file_get_contents($file);
                     if (!empty($content)) {
-                        $flexFormTools = GeneralUtility::makeInstance(FlexFormTools::class);
-                        return $flexFormTools->convertFlexFormContentToArray($content);
+                        $flexFormService = $this->getFlexFormService();
+                        return $flexFormService->convertFlexFormContentToArray($content);
                     }
                 }
             } elseif (is_string($flexFormDS)) {
-                $flexFormTools = GeneralUtility::makeInstance(FlexFormTools::class);
-                return $flexFormTools->convertFlexFormContentToArray($flexFormDS);
+                $flexFormService = $this->getFlexFormService();
+                return $flexFormService->convertFlexFormContentToArray($flexFormDS);
             } elseif (is_array($flexFormDS)) {
                 return $flexFormDS;
             }
@@ -738,6 +737,23 @@ class GetFlexFormSchemaTool extends AbstractRecordTool
         }
 
         return $result;
+    }
+
+    /**
+     * Get the FlexForm service in a backwards-compatible way.
+     *
+     * TYPO3 14.3+ uses FlexFormTools, TYPO3 13.4 uses FlexFormService.
+     * Both classes have the same method signatures.
+     *
+     * @return object FlexFormTools or FlexFormService instance
+     */
+    protected function getFlexFormService(): object
+    {
+        $class = \TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools::class;
+        if (!class_exists($class)) {
+            $class = \TYPO3\CMS\Core\Service\FlexFormService::class;
+        }
+        return GeneralUtility::makeInstance($class);
     }
 
 }

--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -19,7 +19,7 @@ use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
 use Hn\McpServer\Database\Query\Restriction\WorkspaceDeletePlaceholderRestriction;
 use Hn\McpServer\Service\LanguageService;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Core\Service\FlexFormService;
+use TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -588,11 +588,9 @@ class ReadTableTool extends AbstractRecordTool
         // Convert FlexForm XML to JSON
         if ($this->tableAccessService->isFlexFormField($table, $field) && is_string($value) && !empty($value) && strpos($value, '<?xml') === 0) {
             try {
-                // Use TYPO3's FlexFormService to convert XML to array. The
-                // class is aliased to FlexFormTools in TYPO3 14 (#107945) but
-                // the method signature is identical.
-                $flexFormService = GeneralUtility::makeInstance(FlexFormService::class);
-                $flexFormArray = $flexFormService->convertFlexFormContentToArray($value);
+                // Use TYPO3's FlexFormTools to convert XML to array.
+                $flexFormTools = GeneralUtility::makeInstance(FlexFormTools::class);
+                $flexFormArray = $flexFormTools->convertFlexFormContentToArray($value);
 
                 // Simplify the structure for easier use in LLMs
                 $result = [];

--- a/Classes/MCP/Tool/Record/ReadTableTool.php
+++ b/Classes/MCP/Tool/Record/ReadTableTool.php
@@ -19,7 +19,6 @@ use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
 use Hn\McpServer\Database\Query\Restriction\WorkspaceDeletePlaceholderRestriction;
 use Hn\McpServer\Service\LanguageService;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -588,9 +587,9 @@ class ReadTableTool extends AbstractRecordTool
         // Convert FlexForm XML to JSON
         if ($this->tableAccessService->isFlexFormField($table, $field) && is_string($value) && !empty($value) && strpos($value, '<?xml') === 0) {
             try {
-                // Use TYPO3's FlexFormTools to convert XML to array.
-                $flexFormTools = GeneralUtility::makeInstance(FlexFormTools::class);
-                $flexFormArray = $flexFormTools->convertFlexFormContentToArray($value);
+                // Use TYPO3's FlexForm service to convert XML to array.
+                $flexFormService = $this->getFlexFormService();
+                $flexFormArray = $flexFormService->convertFlexFormContentToArray($value);
 
                 // Simplify the structure for easier use in LLMs
                 $result = [];
@@ -1259,6 +1258,23 @@ class ReadTableTool extends AbstractRecordTool
         }
 
         return $indexedRecords;
+    }
+
+    /**
+     * Get the FlexForm service in a backwards-compatible way.
+     *
+     * TYPO3 14.3+ uses FlexFormTools, TYPO3 13.4 uses FlexFormService.
+     * Both classes have the same method signatures.
+     *
+     * @return object FlexFormTools or FlexFormService instance
+     */
+    protected function getFlexFormService(): object
+    {
+        $class = \TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools::class;
+        if (!class_exists($class)) {
+            $class = \TYPO3\CMS\Core\Service\FlexFormService::class;
+        }
+        return GeneralUtility::makeInstance($class);
     }
 
 }


### PR DESCRIPTION
This PR addresses TYPO3 v14.3 deprecation #107945 by replacing the deprecated TYPO3\CMS\Core\Service\FlexFormService with the new TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools class.

What was fixed:

The FlexFormService class has been merged into FlexFormTools in TYPO3 v14, and the old class will be removed in TYPO3 v15. The method signatures remain compatible, but the class namespace has changed.

Files changed:

- Classes/MCP/Tool/Record/GetFlexFormSchemaTool.php - Updated import and method instantiations
- Classes/MCP/Tool/Record/ReadTableTool.php - Updated import and method instantiations

This ensures the extension is compatible with TYPO3 v14+ and future versions.