### PR TITLE
fix(WriteTable): always allow the language control field on create/update (#94)

### DIFF
--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -1141,7 +1141,25 @@ class WriteTableTool extends AbstractRecordTool
                 $availableFields[$typeField] = $typeFieldConfig;
             }
         }
-        
+
+        // The language field (ctrl.languageField, e.g. sys_language_uid) is a control
+        // field the MCP manages itself: it is converted from ISO codes, set by the
+        // translate action, and defaulted for non-admin permission checks (see
+        // ensureLanguageField()). TYPO3 does not list it in the showitem of every
+        // language-aware table — most notably `pages`, where translations are handled by
+        // the dedicated localize workflow instead of by editing the field. As of TYPO3
+        // 13.3 the field is even auto-injected into content-type showitems but never into
+        // pages (feature #104814). Without this, getAvailableFields() (derived from the
+        // showitem) would omit it and validation would wrongly reject a value the MCP
+        // itself added. Treat it as always available, mirroring the type field. (#94)
+        $languageField = $this->tableAccessService->getLanguageFieldName($table);
+        if ($languageField) {
+            $languageFieldConfig = $this->tableAccessService->getFieldConfig($table, $languageField);
+            if ($languageFieldConfig) {
+                $availableFields[$languageField] = $languageFieldConfig;
+            }
+        }
+
         // If we have type-specific configuration, validate field availability
         if (!empty($availableFields) || !empty($typeField)) {
             // Check each field in data is available

--- a/Tests/Functional/MCP/Tool/NonAdminWriteTest.php
+++ b/Tests/Functional/MCP/Tool/NonAdminWriteTest.php
@@ -322,7 +322,79 @@ class NonAdminWriteTest extends AbstractFunctionalTest
     }
 
     /**
-     * Test read operation for non-admin (should work with basic permissions)
+     * Test that a non-admin user can create a page (regression test for #94).
+     *
+     * TYPO3 does not list the language field (sys_language_uid) in the `pages`
+     * showitem - page translations are handled by the dedicated localize
+     * workflow, and as of TYPO3 13.3 the field is only auto-injected into
+     * content-type showitems, never into pages. The WriteTableTool still adds
+     * sys_language_uid to the data for non-admin permission checks
+     * (ensureLanguageField()), so before the fix the availability validation -
+     * which is derived from the showitem - rejected page creation with
+     * "Field 'sys_language_uid' is not available for this record type".
+     */
+    public function testNonAdminCanCreatePage(): void
+    {
+        // 1. Set up BE_USER as user 99 (non-admin)
+        $user = $this->setupDefaultBackendUser(99);
+
+        // 2. Configure user permissions for creating pages
+        $user->groupData['tables_select'] = 'pages';
+        $user->groupData['tables_modify'] = 'pages';
+        // Allow all relevant page fields (incl. the language field so that
+        // ensureLanguageField() adds it and we exercise the validation path)
+        $user->groupData['non_exclude_fields'] = implode(',', [
+            'pages:title',
+            'pages:slug',
+            'pages:doktype',
+            'pages:sys_language_uid',
+            'pages:l18n_cfg',
+            'pages:hidden',
+        ]);
+        $user->groupData['modules'] = 'web_WorkspacesWorkspaces';
+        // Allow standard page type
+        $user->groupData['pagetypes_select'] = '1';
+
+        // DB Mount points - non-admin users need this to access the page tree
+        $user->groupData['webmounts'] = '1,100';
+        $user->user['db_mountpoints'] = '1';
+
+        // 3. Switch to workspace 50 (where user 99 is a member)
+        $this->switchToWorkspace(50);
+
+        $this->assertFalse($GLOBALS['BE_USER']->isAdmin(), 'User should NOT be admin');
+
+        // 4. Create a subpage under page 100 (where user 99 has "new" permission)
+        // Note: sys_language_uid is intentionally NOT provided - it must work
+        // exactly as a normal page creation would.
+        $result = $this->writeTool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => 100,
+            'data' => [
+                'title' => 'Non-Admin Created Page',
+                'slug' => '/non-admin-created-page',
+                'doktype' => 1,
+            ]
+        ]);
+
+        // 5. This SHOULD succeed - before the fix it failed with
+        // "Field 'sys_language_uid' is not available for this record type"
+        $this->assertFalse(
+            $result->isError,
+            'Non-admin page creation FAILED. Error: ' .
+            json_encode($result->jsonSerialize(), JSON_PRETTY_PRINT)
+        );
+
+        // 6. Verify the page was created
+        $responseData = json_decode($result->content[0]->text, true);
+        $this->assertIsArray($responseData, 'Response should be valid JSON');
+        $this->assertArrayHasKey('uid', $responseData, 'Response should contain UID');
+        $this->assertGreaterThan(0, $responseData['uid'], 'UID should be positive');
+    }
+
+    /**
+     * Read operation for non-admin (should work with basic permissions)
      */
     public function testNonAdminCanRead(): void
     {

--- a/Tests/Functional/MCP/Tool/WriteTableToolTest.php
+++ b/Tests/Functional/MCP/Tool/WriteTableToolTest.php
@@ -213,6 +213,49 @@ class WriteTableToolTest extends AbstractFunctionalTest
     }
 
     /**
+     * Regression test for #94: creating a page with an explicit language field
+     * value must be accepted even though sys_language_uid is not part of the
+     * `pages` showitem (and therefore not reported by getAvailableFields()).
+     * The language field is a control field the MCP manages itself, so it must
+     * always be treated as available during validation.
+     */
+    public function testCreatePageWithExplicitLanguageField(): void
+    {
+        $tableAccessService = GeneralUtility::makeInstance(\Hn\McpServer\Service\TableAccessService::class);
+
+        // Document the premise: sys_language_uid is NOT an editable showitem
+        // field for pages, so getAvailableFields() does not list it.
+        $availableFields = $tableAccessService->getAvailableFields('pages', '1');
+        $this->assertArrayNotHasKey(
+            'sys_language_uid',
+            $availableFields,
+            'Premise of #94: sys_language_uid is not part of the pages showitem'
+        );
+
+        $result = $this->tool->execute([
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => $this->getRootPageUid(),
+            'data' => [
+                'title' => 'Page With Explicit Language',
+                'slug' => '/page-with-explicit-language',
+                'doktype' => 1,
+                'sys_language_uid' => 0,
+            ]
+        ]);
+
+        $this->assertFalse(
+            $result->isError,
+            'Creating a page with explicit sys_language_uid must not be rejected. Error: '
+            . json_encode($result->jsonSerialize(), JSON_PRETTY_PRINT)
+        );
+
+        $pageData = $this->extractJsonFromResult($result);
+        $this->assertEquals('create', $pageData['action']);
+        $this->assertIsInt($pageData['uid']);
+    }
+
+    /**
      * User story: Edit existing content element
      */
     public function testEditExistingContentElement(): void


### PR DESCRIPTION
Page creation failed with "Field 'sys_language_uid' is not available for this record type" because the validation derives available fields from the TCA showitem, and TYPO3 never lists the language field in the `pages` showitem (page translations go through the dedicated localize workflow; as of TYPO3 13.3 feature #104814 the field is auto-injected into content-type showitems but never into pages).

The WriteTableTool itself adds sys_language_uid to the data for non-admin permission checks (ensureLanguageField), so validation then rejected a value the tool had just added. This only surfaced for non-admin users (admins skip ensureLanguageField) and for any user explicitly passing the field, which is why it worked via CLI/admin but not via user auth.

Treat the language field (ctrl.languageField) as always available during validation, mirroring how the type field is handled. The field stays out of the schema exposed to the client, so nothing else changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language field validation when creating records to prevent incorrect rejection of language control field values that the system manages automatically.

* **Tests**
  * Added regression tests verifying successful record creation with language field handling in both standard and non-admin user scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->