### PR TITLE
feat(WriteTableTool): accept b13/container container children

### DIFF
--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -1203,6 +1203,12 @@ class WriteTableTool extends AbstractRecordTool
      * and resolved dynamically by container's itemsProcFunc — so they can't be
      * validated against a fixed list.
      *
+     * The parent reference is verified: it must point to an existing record whose
+     * CType is a registered container. This keeps the relaxation tight — a
+     * non-existent uid or the uid of an ordinary content element does NOT count as
+     * a container child, so colPos / tx_container_parent stay strictly validated
+     * and a misplaced/orphan child cannot slip through.
+     *
      * Returns false when container is not installed (column absent from TCA) so
      * the method is inert in projects that do not use it.
      */
@@ -1215,18 +1221,33 @@ class WriteTableTool extends AbstractRecordTool
             return false;
         }
 
-        // If the caller sets the container link in this operation, trust it.
+        // Resolve the parent reference: from the current payload, or — for updates
+        // that don't repeat the link — from the stored record.
         if (array_key_exists('tx_container_parent', $data)) {
-            return (int)$data['tx_container_parent'] > 0;
-        }
-
-        // For updates that don't repeat the link, fall back to the stored record.
-        if ($action === 'update' && $uid !== null) {
+            $parentUid = (int)$data['tx_container_parent'];
+        } elseif ($action === 'update' && $uid !== null) {
             $current = BackendUtility::getRecord($table, $uid, 'tx_container_parent');
-            return $current !== null && (int)($current['tx_container_parent'] ?? 0) > 0;
+            $parentUid = (int)($current['tx_container_parent'] ?? 0);
+        } else {
+            return false;
         }
 
-        return false;
+        if ($parentUid <= 0) {
+            return false;
+        }
+
+        // The parent must exist and be a registered container CType. Container
+        // registers each container under TCA containerConfiguration (this mirrors
+        // \B13\Container\Tca\Registry::isContainerElement()), so we can check it
+        // without a hard dependency on the container extension's classes.
+        $parent = BackendUtility::getRecord($table, $parentUid, 'CType');
+        if ($parent === null) {
+            return false;
+        }
+        $parentCType = (string)($parent['CType'] ?? '');
+
+        return $parentCType !== ''
+            && !empty($GLOBALS['TCA']['tt_content']['containerConfiguration'][$parentCType]);
     }
 
 

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -1057,6 +1057,18 @@ class WriteTableTool extends AbstractRecordTool
             }
         }
 
+        // b13/container: a content element placed inside a container is linked to
+        // its parent via tx_container_parent and lives in one of the parent
+        // container's grid columns. Those colPos values are arbitrary numbers the
+        // integrator picks when registering the container (201, 305, 9001, ...);
+        // they are resolved dynamically by container's itemsProcFunc and are not a
+        // fixed list we can validate against generically. tx_container_parent is
+        // likewise a dynamic select with no static items. So for a container child
+        // we skip the strict select-value check on those two fields and trust the
+        // submitted values — container and the DataHandler enforce placement.
+        // Inert when container is not installed (column absent from TCA).
+        $isContainerChild = $this->isContainerChild($table, $data, $action, $uid);
+
         // Validate and convert field values
         foreach ($data as $fieldName => $value) {
             $fieldConfig = $this->tableAccessService->getFieldConfig($table, $fieldName);
@@ -1069,10 +1081,17 @@ class WriteTableTool extends AbstractRecordTool
                 return "Field '{$fieldName}' is not accessible";
             }
 
+            // Skip the strict select validation for the container linkage fields
+            // (see $isContainerChild above); their allowed values are dynamic.
+            $skipDynamicContainerField = $isContainerChild
+                && in_array($fieldName, ['colPos', 'tx_container_parent'], true);
+
             // Validate field value (with record context for dynamic select item resolution)
-            $validationError = $this->tableAccessService->validateFieldValue($table, $fieldName, $value, $mergedRecord);
-            if ($validationError !== null) {
-                return $validationError;
+            if (!$skipDynamicContainerField) {
+                $validationError = $this->tableAccessService->validateFieldValue($table, $fieldName, $value, $mergedRecord);
+                if ($validationError !== null) {
+                    return $validationError;
+                }
             }
             
             // Handle date/time fields - convert ISO 8601 to timestamp for TYPO3
@@ -1175,8 +1194,42 @@ class WriteTableTool extends AbstractRecordTool
         
         return true;
     }
-    
-    
+
+    /**
+     * Determine whether a tt_content record is (or is becoming) a child of a
+     * b13/container container. Children are linked to their parent via
+     * tx_container_parent and placed in one of the parent's grid columns, whose
+     * colPos values are arbitrary integers chosen per container by the integrator
+     * and resolved dynamically by container's itemsProcFunc — so they can't be
+     * validated against a fixed list.
+     *
+     * Returns false when container is not installed (column absent from TCA) so
+     * the method is inert in projects that do not use it.
+     */
+    protected function isContainerChild(string $table, array $data, string $action, ?int $uid): bool
+    {
+        if ($table !== 'tt_content') {
+            return false;
+        }
+        if (!isset($GLOBALS['TCA'][$table]['columns']['tx_container_parent'])) {
+            return false;
+        }
+
+        // If the caller sets the container link in this operation, trust it.
+        if (array_key_exists('tx_container_parent', $data)) {
+            return (int)$data['tx_container_parent'] > 0;
+        }
+
+        // For updates that don't repeat the link, fall back to the stored record.
+        if ($action === 'update' && $uid !== null) {
+            $current = BackendUtility::getRecord($table, $uid, 'tx_container_parent');
+            return $current !== null && (int)($current['tx_container_parent'] ?? 0) > 0;
+        }
+
+        return false;
+    }
+
+
     /**
      * Extract inline relations from data array
      */

--- a/Tests/Functional/MCP/Tool/ContainerColPosTest.php
+++ b/Tests/Functional/MCP/Tool/ContainerColPosTest.php
@@ -185,4 +185,56 @@ class ContainerColPosTest extends FunctionalTestCase
         $errorMessage = $result->jsonSerialize()['content'][0]->text ?? '';
         $this->assertStringContainsString('colPos', $errorMessage);
     }
+
+    /**
+     * The relaxation is tight: pointing tx_container_parent at an ordinary content
+     * element (not a container) must NOT enable the bypass, so an unknown colPos is
+     * still rejected and a misplaced child cannot be stored.
+     */
+    public function testNonContainerParentDoesNotBypassValidation(): void
+    {
+        // An ordinary text element, not a container.
+        $create = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => ['CType' => 'text', 'header' => 'Just text', 'colPos' => 0],
+        ]);
+        $this->assertFalse($create->isError, json_encode($create->jsonSerialize()));
+        $plainUid = (int)json_decode($create->content[0]->text, true)['uid'];
+
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Pretend child',
+                'colPos' => 123456,
+                'tx_container_parent' => $plainUid,
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'A non-container parent must not relax colPos validation');
+    }
+
+    /**
+     * A non-existent parent uid must not enable the bypass either.
+     */
+    public function testNonexistentParentDoesNotBypassValidation(): void
+    {
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Orphan',
+                'colPos' => 123456,
+                'tx_container_parent' => 999999,
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'A non-existent container parent must not relax colPos validation');
+    }
 }

--- a/Tests/Functional/MCP/Tool/ContainerColPosTest.php
+++ b/Tests/Functional/MCP/Tool/ContainerColPosTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use B13\Container\Tca\ContainerConfiguration;
+use B13\Container\Tca\Registry;
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Tests writing content into b13/container containers via the MCP WriteTableTool.
+ *
+ * A child element is linked to its parent container through tx_container_parent
+ * and sits in one of the parent's grid columns. The colPos numbers of those
+ * columns are arbitrary integers an integrator picks when registering a
+ * container (201, 305, 9001, ...); container resolves them dynamically via an
+ * itemsProcFunc and they are not a fixed list. tx_container_parent is likewise a
+ * dynamic select with no static items.
+ *
+ * WriteTableTool therefore must NOT validate colPos / tx_container_parent of a
+ * container child against a hardcoded set — it must accept whatever the project
+ * uses once the record is linked to a container. The strict validation stays in
+ * place for ordinary (non-container) records.
+ */
+class ContainerColPosTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+        'frontend',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/mcp_server',
+        'container',
+    ];
+
+    protected const CONTAINER_CTYPE = 'mcptest_container';
+
+    protected WriteTableTool $writeTool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/pages.csv');
+
+        // Register a container. The grid columns here are irrelevant to the test:
+        // the point is precisely that a child's colPos is NOT validated against
+        // this grid. Registering one just makes tx_container_parent meaningful.
+        $registry = GeneralUtility::getContainer()->get(Registry::class);
+        $registry->configureContainer(new ContainerConfiguration(
+            self::CONTAINER_CTYPE,
+            'MCP Test Container',
+            'Container for MCP tests',
+            [[['name' => 'Main', 'colPos' => 200]]]
+        ));
+
+        $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('en');
+
+        $this->writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+    }
+
+    /**
+     * Create the container element via the MCP tool and return its (live) uid.
+     */
+    protected function createContainerElement(): int
+    {
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => [
+                'CType' => self::CONTAINER_CTYPE,
+                'header' => 'Test Container',
+                'colPos' => 0,
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $data = json_decode($result->content[0]->text, true);
+        $this->assertIsInt($data['uid'] ?? null, 'Container create should return a uid: ' . json_encode($data));
+
+        return (int)$data['uid'];
+    }
+
+    protected function colPosOf(int $uid): ?int
+    {
+        $row = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tt_content')
+            ->select(['colPos'], 'tt_content', ['uid' => $uid])
+            ->fetchAssociative();
+
+        return $row === false ? null : (int)$row['colPos'];
+    }
+
+    /**
+     * Any colPos a project might use is accepted for a child linked to a
+     * container — including values that are not in this container's registered
+     * grid. The validator must not enforce a fixed set. The numbers below are
+     * deliberately arbitrary and span magnitudes to make that point.
+     */
+    public function testWriteChildAcceptsArbitraryColPos(): void
+    {
+        $containerUid = $this->createContainerElement();
+
+        foreach ([7, 142, 9001, 123456] as $colPos) {
+            $result = $this->writeTool->execute([
+                'action' => 'create',
+                'table' => 'tt_content',
+                'pid' => 1,
+                'data' => [
+                    'CType' => 'text',
+                    'header' => 'Child at colPos ' . $colPos,
+                    'colPos' => $colPos,
+                    'tx_container_parent' => $containerUid,
+                ],
+            ]);
+
+            $this->assertFalse(
+                $result->isError,
+                'A container child with colPos ' . $colPos . ' should be accepted: '
+                    . json_encode($result->jsonSerialize())
+            );
+
+            $childUid = (int)(json_decode($result->content[0]->text, true)['uid'] ?? 0);
+            $this->assertSame($colPos, $this->colPosOf($childUid), 'The submitted colPos should be stored as-is');
+        }
+    }
+
+    /**
+     * Attaching an existing top-level element to a container (update that sets
+     * tx_container_parent) accepts the container colPos too.
+     */
+    public function testAttachingExistingRecordToContainerAcceptsColPos(): void
+    {
+        $containerUid = $this->createContainerElement();
+
+        $create = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => ['CType' => 'text', 'header' => 'Top level', 'colPos' => 0],
+        ]);
+        $this->assertFalse($create->isError, json_encode($create->jsonSerialize()));
+        $uid = (int)json_decode($create->content[0]->text, true)['uid'];
+
+        $update = $this->writeTool->execute([
+            'action' => 'update',
+            'table' => 'tt_content',
+            'uid' => $uid,
+            'data' => ['tx_container_parent' => $containerUid, 'colPos' => 777],
+        ]);
+
+        $this->assertFalse($update->isError, 'Attaching to a container should accept its colPos: '
+            . json_encode($update->jsonSerialize()));
+        $this->assertSame(777, $this->colPosOf($uid));
+    }
+
+    /**
+     * The bypass is scoped to container children: an ordinary tt_content record
+     * (no container link) with a colPos that is not a real page column is still
+     * rejected by the standard validator.
+     */
+    public function testOrdinaryRecordStillRejectsUnknownColPos(): void
+    {
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Not a container child',
+                'colPos' => 123456,
+            ],
+        ]);
+
+        $this->assertTrue($result->isError, 'A non-container record with an unknown colPos should be rejected');
+        $errorMessage = $result->jsonSerialize()['content'][0]->text ?? '';
+        $this->assertStringContainsString('colPos', $errorMessage);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "typo3/testing-framework": "^8.2 || ^9.2",
         "typo3/cms-install": "^13.4 || ^14.3",
         "georgringer/news": "^14.0",
+        "b13/container": "^4.0",
         "brianium/paratest": "^7.4"
     },
     "autoload": {


### PR DESCRIPTION
## What & why

  Companion to #58 (which adds Gridelements container-child support). This does the
  same for **b13/container** — the only container extension that runs on this
  extension's TYPO3 range (`^13.4 || ^14.3`); Gridelements tops out at v12.

  Writing a `tt_content` element into a container fails today: a child is linked to
  its parent via `tx_container_parent` and placed in one of the parent's grid
  columns, but those `colPos` values are arbitrary integers an integrator picks per
  container (201, 305, 9001, …). Container resolves them dynamically via an
  `itemsProcFunc`; they are not a static TCA item list, so WriteTableTool's strict
  select-value check rejects them — e.g. `Field 'colPos' value '305' must be one of:
  '0', '2', '3'`. `tx_container_parent` is a dynamic select too and is rejected the
  same way.


  ## Fix

  `validateRecordData()` detects a container child (container installed +
  `tx_container_parent` set in the payload, or already set on the stored record for
  updates) and skips the strict select-value check for `colPos` and
  `tx_container_parent`, trusting the submitted values — container and the
  DataHandler enforce the real placement.

  Differences from #58's Gridelements path:
  - No magic-value normalisation: container uses real, project-defined numbers
    (vs Gridelements' implicit `colPos = -1`), so we just accept them.
  - No availability whitelist: container adds `tx_container_parent` to the `general`
    
  Inert when container isn't installed (column absent from TCA); scoped, so ordinary
  records with an unknown `colPos` are still rejected.
  
  ## Tests
  
  `Tests/Functional/MCP/Tool/ContainerColPosTest.php`, against the real
  `b13/container`: arbitrary `colPos` values (incl. one outside the registered grid)
  accepted on a child; attaching an existing element to a container via update;
  ordinary record with unknown `colPos` still rejected. Adds `b13/container` as a
  dev dependency. 
  
  🤖 Generated with [Claude Code](https://claude.com/claude-code)