### PR TITLE
Fix SelectItemResolver to pass record context to itemsProcFunc

### DIFF
--- a/Classes/Service/SelectItemResolver.php
+++ b/Classes/Service/SelectItemResolver.php
@@ -87,13 +87,13 @@ class SelectItemResolver
     private function compileFormData(string $table, array $record): array
     {
         $pid = (int)($record['pid'] ?? 0);
-        $defaultValues = $this->extractDefaultValues($table, $record);
+        $rowValues = $this->extractRowValues($table, $record);
 
         // The cache must key on the full record context, not just table:pid:
         // itemsProcFunc results can differ for two records on the same page
         // (e.g. depending on tx_container_parent or CType), so a table:pid key
         // would hand back a stale item list for a different record.
-        $cacheKey = $table . ':' . $pid . ':' . md5(serialize($defaultValues));
+        $cacheKey = $table . ':' . $pid . ':' . md5(serialize($rowValues));
 
         if (isset($this->cache[$cacheKey])) {
             return $this->cache[$cacheKey];
@@ -109,7 +109,10 @@ class SelectItemResolver
             'tableName' => $table,
             'vanillaUid' => $pid,
             'command' => 'new',
-            'defaultValues' => $defaultValues === [] ? [] : [$table => $defaultValues],
+            // FormEngine seeds these into the databaseRow (the &defVals mechanism).
+            // Empty when no record context is given (e.g. schema display), which
+            // makes this a plain blank "new" record exactly as before.
+            'defaultValues' => $rowValues === [] ? [] : [$table => $rowValues],
         ];
 
         // Because we seed the record's own field values (above), FormEngine would
@@ -164,19 +167,20 @@ class SelectItemResolver
     }
 
     /**
-     * Reduce the record context to the scalar field values that can be seeded as
-     * FormEngine default values. Non-scalar values (inline/file collections, etc.)
-     * and the pid (handled separately via vanillaUid) are dropped: they are never
-     * itemsProcFunc inputs and could trip up the compiler pipeline.
+     * Reduce the record context to the scalar field values to seed into the form's
+     * databaseRow, so itemsProcFunc callbacks see the record they are resolving for.
+     * Non-scalar values (inline/file collections, etc.) and the pid (handled
+     * separately via vanillaUid) are dropped: they are never itemsProcFunc inputs
+     * and could trip up the compiler pipeline.
      *
      * @param string $table Table name
      * @param array $record Record context
      * @return array<string, scalar> Field name => value
      */
-    private function extractDefaultValues(string $table, array $record): array
+    private function extractRowValues(string $table, array $record): array
     {
         $columns = $GLOBALS['TCA'][$table]['columns'] ?? [];
-        $defaultValues = [];
+        $rowValues = [];
         foreach ($record as $fieldName => $value) {
             if ($fieldName === 'pid') {
                 continue;
@@ -187,10 +191,10 @@ class SelectItemResolver
             if (!isset($columns[$fieldName])) {
                 continue;
             }
-            $defaultValues[$fieldName] = $value;
+            $rowValues[$fieldName] = $value;
         }
 
-        return $defaultValues;
+        return $rowValues;
     }
 
     /**

--- a/Classes/Service/SelectItemResolver.php
+++ b/Classes/Service/SelectItemResolver.php
@@ -71,6 +71,15 @@ class SelectItemResolver
     /**
      * Compile form data using TYPO3's FormDataCompiler.
      *
+     * The record's field values are fed into the compiler as "defaultValues"
+     * (the same mechanism the backend uses for &defVals[...] when opening a new
+     * record). DatabaseRowInitializeNew copies these into the databaseRow, which
+     * is what itemsProcFunc callbacks receive as $parameters['row']. Without this,
+     * dynamic select fields whose items depend on sibling field values cannot be
+     * resolved — e.g. b13/container's tt_content.colPos itemsProcFunc reads
+     * tx_container_parent (and the current colPos) off the row to expose the
+     * container's grid columns.
+     *
      * @param string $table Table name
      * @param array $record Record context for databaseRow and pid resolution
      * @return array The compiled form data
@@ -78,7 +87,13 @@ class SelectItemResolver
     private function compileFormData(string $table, array $record): array
     {
         $pid = (int)($record['pid'] ?? 0);
-        $cacheKey = $table . ':' . $pid;
+        $defaultValues = $this->extractDefaultValues($table, $record);
+
+        // The cache must key on the full record context, not just table:pid:
+        // itemsProcFunc results can differ for two records on the same page
+        // (e.g. depending on tx_container_parent or CType), so a table:pid key
+        // would hand back a stale item list for a different record.
+        $cacheKey = $table . ':' . $pid . ':' . md5(serialize($defaultValues));
 
         if (isset($this->cache[$cacheKey])) {
             return $this->cache[$cacheKey];
@@ -94,12 +109,88 @@ class SelectItemResolver
             'tableName' => $table,
             'vanillaUid' => $pid,
             'command' => 'new',
+            'defaultValues' => $defaultValues === [] ? [] : [$table => $defaultValues],
         ];
 
-        $result = $formDataCompiler->compile($input, $formDataGroup);
+        // Because we seed the record's own field values (above), FormEngine would
+        // otherwise echo any seeded select value back as a "[ invalid value ]"
+        // pseudo-item (TcaSelectItems::addInvalidItemsFromDatabase) so the backend
+        // form does not silently drop an out-of-range stored value. For *validation*
+        // that is exactly wrong: it would make every submitted value resolve as
+        // "allowed". We want the canonical item set, so suppress that affordance.
+        $restoreTca = $this->disableNoMatchingValueElement($table);
+        try {
+            $result = $formDataCompiler->compile($input, $formDataGroup);
+        } finally {
+            $restoreTca();
+        }
         $this->cache[$cacheKey] = $result;
 
         return $result;
+    }
+
+    /**
+     * Temporarily set disableNoMatchingValueElement on every select column of the
+     * table so the compiler does not add the seeded value back as an invalid
+     * pseudo-item. Returns a restore closure to revert the TCA afterwards.
+     *
+     * @return callable(): void
+     */
+    private function disableNoMatchingValueElement(string $table): callable
+    {
+        $columns = &$GLOBALS['TCA'][$table]['columns'];
+        if (!is_array($columns)) {
+            return static function (): void {};
+        }
+
+        $originals = [];
+        foreach ($columns as $fieldName => $fieldConfig) {
+            if (($fieldConfig['config']['type'] ?? '') !== 'select') {
+                continue;
+            }
+            $originals[$fieldName] = $columns[$fieldName]['config']['disableNoMatchingValueElement'] ?? null;
+            $columns[$fieldName]['config']['disableNoMatchingValueElement'] = true;
+        }
+
+        return static function () use ($table, $originals): void {
+            foreach ($originals as $fieldName => $original) {
+                if ($original === null) {
+                    unset($GLOBALS['TCA'][$table]['columns'][$fieldName]['config']['disableNoMatchingValueElement']);
+                } else {
+                    $GLOBALS['TCA'][$table]['columns'][$fieldName]['config']['disableNoMatchingValueElement'] = $original;
+                }
+            }
+        };
+    }
+
+    /**
+     * Reduce the record context to the scalar field values that can be seeded as
+     * FormEngine default values. Non-scalar values (inline/file collections, etc.)
+     * and the pid (handled separately via vanillaUid) are dropped: they are never
+     * itemsProcFunc inputs and could trip up the compiler pipeline.
+     *
+     * @param string $table Table name
+     * @param array $record Record context
+     * @return array<string, scalar> Field name => value
+     */
+    private function extractDefaultValues(string $table, array $record): array
+    {
+        $columns = $GLOBALS['TCA'][$table]['columns'] ?? [];
+        $defaultValues = [];
+        foreach ($record as $fieldName => $value) {
+            if ($fieldName === 'pid') {
+                continue;
+            }
+            if (!is_scalar($value)) {
+                continue;
+            }
+            if (!isset($columns[$fieldName])) {
+                continue;
+            }
+            $defaultValues[$fieldName] = $value;
+        }
+
+        return $defaultValues;
     }
 
     /**

--- a/Tests/Functional/Service/ContainerSelectItemResolverTest.php
+++ b/Tests/Functional/Service/ContainerSelectItemResolverTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\Service;
+
+use B13\Container\Tca\ContainerConfiguration;
+use B13\Container\Tca\Registry;
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use Hn\McpServer\Service\SelectItemResolver;
+use Hn\McpServer\Service\TableAccessService;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Validates that SelectItemResolver actually executes a field's itemsProcFunc
+ * with the *record context* it needs.
+ *
+ * b13/container is the realistic example: tt_content.colPos uses an itemsProcFunc
+ * (\B13\Container\Tca\ItemProcFunc::colPos) that reads $parameters['row'] —
+ * specifically tx_container_parent (which container the child belongs to) and the
+ * current colPos (it only returns the grid column matching that value). Without the
+ * row, the function falls through to the plain backend-layout colPos list and the
+ * container columns never appear.
+ *
+ * If SelectItemResolver feeds the record into the FormDataCompiler correctly, the
+ * registered grid colPos of a container child resolves and validates; an
+ * unregistered colPos does not. This is exactly what PR #96 worked around by
+ * bypassing validation entirely.
+ */
+class ContainerSelectItemResolverTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+        'frontend',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/mcp_server',
+        'container',
+    ];
+
+    protected const CONTAINER_CTYPE = 'mcptest_container';
+    protected const GRID_COLPOS = 200;
+
+    protected SelectItemResolver $selectItemResolver;
+    protected TableAccessService $tableAccessService;
+    protected WriteTableTool $writeTool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/pages.csv');
+
+        // Register a container with a single grid column at colPos 200.
+        $registry = GeneralUtility::getContainer()->get(Registry::class);
+        $registry->configureContainer(new ContainerConfiguration(
+            self::CONTAINER_CTYPE,
+            'MCP Test Container',
+            'Container for MCP tests',
+            [[['name' => 'Main', 'colPos' => self::GRID_COLPOS]]]
+        ));
+
+        $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('en');
+
+        $this->selectItemResolver = GeneralUtility::makeInstance(SelectItemResolver::class);
+        $this->tableAccessService = GeneralUtility::makeInstance(TableAccessService::class);
+        $this->writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+    }
+
+    /**
+     * Create the container element via the MCP tool and return its (live) uid.
+     */
+    protected function createContainerElement(): int
+    {
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => [
+                'CType' => self::CONTAINER_CTYPE,
+                'header' => 'Test Container',
+                'colPos' => 0,
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $data = json_decode($result->content[0]->text, true);
+        $this->assertIsInt($data['uid'] ?? null, 'Container create should return a uid: ' . json_encode($data));
+
+        return (int)$data['uid'];
+    }
+
+    /**
+     * Sanity check: itemsProcFunc IS executed at all. Without any container link,
+     * colPos resolves to the standard backend-layout columns (which always include 0).
+     */
+    public function testColPosResolvesWithoutContainerContext(): void
+    {
+        $resolved = $this->selectItemResolver->resolveSelectItems('tt_content', 'colPos', ['pid' => 1]);
+        $this->assertNotNull($resolved);
+        $this->assertContains('0', $resolved['values'], 'Default colPos list should contain 0: ' . json_encode($resolved['values']));
+    }
+
+    /**
+     * The core assertion: when the record context carries tx_container_parent and the
+     * registered grid colPos, the container itemsProcFunc must expose that colPos.
+     *
+     * This fails with the current implementation because compileFormData() never
+     * passes the record into the FormDataCompiler (it compiles a blank "new" record),
+     * so the itemsProcFunc sees an empty row and the container column never appears.
+     */
+    public function testContainerGridColPosIsResolvedForChild(): void
+    {
+        $containerUid = $this->createContainerElement();
+
+        $record = [
+            'pid' => 1,
+            'CType' => 'text',
+            'tx_container_parent' => $containerUid,
+            'colPos' => self::GRID_COLPOS,
+        ];
+
+        $resolved = $this->selectItemResolver->resolveSelectItems('tt_content', 'colPos', $record);
+        $this->assertNotNull($resolved, 'colPos should resolve for a container child');
+
+        $this->assertContains(
+            (string)self::GRID_COLPOS,
+            $resolved['values'],
+            'The container grid colPos ' . self::GRID_COLPOS . ' must be resolved via the itemsProcFunc when the '
+            . 'record carries tx_container_parent. Got: ' . json_encode($resolved['values'])
+        );
+    }
+
+    /**
+     * Consequence for validation: a container child placed in a registered grid
+     * column must pass validateFieldValue, and one placed in an unregistered column
+     * must fail. The container itemsProcFunc only echoes back the colPos that matches
+     * a registered grid column, so this distinction is exactly what we want.
+     */
+    public function testValidationAcceptsRegisteredColPosAndRejectsUnregistered(): void
+    {
+        $containerUid = $this->createContainerElement();
+
+        $validRecord = [
+            'pid' => 1,
+            'CType' => 'text',
+            'tx_container_parent' => $containerUid,
+            'colPos' => self::GRID_COLPOS,
+        ];
+        $error = $this->tableAccessService->validateFieldValue('tt_content', 'colPos', self::GRID_COLPOS, $validRecord);
+        $this->assertNull($error, 'A container child in the registered grid colPos should validate. Error: ' . (string)$error);
+
+        $invalidRecord = [
+            'pid' => 1,
+            'CType' => 'text',
+            'tx_container_parent' => $containerUid,
+            'colPos' => 9001,
+        ];
+        $error = $this->tableAccessService->validateFieldValue('tt_content', 'colPos', 9001, $invalidRecord);
+        $this->assertNotNull($error, 'A container child in an unregistered colPos (9001) should fail validation');
+    }
+
+    /**
+     * The runtime cache must not collide across different record contexts on the same
+     * pid. Resolving colPos for a container child and then for a plain record on the
+     * same page must yield different item sets — the container column must not leak
+     * into the plain record and vice versa.
+     */
+    public function testCacheDoesNotCollideAcrossRecordContextsOnSamePid(): void
+    {
+        $containerUid = $this->createContainerElement();
+
+        $childResolved = $this->selectItemResolver->resolveSelectItems('tt_content', 'colPos', [
+            'pid' => 1,
+            'CType' => 'text',
+            'tx_container_parent' => $containerUid,
+            'colPos' => self::GRID_COLPOS,
+        ]);
+        $plainResolved = $this->selectItemResolver->resolveSelectItems('tt_content', 'colPos', [
+            'pid' => 1,
+            'CType' => 'text',
+        ]);
+
+        $this->assertNotNull($childResolved);
+        $this->assertNotNull($plainResolved);
+
+        $this->assertContains((string)self::GRID_COLPOS, $childResolved['values'], 'Child context should expose the grid colPos');
+        $this->assertNotContains(
+            (string)self::GRID_COLPOS,
+            $plainResolved['values'],
+            'Plain record on the same pid must NOT inherit the container grid colPos from a cached result'
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "typo3/testing-framework": "^8.2 || ^9.2",
         "typo3/cms-install": "^13.4 || ^14.3",
         "georgringer/news": "^14.0",
+        "b13/container": "^4.0",
         "brianium/paratest": "^7.4"
     },
     "autoload": {


### PR DESCRIPTION
## Summary

Fix `SelectItemResolver.resolveSelectItems()` to properly pass record context (field values) to TYPO3's FormDataCompiler, enabling dynamic select fields like b13/container's `tt_content.colPos` to resolve correctly based on sibling field values (e.g., `tx_container_parent`).

Previously, the compiler was invoked with a blank "new" record, causing itemsProcFunc callbacks to receive an empty row and fail to expose context-dependent items. This prevented validation of container children placed in registered grid columns.

## Key Changes

- **Pass record field values as `defaultValues`** to FormDataCompiler, which seeds them into the databaseRow that itemsProcFunc callbacks receive as `$parameters['row']`. This mirrors how the TYPO3 backend handles `&defVals[...]` when opening new records.

- **Extract and filter record values** via new `extractRowValues()` method: only scalar field values defined in TCA are passed to the compiler; non-scalar values (inline/file collections) and `pid` (handled separately) are dropped to avoid tripping up the compiler pipeline.

- **Fix cache key collision** by including a hash of the record context (`md5(serialize($rowValues))`) in addition to `table:pid`. Different records on the same page can have different itemsProcFunc results (e.g., depending on `tx_container_parent` or `CType`), so the old `table:pid` key would incorrectly return stale item lists.

- **Suppress invalid pseudo-items** via new `disableNoMatchingValueElement()` method: temporarily disable the TCA option that adds seeded values back as "[ invalid value ]" pseudo-items. This affordance is correct for form display (to avoid silently dropping out-of-range stored values) but wrong for validation, where we want the canonical item set.

- **Add comprehensive functional test** (`ContainerSelectItemResolverTest`) that validates:
  - itemsProcFunc is executed and resolves items correctly
  - Container grid columns are exposed when the record carries `tx_container_parent`
  - Validation accepts registered colPos and rejects unregistered ones
  - Cache does not collide across different record contexts on the same page

- **Add b13/container to dev dependencies** to enable realistic testing of the container use case.

## Implementation Details

The fix ensures that validation of container children now works correctly: a child placed in a registered grid column passes `validateFieldValue()`, while one in an unregistered column fails. This resolves the issue that PR #96 worked around by bypassing validation entirely.

https://claude.ai/code/session_01CjygHCfxxQAFGXbDQPW3qq