### PR TITLE
fix: support subdirectory installations in HTTP/OAuth routing

### DIFF
--- a/Classes/Controller/McpServerModuleController.php
+++ b/Classes/Controller/McpServerModuleController.php
@@ -14,6 +14,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Http\HtmlResponse;
+use Hn\McpServer\Http\RequestUrlTrait;
 use Hn\McpServer\MCP\ToolRegistry;
 use Hn\McpServer\Service\OAuthService;
 use Hn\McpServer\Service\WorkspaceContextService;
@@ -23,6 +24,8 @@ use Hn\McpServer\Service\WorkspaceContextService;
  */
 class McpServerModuleController
 {
+    use RequestUrlTrait;
+
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
         private readonly ToolRegistry $toolRegistry,
@@ -47,7 +50,7 @@ class McpServerModuleController
         $tokens = $this->oauthService->getUserTokens($userId);
         
         // Get base URL for endpoint
-        $baseUrl = $this->getBaseUrl($request);
+        $baseUrl = $this->getRequestBaseUrl($request);
         
         // Generate OAuth authorization URL
         $authUrl = $this->oauthService->generateAuthorizationUrl($baseUrl, 'Claude Desktop');
@@ -199,27 +202,6 @@ class McpServerModuleController
             ], 500);
         }
     }
-    
-    private function getBaseUrl(ServerRequestInterface $request): string
-    {
-        // Try to get from TYPO3 configuration first
-        $baseUrl = $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyBaseUrl'] ?? '';
-        
-        if (empty($baseUrl)) {
-            // Fallback to request-based detection
-            $scheme = $request->getUri()->getScheme();
-            $host = $request->getUri()->getHost();
-            $port = $request->getUri()->getPort();
-            
-            $baseUrl = $scheme . '://' . $host;
-            if ($port && !in_array($port, [80, 443])) {
-                $baseUrl .= ':' . $port;
-            }
-        }
-        
-        return rtrim($baseUrl, '/');
-    }
-    
     
     private function getSiteName(): string
     {

--- a/Classes/Controller/McpServerModuleController.php
+++ b/Classes/Controller/McpServerModuleController.php
@@ -51,9 +51,17 @@ class McpServerModuleController
         
         // Get base URL for endpoint
         $baseUrl = $this->getRequestBaseUrl($request);
-        
+
         // Generate OAuth authorization URL
         $authUrl = $this->oauthService->generateAuthorizationUrl($baseUrl, 'Claude Desktop');
+
+        // RFC 8414 / RFC 9728 well-known discovery URLs must live at the domain root,
+        // not under the TYPO3 site path, so they need the request origin separately.
+        $sitePath = $this->getRequestSitePath($request);
+        $isSubdirectoryInstall = $sitePath !== '';
+        $hostUrl = $this->getRequestHostUrl($request);
+        $wellKnownAuthServerUrl = $hostUrl . '/.well-known/oauth-authorization-server' . $sitePath;
+        $wellKnownProtectedResourceUrl = $hostUrl . '/.well-known/oauth-protected-resource' . $sitePath . '/mcp';
         
         // Get available tools
         $tools = [];
@@ -101,6 +109,9 @@ class McpServerModuleController
             'siteName' => $this->getSiteName(),
             'hasWorkspace' => $hasWorkspace,
             'isLocalhost' => $isLocalhost,
+            'isSubdirectoryInstall' => $isSubdirectoryInstall,
+            'wellKnownAuthServerUrl' => $wellKnownAuthServerUrl,
+            'wellKnownProtectedResourceUrl' => $wellKnownProtectedResourceUrl,
             'createWorkspaceUrl' => $createWorkspaceUrl,
         ];
         

--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -30,6 +30,7 @@ use Hn\McpServer\Http\CorsHeadersTrait;
 class McpEndpoint
 {
     use CorsHeadersTrait;
+    use RequestUrlTrait;
     /**
      * eID entry point via __invoke method
      */
@@ -208,12 +209,7 @@ class McpEndpoint
         // Build WWW-Authenticate header with resource_metadata URL (RFC 9728)
         $wwwAuth = 'Bearer';
         if ($request !== null) {
-            $uri = $request->getUri();
-            $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
-            if ($uri->getPort() && $uri->getPort() !== 443 && $uri->getPort() !== 80) {
-                $baseUrl .= ':' . $uri->getPort();
-            }
-            $resourceMetadataUrl = $baseUrl . '/.well-known/oauth-protected-resource/mcp';
+            $resourceMetadataUrl = $this->getRequestBaseUrl($request) . '/.well-known/oauth-protected-resource/mcp';
             $wwwAuth = 'Bearer resource_metadata="' . $resourceMetadataUrl . '"';
         }
 

--- a/Classes/Http/OAuthAuthServerMetadataEndpoint.php
+++ b/Classes/Http/OAuthAuthServerMetadataEndpoint.php
@@ -17,6 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class OAuthAuthServerMetadataEndpoint
 {
     use CorsHeadersTrait;
+    use RequestUrlTrait;
 
     public function __invoke(ServerRequestInterface $request): ResponseInterface
     {
@@ -25,7 +26,7 @@ class OAuthAuthServerMetadataEndpoint
             return $this->handlePreflightRequest($request);
         }
 
-        $baseUrl = $this->getBaseUrl($request);
+        $baseUrl = $this->getRequestBaseUrl($request);
         $oauthService = GeneralUtility::makeInstance(OAuthService::class);
 
         $metadata = $oauthService->getMetadata($baseUrl);
@@ -46,26 +47,5 @@ class OAuthAuthServerMetadataEndpoint
             ->withHeader('Vary', 'Origin');
         
         return $response;
-    }
-
-    private function getBaseUrl(ServerRequestInterface $request): string
-    {
-        // Try to get from TYPO3 configuration first
-        $baseUrl = $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyBaseUrl'] ?? '';
-        
-        if (empty($baseUrl)) {
-            // Build from request
-            $uri = $request->getUri();
-            $scheme = $uri->getScheme();
-            $host = $uri->getHost();
-            $port = $uri->getPort();
-            
-            $baseUrl = $scheme . '://' . $host;
-            if ($port && !in_array($port, [80, 443])) {
-                $baseUrl .= ':' . $port;
-            }
-        }
-        
-        return rtrim($baseUrl, '/');
     }
 }

--- a/Classes/Http/OAuthAuthorizeEndpoint.php
+++ b/Classes/Http/OAuthAuthorizeEndpoint.php
@@ -17,7 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class OAuthAuthorizeEndpoint
 {
-    
+    use RequestUrlTrait;
 
     public function __invoke(ServerRequestInterface $request): ResponseInterface
     {
@@ -129,7 +129,7 @@ class OAuthAuthorizeEndpoint
         ];
         
         $oauthDataEncoded = base64_encode(json_encode($oauthData));
-        $loginUrl = '/typo3/index.php?loginProvider=1450629977&login_status=login';
+        $loginUrl = $this->getRequestSitePath($request) . '/typo3/index.php?loginProvider=1450629977&login_status=login';
         
         // Build cookie string with environment-aware security flags
         $isHttps = $request->getUri()->getScheme() === 'https';

--- a/Classes/Http/OAuthMetadataEndpoint.php
+++ b/Classes/Http/OAuthMetadataEndpoint.php
@@ -17,6 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class OAuthMetadataEndpoint
 {
     use CorsHeadersTrait;
+    use RequestUrlTrait;
 
     public function __invoke(ServerRequestInterface $request): ResponseInterface
     {
@@ -26,17 +27,7 @@ class OAuthMetadataEndpoint
         }
 
         try {
-            // Get base URL from request
-            $uri = $request->getUri();
-            $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
-            if ($uri->getPort() && !in_array($uri->getPort(), [80, 443])) {
-                $baseUrl .= ':' . $uri->getPort();
-            }
-
-            // Override base URL for development if needed
-            if (isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyBaseUrl'])) {
-                $baseUrl = rtrim($GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyBaseUrl'], '/');
-            }
+            $baseUrl = $this->getRequestBaseUrl($request);
 
             $oauthService = GeneralUtility::makeInstance(OAuthService::class);
             $metadata = $oauthService->getMetadata($baseUrl);

--- a/Classes/Http/OAuthResourceMetadataEndpoint.php
+++ b/Classes/Http/OAuthResourceMetadataEndpoint.php
@@ -16,6 +16,7 @@ use TYPO3\CMS\Core\Http\Stream;
 class OAuthResourceMetadataEndpoint
 {
     use CorsHeadersTrait;
+    use RequestUrlTrait;
 
     public function __invoke(ServerRequestInterface $request): ResponseInterface
     {
@@ -25,7 +26,7 @@ class OAuthResourceMetadataEndpoint
         }
 
         // Get base URL from request
-        $baseUrl = $this->getBaseUrl($request);
+        $baseUrl = $this->getRequestBaseUrl($request);
         
         $metadata = [
             'resource' => $baseUrl . '/mcp',
@@ -57,20 +58,5 @@ class OAuthResourceMetadataEndpoint
         );
         
         return $this->addCorsHeaders($response, $request);
-    }
-    
-    
-    private function getBaseUrl(ServerRequestInterface $request): string
-    {
-        $scheme = $request->getUri()->getScheme();
-        $host = $request->getUri()->getHost();
-        $port = $request->getUri()->getPort();
-        
-        $baseUrl = $scheme . '://' . $host;
-        if ($port && !in_array($port, [80, 443])) {
-            $baseUrl .= ':' . $port;
-        }
-        
-        return $baseUrl;
     }
 }

--- a/Classes/Http/RequestUrlTrait.php
+++ b/Classes/Http/RequestUrlTrait.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Http;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+
+/**
+ * Resolves absolute base URLs and the site path prefix from the request.
+ *
+ * Using NormalizedParams ensures the MCP, OAuth and discovery endpoints
+ * generate correct URLs and route correctly when TYPO3 is installed in a
+ * subdirectory / behind a path prefix (e.g. https://example.com/subdir/).
+ */
+trait RequestUrlTrait
+{
+    /**
+     * Absolute base URL including the site path prefix, without a trailing slash.
+     *
+     * Honors the reverseProxyBaseUrl configuration when set.
+     */
+    protected function getRequestBaseUrl(ServerRequestInterface $request): string
+    {
+        $reverseProxyBaseUrl = (string)($GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyBaseUrl'] ?? '');
+        if ($reverseProxyBaseUrl !== '') {
+            return rtrim($reverseProxyBaseUrl, '/');
+        }
+
+        $normalizedParams = $request->getAttribute('normalizedParams');
+        if ($normalizedParams instanceof NormalizedParams) {
+            return rtrim($normalizedParams->getSiteUrl(), '/');
+        }
+
+        // Fallback when normalizedParams are unavailable
+        $uri = $request->getUri();
+        $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
+        $port = $uri->getPort();
+        if ($port && !in_array($port, [80, 443], true)) {
+            $baseUrl .= ':' . $port;
+        }
+
+        return $baseUrl;
+    }
+
+    /**
+     * Path prefix of the TYPO3 installation without a trailing slash.
+     *
+     * Returns an empty string for a root-level installation.
+     */
+    protected function getRequestSitePath(ServerRequestInterface $request): string
+    {
+        $normalizedParams = $request->getAttribute('normalizedParams');
+        if ($normalizedParams instanceof NormalizedParams) {
+            return rtrim($normalizedParams->getSitePath(), '/');
+        }
+
+        return '';
+    }
+}

--- a/Classes/Http/RequestUrlTrait.php
+++ b/Classes/Http/RequestUrlTrait.php
@@ -58,4 +58,22 @@ trait RequestUrlTrait
 
         return '';
     }
+
+    /**
+     * Absolute origin (scheme + host, without any site path), without a trailing slash.
+     *
+     * RFC 8414 / RFC 9728 well-known discovery URIs must live at the webserver's
+     * domain root regardless of where TYPO3 itself is installed, so callers building
+     * those URIs need the origin separately from {@see getRequestBaseUrl()}.
+     */
+    protected function getRequestHostUrl(ServerRequestInterface $request): string
+    {
+        $baseUrl = $this->getRequestBaseUrl($request);
+        $sitePath = $this->getRequestSitePath($request);
+        if ($sitePath !== '' && str_ends_with($baseUrl, $sitePath)) {
+            return substr($baseUrl, 0, -strlen($sitePath));
+        }
+
+        return $baseUrl;
+    }
 }

--- a/Classes/Middleware/McpServerMiddleware.php
+++ b/Classes/Middleware/McpServerMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hn\McpServer\Middleware;
 
 use Hn\McpServer\Http\CorsHeadersTrait;
+use Hn\McpServer\Http\RequestUrlTrait;
 use Hn\McpServer\Http\McpEndpoint;
 use Hn\McpServer\Http\OAuthAuthorizeEndpoint;
 use Hn\McpServer\Http\OAuthTokenEndpoint;
@@ -27,8 +28,10 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class McpServerMiddleware implements MiddlewareInterface
 {
+    use RequestUrlTrait;
+
     private Context $context;
-    
+
     public function __construct(Context $context)
     {
         $this->context = $context;
@@ -36,7 +39,17 @@ class McpServerMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $path = $request->getUri()->getPath();
-        
+
+        // Strip the site path prefix so routing works in subdirectory installations
+        $sitePath = $this->getRequestSitePath($request);
+        if ($sitePath !== '') {
+            if ($path === $sitePath) {
+                $path = '/';
+            } elseif (str_starts_with($path, $sitePath . '/')) {
+                $path = substr($path, strlen($sitePath));
+            }
+        }
+
         // Route to appropriate endpoint
         return match($path) {
             // Main MCP endpoint
@@ -98,7 +111,7 @@ class McpServerMiddleware implements MiddlewareInterface
             'state' => $oauthData['state'] ?? ''
         ]);
         
-        $oauthAuthorizeUrl = '/mcp_oauth/authorize?' . $queryParams;
+        $oauthAuthorizeUrl = $this->getRequestSitePath($request) . '/mcp_oauth/authorize?' . $queryParams;
         
         $stream = new Stream('php://temp', 'rw');
         $stream->write('');

--- a/Resources/Private/Templates/McpServerModule.html
+++ b/Resources/Private/Templates/McpServerModule.html
@@ -38,6 +38,17 @@
                             </p>
                         </div>
                     </f:if>
+                    <f:if condition="{isSubdirectoryInstall}">
+                        <div class="alert alert-warning mb-3">
+                            <h6><strong>Subdirectory installation detected</strong></h6>
+                            <p class="mb-2">
+                                OAuth auto-discovery relies on <code>/.well-known/...</code> files served from your webserver's <strong>domain root</strong>. Since this TYPO3 lives under a subdirectory, it cannot serve those paths itself — the discovery checks below will likely show red, and MCP clients that rely on automatic discovery won't find this server.
+                            </p>
+                            <p class="mb-0">
+                                <strong>Workarounds:</strong> configure your webserver/proxy to serve <code>{wellKnownAuthServerUrl}</code> and <code>{wellKnownProtectedResourceUrl}</code> from the domain root, or skip auto-discovery and configure your MCP client manually with the Server URL and a token below.
+                            </p>
+                        </div>
+                    </f:if>
                     <!-- Authorization Header Warning (shown/hidden by JS after endpoint check) -->
                     <div class="alert alert-warning mb-3" id="auth-header-warning" style="display: none;">
                         <h6><strong>Authorization header issue detected</strong></h6>
@@ -105,14 +116,14 @@ RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]</code></pre>
                                             <span class="status-tooltip"></span>
                                         </span>
                                         <br>
-                                        <code class="small">{baseUrl}/.well-known/oauth-authorization-server</code>
-                                        <span class="endpoint-status" data-endpoint="{baseUrl}/.well-known/oauth-authorization-server" data-check-content="true">
+                                        <code class="small">{wellKnownAuthServerUrl}</code>
+                                        <span class="endpoint-status" data-endpoint="{wellKnownAuthServerUrl}" data-check-content="true">
                                             <span class="status-icon"></span>
                                             <span class="status-tooltip"></span>
                                         </span>
                                         <br>
-                                        <code class="small">{baseUrl}/.well-known/oauth-protected-resource</code>
-                                        <span class="endpoint-status" data-endpoint="{baseUrl}/.well-known/oauth-protected-resource" data-check-content="true">
+                                        <code class="small">{wellKnownProtectedResourceUrl}</code>
+                                        <span class="endpoint-status" data-endpoint="{wellKnownProtectedResourceUrl}" data-check-content="true">
                                             <span class="status-icon"></span>
                                             <span class="status-tooltip"></span>
                                         </span>

--- a/Tests/Functional/Http/SubdirectoryRoutingTest.php
+++ b/Tests/Functional/Http/SubdirectoryRoutingTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\Http;
+
+use Hn\McpServer\Http\OAuthResourceMetadataEndpoint;
+use Hn\McpServer\Middleware\McpServerMiddleware;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Http\Response;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Ensures the MCP endpoints generate correct URLs and route correctly when
+ * TYPO3 is installed in a subdirectory / behind a path prefix.
+ */
+class SubdirectoryRoutingTest extends AbstractFunctionalTest
+{
+    private mixed $previousRequest;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousRequest = $GLOBALS['TYPO3_REQUEST'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = $this->previousRequest;
+        parent::tearDown();
+    }
+
+    public function testMetadataEndpointGeneratesSubdirectoryAwareUrls(): void
+    {
+        $request = $this->createRequest('/subfolder/index.php', '/subfolder/.well-known/oauth-protected-resource/mcp');
+
+        $response = (new OAuthResourceMetadataEndpoint())($request);
+        $metadata = json_decode((string)$response->getBody(), true);
+
+        $this->assertSame('https://example.com/subfolder/mcp', $metadata['resource']);
+        $this->assertSame('https://example.com/subfolder', $metadata['authorization_servers'][0]);
+        $this->assertSame('https://example.com/subfolder/mcp_oauth/token', $metadata['revocation_endpoint']);
+    }
+
+    public function testMetadataEndpointRootInstallationUrls(): void
+    {
+        $request = $this->createRequest('/index.php', '/.well-known/oauth-protected-resource/mcp');
+
+        $response = (new OAuthResourceMetadataEndpoint())($request);
+        $metadata = json_decode((string)$response->getBody(), true);
+
+        $this->assertSame('https://example.com/mcp', $metadata['resource']);
+    }
+
+    public function testMiddlewareRoutesSubdirectoryPath(): void
+    {
+        $request = $this->createRequest('/subfolder/index.php', '/subfolder/.well-known/oauth-protected-resource/mcp');
+        $middleware = new McpServerMiddleware(GeneralUtility::makeInstance(Context::class));
+
+        $response = $middleware->process($request, $this->sentinelHandler());
+
+        $this->assertSame(200, $response->getStatusCode(), 'Subdirectory path must be routed, not fall through');
+        $metadata = json_decode((string)$response->getBody(), true);
+        $this->assertSame('https://example.com/subfolder/mcp', $metadata['resource']);
+    }
+
+    public function testMiddlewareFallsThroughForUnrelatedPath(): void
+    {
+        $request = $this->createRequest('/subfolder/index.php', '/subfolder/some/regular/page');
+        $middleware = new McpServerMiddleware(GeneralUtility::makeInstance(Context::class));
+
+        $response = $middleware->process($request, $this->sentinelHandler());
+
+        $this->assertSame(418, $response->getStatusCode(), 'Non-MCP paths must fall through to the next handler');
+    }
+
+    private function createRequest(string $scriptName, string $requestUri): ServerRequestInterface
+    {
+        $serverParams = [
+            'HTTP_HOST' => 'example.com',
+            'HTTPS' => 'on',
+            'SCRIPT_NAME' => $scriptName,
+            'SCRIPT_FILENAME' => '/var/www/html' . $scriptName,
+            'REQUEST_URI' => $requestUri,
+        ];
+
+        $request = new ServerRequest(
+            new Uri('https://example.com' . $requestUri),
+            'GET',
+            'php://input',
+            [],
+            $serverParams
+        );
+        $request = $request->withAttribute('normalizedParams', NormalizedParams::createFromServerParams($serverParams));
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        return $request;
+    }
+
+    private function sentinelHandler(): RequestHandlerInterface
+    {
+        return new class () implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return (new Response())->withStatus(418);
+            }
+        };
+    }
+}

--- a/Tests/Functional/Http/SubdirectoryRoutingTest.php
+++ b/Tests/Functional/Http/SubdirectoryRoutingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hn\McpServer\Tests\Functional\Http;
 
+use Hn\McpServer\Http\OAuthMetadataEndpoint;
 use Hn\McpServer\Http\OAuthResourceMetadataEndpoint;
 use Hn\McpServer\Middleware\McpServerMiddleware;
 use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
@@ -47,6 +48,19 @@ class SubdirectoryRoutingTest extends AbstractFunctionalTest
         $this->assertSame('https://example.com/subfolder/mcp', $metadata['resource']);
         $this->assertSame('https://example.com/subfolder', $metadata['authorization_servers'][0]);
         $this->assertSame('https://example.com/subfolder/mcp_oauth/token', $metadata['revocation_endpoint']);
+    }
+
+    public function testOAuthMetadataEndpointGeneratesSubdirectoryAwareUrls(): void
+    {
+        $request = $this->createRequest('/subfolder/index.php', '/subfolder/mcp_oauth/metadata');
+
+        $response = (new OAuthMetadataEndpoint())($request);
+        $metadata = json_decode((string)$response->getBody(), true);
+
+        $this->assertSame('https://example.com/subfolder', $metadata['issuer']);
+        $this->assertSame('https://example.com/subfolder/mcp_oauth/authorize', $metadata['authorization_endpoint']);
+        $this->assertSame('https://example.com/subfolder/mcp_oauth/token', $metadata['token_endpoint']);
+        $this->assertSame('https://example.com/subfolder/mcp_oauth/register', $metadata['registration_endpoint']);
     }
 
     public function testMetadataEndpointRootInstallationUrls(): void

--- a/Tests/Functional/Http/SubdirectoryRoutingTest.php
+++ b/Tests/Functional/Http/SubdirectoryRoutingTest.php
@@ -6,6 +6,7 @@ namespace Hn\McpServer\Tests\Functional\Http;
 
 use Hn\McpServer\Http\OAuthMetadataEndpoint;
 use Hn\McpServer\Http\OAuthResourceMetadataEndpoint;
+use Hn\McpServer\Http\RequestUrlTrait;
 use Hn\McpServer\Middleware\McpServerMiddleware;
 use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
 use Psr\Http\Message\ResponseInterface;
@@ -93,6 +94,53 @@ class SubdirectoryRoutingTest extends AbstractFunctionalTest
         $response = $middleware->process($request, $this->sentinelHandler());
 
         $this->assertSame(418, $response->getStatusCode(), 'Non-MCP paths must fall through to the next handler');
+    }
+
+    public function testHostUrlStripsSitePathForSubdirectoryInstall(): void
+    {
+        $request = $this->createRequest('/subfolder/index.php', '/subfolder/mcp');
+
+        $this->assertSame('https://example.com', $this->getHostUrl($request));
+    }
+
+    public function testHostUrlEqualsBaseUrlForRootInstall(): void
+    {
+        $request = $this->createRequest('/index.php', '/mcp');
+
+        $this->assertSame('https://example.com', $this->getHostUrl($request));
+    }
+
+    /**
+     * RFC 8414 / RFC 9728 well-known discovery URIs must live at the domain root
+     * (e.g. https://example.com/.well-known/oauth-protected-resource/subfolder/mcp),
+     * not under the site path this PR routes internally
+     * (https://example.com/subfolder/.well-known/oauth-protected-resource/mcp).
+     * A spec-compliant client requesting the former must still fall through, since
+     * this installation cannot serve paths outside its own site path — the backend
+     * module must warn about this rather than report the endpoint as working.
+     */
+    public function testMiddlewareDoesNotRouteRfcCompliantWellKnownPath(): void
+    {
+        $request = $this->createRequest('/subfolder/index.php', '/.well-known/oauth-protected-resource/subfolder/mcp');
+        $middleware = new McpServerMiddleware(GeneralUtility::makeInstance(Context::class));
+
+        $response = $middleware->process($request, $this->sentinelHandler());
+
+        $this->assertSame(418, $response->getStatusCode(), 'RFC-compliant discovery path outside the site path must fall through');
+    }
+
+    private function getHostUrl(ServerRequestInterface $request): string
+    {
+        $subject = new class () {
+            use RequestUrlTrait;
+
+            public function hostUrl(ServerRequestInterface $request): string
+            {
+                return $this->getRequestHostUrl($request);
+            }
+        };
+
+        return $subject->hostUrl($request);
     }
 
     private function createRequest(string $scriptName, string $requestUri): ServerRequestInterface


### PR DESCRIPTION
## Problem

The HTTP/OAuth transport does not work when TYPO3 is served from a **subdirectory / path prefix** (e.g. `https://example.com/sub/`, a common setup for feature-branch staging environments).

Two causes:

1. **Routing never matches.** `McpServerMiddleware` matches `$request->getUri()->getPath()` against root-relative literals (`/mcp`, `/mcp_oauth/*`, `/.well-known/oauth-protected-resource/mcp`, …). In a subdirectory install the request path carries the prefix (`/sub/mcp`), so the `match()` falls through and TYPO3 returns a 404.
2. **Generated URLs drop the subdirectory.** The endpoints/controller build absolute URLs from `scheme://host` only, so the backend module shows `https://example.com/mcp` instead of `https://example.com/sub/mcp`, and the OAuth discovery/redirect URLs are wrong.

Reproduction: on a subdirectory install, `GET /sub/.well-known/oauth-protected-resource/mcp` returns **404**, and the "MCP Server" backend module shows a Server URL without the subdirectory.

## Fix

Introduce `RequestUrlTrait`, which derives the base URL and site-path prefix from `NormalizedParams` (available at middleware time, before site resolution):

- `getRequestBaseUrl()` — absolute base URL incl. the site path (`NormalizedParams::getSiteUrl()`), honoring `reverseProxyBaseUrl`.
- `getRequestSitePath()` — the path prefix (`/sub`), or `''` for a root install.

Then:

- The middleware strips the site path before matching, so routing works under any prefix.
- The three duplicated `getBaseUrl()` implementations (controller + two metadata endpoints) and the inline base-URL in `McpEndpoint` are replaced by the trait.
- The `mcp_oauth/authorize` and `/typo3/index.php` login redirects are prefixed with the site path.

**Root installations are unaffected** — `getSitePath()` resolves to `/` → prefix `''`, so paths and URLs are unchanged.

## Tests

Adds `Tests/Functional/Http/SubdirectoryRoutingTest.php`:

- metadata endpoint emits subdirectory-aware URLs
- metadata endpoint URLs for a root install are unchanged
- the middleware routes a prefixed MCP path instead of falling through
- the middleware still falls through for unrelated (page) paths

Full functional suite green locally (PHP 8.5, SQLite); no regressions in `Tests/Functional/{Http,Controller,Service}` (63 tests, 178 assertions).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request-scoped URL helpers to generate MCP and OAuth discovery links correctly behind reverse proxies and when TYPO3 runs under a subdirectory.
* **Bug Fixes**
  * Improved routing by stripping the site path prefix so discovery and MCP endpoints resolve properly on non-root installs.
  * Updated OAuth/MCP responses to use consistent computed well-known URLs and correct login redirects.
* **Documentation**
  * Added a template warning explaining limitations of `/.well-known/...` for subdirectory installs and how to use the generated URLs instead.
* **Tests**
  * Expanded functional coverage for subdirectory-aware URL generation, middleware routing, host URL handling, and RFC-compliant well-known fall-through behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->