### PR TITLE
feat: add 'mcp:oauth create' to mint static access tokens (for clients without OAuth discovery)

### DIFF
--- a/Classes/Command/OAuthManageCommand.php
+++ b/Classes/Command/OAuthManageCommand.php
@@ -22,11 +22,12 @@ class OAuthManageCommand extends Command
     {
         $this->setDescription('Manage OAuth tokens for MCP server')
             ->setHelp('This command helps manage OAuth tokens and provides authorization URLs for MCP clients.')
-            ->addArgument('action', InputArgument::REQUIRED, 'Action to perform: url, list, revoke, cleanup')
-            ->addArgument('username', InputArgument::OPTIONAL, 'Backend username (required for url, list, revoke actions)')
+            ->addArgument('action', InputArgument::REQUIRED, 'Action to perform: url, create, list, revoke, cleanup')
+            ->addArgument('username', InputArgument::OPTIONAL, 'Backend username (required for url, create, list, revoke actions)')
             ->addOption('client-name', 'c', InputOption::VALUE_OPTIONAL, 'Client name for authorization URL', 'MCP Client')
             ->addOption('token-id', 't', InputOption::VALUE_OPTIONAL, 'Token ID to revoke (for revoke action)')
-            ->addOption('all', 'a', InputOption::VALUE_NONE, 'Revoke all tokens for user (for revoke action)');
+            ->addOption('all', 'a', InputOption::VALUE_NONE, 'Revoke all tokens for user (for revoke action)')
+            ->addOption('ttl-days', null, InputOption::VALUE_OPTIONAL, 'Token lifetime in days (for create action; default 30)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -38,6 +39,8 @@ class OAuthManageCommand extends Command
             switch ($action) {
                 case 'url':
                     return $this->generateAuthUrl($input, $output, $username);
+                case 'create':
+                    return $this->createToken($input, $output, $username);
                 case 'list':
                     return $this->listTokens($input, $output, $username);
                 case 'revoke':
@@ -45,7 +48,7 @@ class OAuthManageCommand extends Command
                 case 'cleanup':
                     return $this->cleanupTokens($input, $output);
                 default:
-                    $output->writeln("<error>Invalid action. Use: url, list, revoke, or cleanup</error>");
+                    $output->writeln("<error>Invalid action. Use: url, create, list, revoke, or cleanup</error>");
                     return Command::FAILURE;
             }
         } catch (\Throwable $e) {
@@ -82,6 +85,40 @@ class OAuthManageCommand extends Command
         $output->writeln("2. Log in to TYPO3 backend if not already logged in");
         $output->writeln("3. Authorize the MCP client access");
         $output->writeln("4. Use the generated token in your MCP client configuration");
+
+        return Command::SUCCESS;
+    }
+
+    private function createToken(InputInterface $input, OutputInterface $output, ?string $username): int
+    {
+        if (empty($username)) {
+            $output->writeln("<error>Username is required for token creation</error>");
+            return Command::FAILURE;
+        }
+
+        $user = $this->findUser($username);
+        if (!$user) {
+            $output->writeln("<error>User '$username' not found or disabled</error>");
+            return Command::FAILURE;
+        }
+
+        $clientName = $input->getOption('client-name');
+        $ttlDays = $input->getOption('ttl-days');
+        $ttlSeconds = $ttlDays !== null ? (int)$ttlDays * 86400 : null;
+
+        $oauthService = GeneralUtility::makeInstance(OAuthService::class);
+        $token = $oauthService->createToken((int)$user['uid'], $clientName, $ttlSeconds);
+
+        $output->writeln("<info>Access token created for user '$username':</info>");
+        $output->writeln("");
+        $output->writeln($token['access_token']);
+        $output->writeln("");
+        $output->writeln("Client: <info>$clientName</info>");
+        $output->writeln("Expires: <info>" . date('Y-m-d H:i:s', $token['expires']) . "</info>");
+        $output->writeln("");
+        $output->writeln("<comment>Store it now — it cannot be retrieved later (only a hash is kept).</comment>");
+        $output->writeln("Use it as a static Bearer header in your MCP client, e.g.:");
+        $output->writeln('  claude mcp add --transport http typo3 <server-url> --header "Authorization: Bearer <token>"');
 
         return Command::SUCCESS;
     }

--- a/Classes/Command/OAuthManageCommand.php
+++ b/Classes/Command/OAuthManageCommand.php
@@ -104,6 +104,10 @@ class OAuthManageCommand extends Command
 
         $clientName = $input->getOption('client-name');
         $ttlDays = $input->getOption('ttl-days');
+        if ($ttlDays !== null && (!is_string($ttlDays) || !ctype_digit($ttlDays) || (int)$ttlDays < 1)) {
+            $output->writeln('<error>--ttl-days must be a positive integer</error>');
+            return Command::FAILURE;
+        }
         $ttlSeconds = $ttlDays !== null ? (int)$ttlDays * 86400 : null;
 
         $oauthService = GeneralUtility::makeInstance(OAuthService::class);
@@ -220,7 +224,8 @@ class OAuthManageCommand extends Command
             ->from('be_users')
             ->where(
                 $queryBuilder->expr()->eq('username', $queryBuilder->createNamedParameter($username)),
-                $queryBuilder->expr()->eq('disable', $queryBuilder->createNamedParameter(0))
+                $queryBuilder->expr()->eq('disable', $queryBuilder->createNamedParameter(0)),
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0))
             )
             ->executeQuery()
             ->fetchAssociative();

--- a/Classes/Service/OAuthService.php
+++ b/Classes/Service/OAuthService.php
@@ -441,6 +441,46 @@ class OAuthService
     }
 
     /**
+     * Create a long-lived access token for a backend user without the
+     * interactive OAuth flow. Intended for MCP clients that cannot perform
+     * OAuth discovery (e.g. subdirectory installs) and authenticate with a
+     * static Authorization header instead. Returns the plaintext token, which
+     * is only available at creation time (the database stores a hash).
+     */
+    public function createToken(int $beUserUid, string $clientName, ?int $ttlSeconds = null): array
+    {
+        $accessToken = $this->generateSecureToken();
+        $ttl = $ttlSeconds ?? self::TOKEN_EXPIRY_SECONDS;
+        $expires = time() + $ttl;
+
+        GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_access_tokens')
+            ->insert(
+                'tx_mcpserver_access_tokens',
+                [
+                    'pid' => 0,
+                    'tstamp' => time(),
+                    'crdate' => time(),
+                    'token' => $this->hashToken($accessToken),
+                    'be_user_uid' => $beUserUid,
+                    'client_name' => $clientName,
+                    'expires' => $expires,
+                    'last_used' => 0,
+                    'created_ip' => '',
+                    'last_used_ip' => '',
+                    'token_version' => 1,
+                ]
+            );
+
+        return [
+            'access_token' => $accessToken,
+            'token_type' => 'Bearer',
+            'expires' => $expires,
+            'expires_in' => $ttl,
+        ];
+    }
+
+    /**
      * Generate cryptographically secure token
      */
     private function generateSecureToken(): string

--- a/Classes/Service/OAuthService.php
+++ b/Classes/Service/OAuthService.php
@@ -451,6 +451,9 @@ class OAuthService
     {
         $accessToken = $this->generateSecureToken();
         $ttl = $ttlSeconds ?? self::TOKEN_EXPIRY_SECONDS;
+        if ($ttl <= 0) {
+            throw new \InvalidArgumentException('Token TTL must be greater than zero seconds.');
+        }
         $expires = time() + $ttl;
 
         GeneralUtility::makeInstance(ConnectionPool::class)


### PR DESCRIPTION
## Summary

Adds a `create` action to the `mcp:oauth` console command that mints a long-lived access token for a backend user **without** the interactive OAuth flow.

```bash
vendor/bin/typo3 mcp:oauth create <username> [--client-name="…"] [--ttl-days=N]
```

The plaintext token is printed once (the database stores only a SHA-256 hash, like OAuth-issued tokens).

## Why

Some MCP clients authenticate with a **static `Authorization: Bearer` header** instead of performing the OAuth authorization-code flow. This is the only viable option when OAuth **discovery** cannot work — most notably **subdirectory / path-prefix installations**: for a path-based issuer (`https://host/sub`), RFC 8414 requires the authorization-server metadata at the domain root (`https://host/.well-known/oauth-authorization-server/sub`), which such an install does not control. The token endpoints route fine, but the client can never discover them.

With this command an admin can issue a token out-of-band and hand it to the client, e.g. Claude Code:

```bash
claude mcp add --transport http typo3 https://host/sub/mcp \
  --header "Authorization: Bearer <token>"
```

A provided header disables OAuth fallback in such clients, so no discovery happens and the static token authenticates directly.

## Changes

- `OAuthService::createToken(int $beUserUid, string $clientName, ?int $ttlSeconds = null): array` — mints + stores (hashed) an access token, returns the plaintext. Reuses the existing token generation/hashing; defaults to the standard 30-day lifetime, overridable.
- `OAuthManageCommand`: new `create` action with a `--ttl-days` option; prints the token, expiry and usage hint. Reuses the existing `findUser()` resolver.

No changes to validation — minted tokens are ordinary `token_version=1` access tokens validated by `validateToken()` like any OAuth-issued token, and are revocable via the existing `revoke`/backend module.

## Security note

A long-lived static token is a credential equivalent to the backend user's MCP access. It is shown once and stored hashed; choose `--ttl-days` deliberately and revoke when no longer needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI action to create OAuth access tokens directly for a backend user.
  * Introduced a `--ttl-days` option to control token lifetime.
  * After creation, the command outputs the generated access token along with expiration details.

* **Bug Fixes**
  * Strengthened eligibility checks for the target backend user (now excludes deleted users).
  * Improved validation for `--ttl-days` to ensure it’s a positive integer and better handles unsupported actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->