### PR TITLE
Add UploadFile MCP tool for file storage management

### DIFF
--- a/Build/build-ter.sh
+++ b/Build/build-ter.sh
@@ -46,7 +46,9 @@ for dir in Classes Configuration Documentation Resources; do
 done
 
 # Copy specific files from root
-for file in ext_emconf.php ext_localconf.php ext_tables.php ext_tables.sql composer.json README.md LICENSE; do
+# ext_conf_template.txt carries the extension settings (e.g. maxFileSizeMb) -
+# without it the Extension Configuration module shows nothing to configure.
+for file in ext_emconf.php ext_localconf.php ext_tables.php ext_tables.sql ext_conf_template.txt composer.json README.md LICENSE; do
     if [ -f "$PROJECT_DIR/$file" ]; then
         cp "$PROJECT_DIR/$file" "$EXTENSION_DIR/"
     fi

--- a/Build/deploy-classic.sh
+++ b/Build/deploy-classic.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Deploys the current git HEAD of this extension into a classic-mode (non-composer)
+# TYPO3 installation and runs the extension setup (database schema, caches).
+# Replaces the manual "build TER zip + upload in the extension manager" workflow.
+#
+# Usage:
+#   Build/deploy-classic.sh /path/to/typo3-root [docker-container-name]
+#
+# Example (local docker test instance):
+#   Build/deploy-classic.sh /Volumes/Workspace/typo3-nc/typo3_src-14.3.0 typo3_src-14.3.0
+#
+# The TYPO3 root must contain typo3conf/. If a container name is given, the
+# bundled-library composer install and the TYPO3 CLI (extension:setup +
+# cache:flush) run inside that container, so the host needs neither PHP nor
+# composer. The bundled vendor dir survives between deploys, so repeated
+# deploys are fast.
+
+set -euo pipefail
+
+TYPO3_ROOT=${1:?Usage: Build/deploy-classic.sh /path/to/typo3-root [docker-container-name]}
+CONTAINER=${2:-}
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+EXT_DIR="$TYPO3_ROOT/typo3conf/ext/mcp_server"
+
+if [ ! -d "$TYPO3_ROOT/typo3conf" ]; then
+    echo "Error: $TYPO3_ROOT does not look like a classic-mode TYPO3 root (no typo3conf/)" >&2
+    exit 1
+fi
+
+echo "Deploying $(git -C "$REPO_ROOT" rev-parse --short HEAD) ($(git -C "$REPO_ROOT" branch --show-current)) to $EXT_DIR"
+
+if ! git -C "$REPO_ROOT" diff --quiet HEAD -- Classes Configuration Resources ext_localconf.php ext_tables.php ext_tables.sql ext_conf_template.txt ext_emconf.php 2>/dev/null; then
+    echo "WARNING: uncommitted changes in extension files are NOT deployed (git HEAD is exported)." >&2
+fi
+
+# Export only tracked files of HEAD (no .git, no .Build, no local cruft),
+# then sync into the target while keeping the bundled vendor dir alive.
+STAGE_DIR="$REPO_ROOT/.Build/deploy-stage"
+rm -rf "$STAGE_DIR"
+mkdir -p "$STAGE_DIR"
+trap 'rm -rf "$STAGE_DIR"' EXIT
+git -C "$REPO_ROOT" archive HEAD | tar -x -C "$STAGE_DIR"
+
+mkdir -p "$EXT_DIR"
+rsync -a --delete \
+    --exclude 'Resources/Private/PHP/vendor/' \
+    --exclude 'Resources/Private/PHP/composer.lock' \
+    "$STAGE_DIR/" "$EXT_DIR/"
+
+# Classic mode has no root composer autoloader: install the bundled libraries
+# (same as Build/build-ter.sh does for the TER zip).
+if [ -n "$CONTAINER" ]; then
+    echo "Installing bundled libraries in container '$CONTAINER'..."
+    docker exec -w /var/www/html/typo3conf/ext/mcp_server/Resources/Private/PHP "$CONTAINER" \
+        composer install --no-dev --optimize-autoloader --classmap-authoritative --no-interaction --quiet
+    docker exec -w /var/www/html/typo3conf/ext/mcp_server/Resources/Private/PHP "$CONTAINER" \
+        rm -rf vendor/psr/log
+
+    echo "Running extension:setup + cache:flush in container '$CONTAINER'..."
+    docker exec "$CONTAINER" typo3/sysext/core/bin/typo3 extension:setup --extension=mcp_server
+    docker exec "$CONTAINER" typo3/sysext/core/bin/typo3 cache:flush
+    echo "Done. Extension deployed and set up."
+else
+    echo "Installing bundled libraries on the host..."
+    (cd "$EXT_DIR/Resources/Private/PHP" \
+        && composer install --no-dev --optimize-autoloader --classmap-authoritative --no-interaction --quiet \
+        && rm -rf vendor/psr/log)
+    echo "Done. Now run in your TYPO3 root:"
+    echo "  typo3/sysext/core/bin/typo3 extension:setup --extension=mcp_server && typo3/sysext/core/bin/typo3 cache:flush"
+fi

--- a/Build/deploy-classic.sh
+++ b/Build/deploy-classic.sh
@@ -18,8 +18,11 @@
 
 set -euo pipefail
 
-TYPO3_ROOT=${1:?Usage: Build/deploy-classic.sh /path/to/typo3-root [docker-container-name]}
+TYPO3_ROOT=${1:?Usage: Build/deploy-classic.sh /path/to/typo3-root [docker-container-name] [container-typo3-root]}
 CONTAINER=${2:-}
+# TYPO3 root inside the container (only used with a container name);
+# /var/www/html matches the official php:*-apache images.
+CONTAINER_ROOT=${3:-/var/www/html}
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 EXT_DIR="$TYPO3_ROOT/typo3conf/ext/mcp_server"
@@ -31,8 +34,9 @@ fi
 
 echo "Deploying $(git -C "$REPO_ROOT" rev-parse --short HEAD) ($(git -C "$REPO_ROOT" branch --show-current)) to $EXT_DIR"
 
-if ! git -C "$REPO_ROOT" diff --quiet HEAD -- Classes Configuration Resources ext_localconf.php ext_tables.php ext_tables.sql ext_conf_template.txt ext_emconf.php 2>/dev/null; then
-    echo "WARNING: uncommitted changes in extension files are NOT deployed (git HEAD is exported)." >&2
+# git status --porcelain also reports untracked files, which `git diff` would miss
+if [ -n "$(git -C "$REPO_ROOT" status --porcelain --untracked-files=all -- Classes Configuration Resources ext_localconf.php ext_tables.php ext_tables.sql ext_conf_template.txt ext_emconf.php 2>/dev/null)" ]; then
+    echo "WARNING: uncommitted or untracked changes in extension files are NOT deployed (git HEAD is exported)." >&2
 fi
 
 # Export only tracked files of HEAD (no .git, no .Build, no local cruft),
@@ -53,14 +57,14 @@ rsync -a --delete \
 # (same as Build/build-ter.sh does for the TER zip).
 if [ -n "$CONTAINER" ]; then
     echo "Installing bundled libraries in container '$CONTAINER'..."
-    docker exec -w /var/www/html/typo3conf/ext/mcp_server/Resources/Private/PHP "$CONTAINER" \
+    docker exec -w "$CONTAINER_ROOT/typo3conf/ext/mcp_server/Resources/Private/PHP" "$CONTAINER" \
         composer install --no-dev --optimize-autoloader --classmap-authoritative --no-interaction --quiet
-    docker exec -w /var/www/html/typo3conf/ext/mcp_server/Resources/Private/PHP "$CONTAINER" \
+    docker exec -w "$CONTAINER_ROOT/typo3conf/ext/mcp_server/Resources/Private/PHP" "$CONTAINER" \
         rm -rf vendor/psr/log
 
     echo "Running extension:setup + cache:flush in container '$CONTAINER'..."
-    docker exec "$CONTAINER" typo3/sysext/core/bin/typo3 extension:setup --extension=mcp_server
-    docker exec "$CONTAINER" typo3/sysext/core/bin/typo3 cache:flush
+    docker exec -w "$CONTAINER_ROOT" "$CONTAINER" typo3/sysext/core/bin/typo3 extension:setup --extension=mcp_server
+    docker exec -w "$CONTAINER_ROOT" "$CONTAINER" typo3/sysext/core/bin/typo3 cache:flush
     echo "Done. Extension deployed and set up."
 else
     echo "Installing bundled libraries on the host..."

--- a/Build/deploy-classic.sh
+++ b/Build/deploy-classic.sh
@@ -5,7 +5,7 @@
 # Replaces the manual "build TER zip + upload in the extension manager" workflow.
 #
 # Usage:
-#   Build/deploy-classic.sh /path/to/typo3-root [docker-container-name]
+#   Build/deploy-classic.sh /path/to/typo3-root [docker-container-name] [container-typo3-root]
 #
 # Example (local docker test instance):
 #   Build/deploy-classic.sh /Volumes/Workspace/typo3-nc/typo3_src-14.3.0 typo3_src-14.3.0
@@ -13,10 +13,23 @@
 # The TYPO3 root must contain typo3conf/. If a container name is given, the
 # bundled-library composer install and the TYPO3 CLI (extension:setup +
 # cache:flush) run inside that container, so the host needs neither PHP nor
-# composer. The bundled vendor dir survives between deploys, so repeated
-# deploys are fast.
+# composer; the third argument overrides the TYPO3 root inside that container
+# (default /var/www/html). The bundled vendor dir survives between deploys, so
+# repeated deploys are fast.
+#
+# Only the files that make up the shipped extension are deployed - the same
+# payload Build/build-ter.sh puts into the TER zip - so what you test here is
+# what users install.
 
 set -euo pipefail
+
+# Keep in sync with Build/build-ter.sh. Optional entries are filtered below,
+# because `git archive` aborts on a path that does not exist.
+PAYLOAD_CANDIDATES=(
+    Classes Configuration Documentation Resources
+    ext_emconf.php ext_localconf.php ext_tables.php ext_tables.sql ext_conf_template.txt
+    composer.json README.md LICENSE
+)
 
 TYPO3_ROOT=${1:?Usage: Build/deploy-classic.sh /path/to/typo3-root [docker-container-name] [container-typo3-root]}
 CONTAINER=${2:-}
@@ -32,20 +45,27 @@ if [ ! -d "$TYPO3_ROOT/typo3conf" ]; then
     exit 1
 fi
 
+PAYLOAD=()
+for entry in "${PAYLOAD_CANDIDATES[@]}"; do
+    if [ -e "$REPO_ROOT/$entry" ]; then
+        PAYLOAD+=("$entry")
+    fi
+done
+
 echo "Deploying $(git -C "$REPO_ROOT" rev-parse --short HEAD) ($(git -C "$REPO_ROOT" branch --show-current)) to $EXT_DIR"
 
 # git status --porcelain also reports untracked files, which `git diff` would miss
-if [ -n "$(git -C "$REPO_ROOT" status --porcelain --untracked-files=all -- Classes Configuration Resources ext_localconf.php ext_tables.php ext_tables.sql ext_conf_template.txt ext_emconf.php 2>/dev/null)" ]; then
+if [ -n "$(git -C "$REPO_ROOT" status --porcelain --untracked-files=all -- "${PAYLOAD[@]}" 2>/dev/null)" ]; then
     echo "WARNING: uncommitted or untracked changes in extension files are NOT deployed (git HEAD is exported)." >&2
 fi
 
-# Export only tracked files of HEAD (no .git, no .Build, no local cruft),
+# Export the shipped payload of HEAD only (no .git, no Tests, no local cruft),
 # then sync into the target while keeping the bundled vendor dir alive.
 STAGE_DIR="$REPO_ROOT/.Build/deploy-stage"
 rm -rf "$STAGE_DIR"
 mkdir -p "$STAGE_DIR"
 trap 'rm -rf "$STAGE_DIR"' EXIT
-git -C "$REPO_ROOT" archive HEAD | tar -x -C "$STAGE_DIR"
+git -C "$REPO_ROOT" archive HEAD -- "${PAYLOAD[@]}" | tar -x -C "$STAGE_DIR"
 
 mkdir -p "$EXT_DIR"
 rsync -a --delete \

--- a/Classes/Command/McpServerCommand.php
+++ b/Classes/Command/McpServerCommand.php
@@ -12,6 +12,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Configuration\Tca\TcaFactory;
+use Hn\McpServer\Service\BackendUserContextService;
 use Hn\McpServer\MCP\McpServerFactory;
 
 /**
@@ -81,7 +82,8 @@ class McpServerCommand extends Command
             $beUser->user['uid'] = 1; // Add a UID for the fake user to prevent DataHandler errors
             $beUser->user['workspace_id'] = 0; // Set workspace ID to live workspace
             $beUser->workspace = 0; // Set workspace to live workspace
-            $this->restoreStoredUserConfiguration($beUser);
+            GeneralUtility::makeInstance(BackendUserContextService::class)
+                ->restoreStoredUserConfiguration($beUser);
             $GLOBALS['BE_USER'] = $beUser;
         } elseif (!$beUser->isAdmin()) {
             // If user exists but is not admin, set admin flag directly
@@ -94,23 +96,4 @@ class McpServerCommand extends Command
         }
     }
 
-    /**
-     * Load the stored user configuration (uc) of the impersonated backend user.
-     * If $beUser->uc stayed empty, a writeUC() triggered during tool execution
-     * (e.g. by the update signals fired on workspace creation) would overwrite
-     * the real user's backend preferences in the be_users record.
-     */
-    protected function restoreStoredUserConfiguration(BackendUserAuthentication $beUser): void
-    {
-        $storedUc = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getConnectionForTable('be_users')
-            ->select(['uc'], 'be_users', ['uid' => (int)$beUser->user['uid']])
-            ->fetchOne();
-        if (is_string($storedUc)) {
-            $uc = unserialize($storedUc, ['allowed_classes' => false]);
-            if (is_array($uc)) {
-                $beUser->uc = $uc;
-            }
-        }
-    }
 }

--- a/Classes/Command/McpTestCommand.php
+++ b/Classes/Command/McpTestCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Hn\McpServer\Service\BackendUserContextService;
 use Hn\McpServer\MCP\ToolRegistry;
 use Hn\McpServer\Service\WorkspaceContextService;
 use Mcp\Types\CallToolResult;
@@ -160,7 +161,8 @@ class McpTestCommand extends Command
             // Set admin flag directly since setTemporaryAdminFlag doesn't exist in TYPO3 v12
             $beUser->user['admin'] = 1;
             $beUser->user['uid'] = 1; // Add a UID for the fake user to prevent DataHandler errors
-            $this->restoreStoredUserConfiguration($beUser);
+            GeneralUtility::makeInstance(BackendUserContextService::class)
+                ->restoreStoredUserConfiguration($beUser);
             $GLOBALS['BE_USER'] = $beUser;
             
             // Set up workspace context
@@ -183,25 +185,6 @@ class McpTestCommand extends Command
         }
     }
 
-    /**
-     * Load the stored user configuration (uc) of the impersonated backend user.
-     * If $beUser->uc stayed empty, a writeUC() triggered during tool execution
-     * (e.g. by the update signals fired on workspace creation) would overwrite
-     * the real user's backend preferences in the be_users record.
-     */
-    protected function restoreStoredUserConfiguration(BackendUserAuthentication $beUser): void
-    {
-        $storedUc = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getConnectionForTable('be_users')
-            ->select(['uc'], 'be_users', ['uid' => (int)$beUser->user['uid']])
-            ->fetchOne();
-        if (is_string($storedUc)) {
-            $uc = unserialize($storedUc, ['allowed_classes' => false]);
-            if (is_array($uc)) {
-                $beUser->uc = $uc;
-            }
-        }
-    }
 
     /**
      * Ensure TCA is loaded

--- a/Classes/Http/CorsHeadersTrait.php
+++ b/Classes/Http/CorsHeadersTrait.php
@@ -26,8 +26,8 @@ trait CorsHeadersTrait
 
         return $response
             ->withHeader('Access-Control-Allow-Origin', $allowedOrigin)
-            ->withHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-            ->withHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With')
+            ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, OPTIONS')
+            ->withHeader('Access-Control-Allow-Headers', 'Content-Type, Content-Disposition, Authorization, X-Requested-With')
             ->withHeader('Access-Control-Allow-Credentials', 'true')
             ->withHeader('Access-Control-Max-Age', '86400');
     }

--- a/Classes/Http/FileUploadEndpoint.php
+++ b/Classes/Http/FileUploadEndpoint.php
@@ -35,7 +35,7 @@ class FileUploadEndpoint
     {
         try {
             if ($request->getMethod() === 'OPTIONS') {
-                return $this->addCorsHeaders(new JsonResponse([], 204), $request);
+                return $this->handlePreflightRequest($request);
             }
             if (!in_array($request->getMethod(), ['PUT', 'POST'], true)) {
                 return $this->jsonError('Use HTTP PUT (or POST) with the raw file bytes as request body.', 405, $request);
@@ -43,7 +43,7 @@ class FileUploadEndpoint
 
             $uploadService = GeneralUtility::makeInstance(FileUploadService::class);
             $token = (string)($request->getQueryParams()['token'] ?? '');
-            $tokenRow = $uploadService->validateUploadToken($token);
+            $tokenRow = $uploadService->consumeUploadToken($token);
             if ($tokenRow === null) {
                 return $this->jsonError('Invalid, expired, or already used upload token.', 401, $request);
             }
@@ -74,8 +74,6 @@ class FileUploadEndpoint
                     @unlink($tempPath);
                 }
             }
-
-            $uploadService->markUploadTokenUsed((int)$tokenRow['uid']);
 
             $data = $uploadService->describeFile($stored['file']);
             if ($stored['deduplicated']) {

--- a/Classes/Http/FileUploadEndpoint.php
+++ b/Classes/Http/FileUploadEndpoint.php
@@ -4,19 +4,13 @@ declare(strict_types=1);
 
 namespace Hn\McpServer\Http;
 
+use Hn\McpServer\Service\BackendUserContextService;
 use Hn\McpServer\Service\FileUploadService;
 use Hn\McpServer\Service\SiteInformationService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
-use TYPO3\CMS\Core\Configuration\Tca\TcaFactory;
-use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Context\UserAspect;
-use TYPO3\CMS\Core\Context\WorkspaceAspect;
-use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderAccessPermissionsException;
 use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderWritePermissionsException;
@@ -76,6 +70,10 @@ class FileUploadEndpoint
                     $request
                 );
             }
+
+            // Before buffering or touching the storage: a rejected name should
+            // cost neither disk space nor a freshly created folder.
+            $uploadService->assertFileNameIsAllowed($fileName);
 
             $tempPath = $this->bufferToTempFile($body, $uploadService->getMaxFileBytes());
             try {
@@ -170,43 +168,15 @@ class FileUploadEndpoint
     }
 
     /**
-     * Set up the TYPO3 backend user context for the token's user
-     * (same pattern as McpEndpoint's token authentication).
+     * Set up the TYPO3 backend user context for the token's user.
      */
     protected function setupBackendUserContext(int $userId): void
     {
-        $userData = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getConnectionForTable('be_users')
-            ->select(['*'], 'be_users', ['uid' => $userId, 'deleted' => 0])
-            ->fetchAssociative();
-
-        $now = time();
-        if (!$userData
-            || !empty($userData['disable'])
-            || ((int)($userData['starttime'] ?? 0) > 0 && (int)$userData['starttime'] > $now)
-            || ((int)($userData['endtime'] ?? 0) > 0 && (int)$userData['endtime'] < $now)
-        ) {
+        try {
+            GeneralUtility::makeInstance(BackendUserContextService::class)->impersonate($userId);
+        } catch (\InvalidArgumentException) {
+            // Do not reveal whether the user exists, is disabled, or expired
             throw new \InvalidArgumentException('The backend user this upload token belongs to is not available.');
-        }
-
-        $beUser = GeneralUtility::makeInstance(BackendUserAuthentication::class);
-        $beUser->user = $userData;
-        $GLOBALS['BE_USER'] = $beUser;
-        $beUser->initializeUserSessionManager();
-        $beUser->fetchGroupData();
-
-        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)
-            ->createFromUserPreferences($beUser);
-
-        // Keep the Context API in sync with $GLOBALS['BE_USER'] (same as
-        // McpEndpoint): event listeners on the FAL add events may rely on it.
-        $context = GeneralUtility::makeInstance(Context::class);
-        $context->setAspect('backend.user', new UserAspect($beUser));
-        $context->setAspect('workspace', new WorkspaceAspect($beUser->workspace));
-
-        // Ensure TCA is loaded (the middleware runs before the usual TCA bootstrap)
-        if (empty($GLOBALS['TCA'])) {
-            $GLOBALS['TCA'] = GeneralUtility::getContainer()->get(TcaFactory::class)->get();
         }
     }
 }

--- a/Classes/Http/FileUploadEndpoint.php
+++ b/Classes/Http/FileUploadEndpoint.php
@@ -11,9 +11,13 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\Tca\TcaFactory;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\UserAspect;
+use TYPO3\CMS\Core\Context\WorkspaceAspect;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderAccessPermissionsException;
 use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderWritePermissionsException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -42,7 +46,13 @@ class FileUploadEndpoint
             }
 
             $uploadService = GeneralUtility::makeInstance(FileUploadService::class);
-            $token = (string)($request->getQueryParams()['token'] ?? '');
+            // Preferred: Authorization header (query strings end up in server
+            // logs); the ?token= query parameter is kept as fallback.
+            $token = '';
+            if (preg_match('/^Bearer\s+(\S+)$/i', $request->getHeaderLine('Authorization'), $matches)) {
+                $token = $matches[1];
+            }
+            $token = $token !== '' ? $token : (string)($request->getQueryParams()['token'] ?? '');
             $tokenRow = $uploadService->consumeUploadToken($token);
             if ($tokenRow === null) {
                 return $this->jsonError('Invalid, expired, or already used upload token.', 401, $request);
@@ -53,8 +63,10 @@ class FileUploadEndpoint
 
             [$body, $uploadedFileName] = $this->extractUpload($request);
 
-            $fileName = trim((string)($request->getQueryParams()['fileName'] ?? ''))
-                ?: (string)$tokenRow['file_name']
+            // A file name fixed in the token wins: the token authorizes exactly
+            // that upload, the request must not widen it to another file type.
+            $fileName = (string)$tokenRow['file_name']
+                ?: trim((string)($request->getQueryParams()['fileName'] ?? ''))
                 ?: ($uploadedFileName ?? '')
                 ?: ($uploadService->extractFileNameFromContentDisposition($request->getHeaderLine('Content-Disposition')) ?? '');
             if ($fileName === '') {
@@ -88,7 +100,10 @@ class FileUploadEndpoint
         } catch (\InvalidArgumentException $e) {
             return $this->jsonError($e->getMessage(), 400, $request);
         } catch (\Throwable $e) {
-            return $this->jsonError('Upload failed: ' . $e->getMessage(), 500, $request);
+            // Log the details, but do not leak exception messages (paths etc.)
+            GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__)
+                ->error('Pre-signed upload failed: ' . $e->getMessage(), ['exception' => $e]);
+            return $this->jsonError('Upload failed due to an unexpected server error (see TYPO3 log).', 500, $request);
         }
     }
 
@@ -163,7 +178,12 @@ class FileUploadEndpoint
             ->select(['*'], 'be_users', ['uid' => $userId, 'deleted' => 0])
             ->fetchAssociative();
 
-        if (!$userData || !empty($userData['disable'])) {
+        $now = time();
+        if (!$userData
+            || !empty($userData['disable'])
+            || ((int)($userData['starttime'] ?? 0) > 0 && (int)$userData['starttime'] > $now)
+            || ((int)($userData['endtime'] ?? 0) > 0 && (int)$userData['endtime'] < $now)
+        ) {
             throw new \InvalidArgumentException('The backend user this upload token belongs to is not available.');
         }
 
@@ -175,6 +195,12 @@ class FileUploadEndpoint
 
         $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)
             ->createFromUserPreferences($beUser);
+
+        // Keep the Context API in sync with $GLOBALS['BE_USER'] (same as
+        // McpEndpoint): event listeners on the FAL add events may rely on it.
+        $context = GeneralUtility::makeInstance(Context::class);
+        $context->setAspect('backend.user', new UserAspect($beUser));
+        $context->setAspect('workspace', new WorkspaceAspect($beUser->workspace));
 
         // Ensure TCA is loaded (the middleware runs before the usual TCA bootstrap)
         if (empty($GLOBALS['TCA'])) {

--- a/Classes/Http/FileUploadEndpoint.php
+++ b/Classes/Http/FileUploadEndpoint.php
@@ -90,6 +90,8 @@ class FileUploadEndpoint
             $data = $uploadService->describeFile($stored['file']);
             if ($stored['deduplicated']) {
                 $data['deduplicated'] = true;
+                $data['note'] = 'A file with identical content already existed in this storage (see identifier, '
+                    . 'possibly in a different folder than requested); it is returned instead of creating a duplicate.';
             } elseif ($stored['file']->getName() !== basename($fileName)) {
                 $data['renamedFrom'] = basename($fileName);
             }

--- a/Classes/Http/FileUploadEndpoint.php
+++ b/Classes/Http/FileUploadEndpoint.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Http;
+
+use Hn\McpServer\Service\FileUploadService;
+use Hn\McpServer\Service\SiteInformationService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Configuration\Tca\TcaFactory;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderAccessPermissionsException;
+use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderWritePermissionsException;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Target of the pre-signed upload URLs handed out by the UploadFile MCP tool.
+ *
+ * Accepts the raw file bytes as PUT/POST body (curl -T style) or a multipart
+ * form upload, authenticated by a single-use token bound to a backend user
+ * and a target folder. This is the "out-of-band upload" pattern for MCP:
+ * binary data never travels through the model's context - the client's
+ * harness uploads directly and gets the created sys_file back as JSON.
+ */
+class FileUploadEndpoint
+{
+    use CorsHeadersTrait;
+
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        try {
+            if ($request->getMethod() === 'OPTIONS') {
+                return $this->addCorsHeaders(new JsonResponse([], 204), $request);
+            }
+            if (!in_array($request->getMethod(), ['PUT', 'POST'], true)) {
+                return $this->jsonError('Use HTTP PUT (or POST) with the raw file bytes as request body.', 405, $request);
+            }
+
+            $uploadService = GeneralUtility::makeInstance(FileUploadService::class);
+            $token = (string)($request->getQueryParams()['token'] ?? '');
+            $tokenRow = $uploadService->validateUploadToken($token);
+            if ($tokenRow === null) {
+                return $this->jsonError('Invalid, expired, or already used upload token.', 401, $request);
+            }
+
+            $this->setupBackendUserContext((int)$tokenRow['be_user_uid']);
+            GeneralUtility::makeInstance(SiteInformationService::class)->setCurrentRequest($request);
+
+            [$body, $uploadedFileName] = $this->extractUpload($request);
+
+            $fileName = trim((string)($request->getQueryParams()['fileName'] ?? ''))
+                ?: (string)$tokenRow['file_name']
+                ?: ($uploadedFileName ?? '')
+                ?: ($uploadService->extractFileNameFromContentDisposition($request->getHeaderLine('Content-Disposition')) ?? '');
+            if ($fileName === '') {
+                return $this->jsonError(
+                    'No file name given. Pass it as ?fileName=<name.ext> query parameter or Content-Disposition header.',
+                    400,
+                    $request
+                );
+            }
+
+            $tempPath = $this->bufferToTempFile($body, $uploadService->getMaxFileBytes());
+            try {
+                $folder = $uploadService->resolveTargetFolder((string)$tokenRow['target_folder']);
+                $stored = $uploadService->storeFile($tempPath, $fileName, $folder);
+            } finally {
+                if (file_exists($tempPath)) {
+                    @unlink($tempPath);
+                }
+            }
+
+            $uploadService->markUploadTokenUsed((int)$tokenRow['uid']);
+
+            $data = $uploadService->describeFile($stored['file']);
+            if ($stored['deduplicated']) {
+                $data['deduplicated'] = true;
+            } elseif ($stored['file']->getName() !== basename($fileName)) {
+                $data['renamedFrom'] = basename($fileName);
+            }
+
+            return $this->addCorsHeaders(new JsonResponse($data, 201), $request);
+        } catch (InsufficientFolderAccessPermissionsException | InsufficientFolderWritePermissionsException $e) {
+            return $this->jsonError('No permission for the target folder: ' . $e->getMessage(), 403, $request);
+        } catch (\InvalidArgumentException $e) {
+            return $this->jsonError($e->getMessage(), 400, $request);
+        } catch (\Throwable $e) {
+            return $this->jsonError('Upload failed: ' . $e->getMessage(), 500, $request);
+        }
+    }
+
+    /**
+     * Get the upload source: a multipart file upload when present (browser
+     * forms, curl -F), otherwise the raw request body (curl -T / PUT).
+     *
+     * @return array{0: StreamInterface, 1: string|null} stream and optional client file name
+     */
+    protected function extractUpload(ServerRequestInterface $request): array
+    {
+        $uploadedFiles = $request->getUploadedFiles();
+        if (!empty($uploadedFiles)) {
+            $first = reset($uploadedFiles);
+            if (is_array($first)) {
+                $first = reset($first);
+            }
+            if ($first instanceof \Psr\Http\Message\UploadedFileInterface) {
+                $clientName = $first->getClientFilename();
+                return [$first->getStream(), $clientName !== null ? basename($clientName) : null];
+            }
+        }
+        return [$request->getBody(), null];
+    }
+
+    /**
+     * Stream the upload into a temp file, enforcing the size limit.
+     */
+    protected function bufferToTempFile(StreamInterface $body, int $maxBytes): string
+    {
+        $tempPath = GeneralUtility::tempnam('mcp_upload_');
+        $handle = fopen($tempPath, 'wb');
+        $bytes = 0;
+        while (!$body->eof()) {
+            $chunk = $body->read(65536);
+            if ($chunk === '') {
+                break;
+            }
+            $bytes += strlen($chunk);
+            if ($bytes > $maxBytes) {
+                fclose($handle);
+                @unlink($tempPath);
+                throw new \InvalidArgumentException(
+                    'The file exceeds the maximum size of ' . round($maxBytes / 1048576) . ' MiB '
+                    . '(configurable via the extension setting "maxFileSizeMb").'
+                );
+            }
+            fwrite($handle, $chunk);
+        }
+        fclose($handle);
+
+        if ($bytes === 0) {
+            @unlink($tempPath);
+            throw new \InvalidArgumentException('The request body was empty - send the raw file bytes as PUT/POST body.');
+        }
+        return $tempPath;
+    }
+
+    protected function jsonError(string $message, int $status, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->addCorsHeaders(new JsonResponse(['error' => $message], $status), $request);
+    }
+
+    /**
+     * Set up the TYPO3 backend user context for the token's user
+     * (same pattern as McpEndpoint's token authentication).
+     */
+    protected function setupBackendUserContext(int $userId): void
+    {
+        $userData = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('be_users')
+            ->select(['*'], 'be_users', ['uid' => $userId, 'deleted' => 0])
+            ->fetchAssociative();
+
+        if (!$userData || !empty($userData['disable'])) {
+            throw new \InvalidArgumentException('The backend user this upload token belongs to is not available.');
+        }
+
+        $beUser = GeneralUtility::makeInstance(BackendUserAuthentication::class);
+        $beUser->user = $userData;
+        $GLOBALS['BE_USER'] = $beUser;
+        $beUser->initializeUserSessionManager();
+        $beUser->fetchGroupData();
+
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)
+            ->createFromUserPreferences($beUser);
+
+        // Ensure TCA is loaded (the middleware runs before the usual TCA bootstrap)
+        if (empty($GLOBALS['TCA'])) {
+            $GLOBALS['TCA'] = GeneralUtility::getContainer()->get(TcaFactory::class)->get();
+        }
+    }
+}

--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -8,17 +8,13 @@ use Mcp\Server\HttpServerRunner;
 use Mcp\Server\Transport\Http\StandardPhpAdapter;
 use Mcp\Server\Transport\Http\FileSessionStore;
 use TYPO3\CMS\Core\Core\Environment;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Context\UserAspect;
-use TYPO3\CMS\Core\Context\WorkspaceAspect;
 use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Http\Stream;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Hn\McpServer\MCP\McpServerFactory;
+use Hn\McpServer\Service\BackendUserContextService;
 use Hn\McpServer\Service\WorkspaceContextService;
 use Hn\McpServer\Service\OAuthService;
 use Hn\McpServer\Service\SiteInformationService;
@@ -234,95 +230,16 @@ class McpEndpoint
      */
     private function setupBackendUserContext(int $userId): void
     {
-        $beUser = GeneralUtility::makeInstance(BackendUserAuthentication::class);
+        $userContext = GeneralUtility::makeInstance(BackendUserContextService::class);
+        $beUser = $userContext->impersonate($userId);
 
-        // Load user data
-        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getConnectionForTable('be_users');
+        // Pick the workspace the MCP tools work in and keep the Context aspect
+        // in sync with it.
+        $workspaceService = GeneralUtility::makeInstance(WorkspaceContextService::class);
+        $workspaceId = $workspaceService->switchToOptimalWorkspace($beUser);
+        $userContext->updateWorkspaceAspect($workspaceId);
 
-        $queryBuilder = $connection->createQueryBuilder();
-        $userData = $queryBuilder
-            ->select('*')
-            ->from('be_users')
-            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($userId)))
-            ->executeQuery()
-            ->fetchAssociative();
-
-        if ($userData) {
-            $beUser->user = $userData;
-
-            // CRITICAL: Restore the user's stored configuration (uc). The regular
-            // authentication flow unserializes it via unpack_uc(), which token auth
-            // bypasses. Without this, $beUser->uc stays empty and any writeUC()
-            // triggered during request processing (e.g. the update signals fired
-            // when the MCP workspace is created below) overwrites the user's
-            // stored backend preferences with a nearly empty array. That in turn
-            // breaks the backend Setup module, which expects keys like 'titleLen'
-            // to exist ("Undefined array key" warning in SetupModuleController).
-            $storedUc = unserialize((string)($userData['uc'] ?? ''), ['allowed_classes' => false]);
-            if (is_array($storedUc)) {
-                $beUser->uc = $storedUc;
-            }
-
-            $GLOBALS['BE_USER'] = $beUser;
-
-            // CRITICAL: Initialize an (anonymous) user session.
-            // Normal TYPO3 requests go through BackendUserAuthenticator middleware which wires
-            // up a real UserSession. Token auth bypasses that, so DataHandler write paths
-            // that touch $beUser->setAndSaveSessionData() (FlashMessageQueue, BackendFormProtection)
-            // crash with "Call to a member function set() on null" on UPDATE operations.
-            // An anonymous in-memory session is discarded at request end — sufficient for stateless MCP.
-            $beUser->initializeUserSessionManager();
-
-            // CRITICAL: Fetch group data to populate permissions
-            // This computes tables_select, tables_modify, non_exclude_fields, webmounts, etc.
-            // Without this, non-admin users have no permissions computed from their groups
-            $beUser->fetchGroupData();
-
-            // Apply the uc defaults and TSconfig overrides, exactly like
-            // initializeBackendLogin() does after fetchGroupData() on a regular
-            // login. This covers users who never logged into the backend: their
-            // stored uc is empty, and without the defaults the first writeUC()
-            // would persist a nearly empty uc - which core never repairs, since
-            // backendSetUC() only fills in the defaults while uc is completely
-            // empty.
-            $beUser->backendSetUC();
-
-            // Initialize language service (required for DataHandler and other core components)
-            $this->initializeLanguageService($beUser);
-
-            // Set up workspace context
-            $workspaceService = GeneralUtility::makeInstance(WorkspaceContextService::class);
-            $workspaceId = $workspaceService->switchToOptimalWorkspace($beUser);
-
-            // Set up TYPO3 Context API (following BackendUserAuthenticator pattern)
-            $context = GeneralUtility::makeInstance(Context::class);
-            $context->setAspect('backend.user', new UserAspect($beUser));
-            $context->setAspect('workspace', new WorkspaceAspect($workspaceId));
-
-            // Log workspace selection for debugging
-            error_log("MCP: User {$userId} switched to workspace {$workspaceId}");
-        }
-
-        // Ensure TCA is loaded using proper TYPO3 core method
-        $tcaFactory = GeneralUtility::getContainer()->get(\TYPO3\CMS\Core\Configuration\Tca\TcaFactory::class);
-        $GLOBALS['TCA'] = $tcaFactory->get();
-    }
-
-    /**
-     * Initialize language service for the backend user
-     */
-    private function initializeLanguageService(BackendUserAuthentication $beUser): void
-    {
-        // Get user's preferred language or fall back to default
-        $userLanguage = $beUser->user['lang'] ?? 'default';
-
-        // Create language service
-        $languageServiceFactory = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Localization\LanguageServiceFactory::class);
-        $languageService = $languageServiceFactory->createFromUserPreferences($beUser);
-
-        // Set global language service
-        $GLOBALS['LANG'] = $languageService;
+        error_log("MCP: User {$userId} switched to workspace {$workspaceId}");
     }
 
     /**

--- a/Classes/MCP/Tool/File/UploadFileTool.php
+++ b/Classes/MCP/Tool/File/UploadFileTool.php
@@ -274,7 +274,14 @@ class UploadFileTool extends AbstractRecordTool
             $proxyConfigured = !empty($GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']);
             if (!$proxyConfigured && $resolvedIp !== null && !filter_var($host, FILTER_VALIDATE_IP) && defined('CURLOPT_RESOLVE')) {
                 $port = $parts['port'] ?? (($parts['scheme'] ?? 'https') === 'https' ? 443 : 80);
-                $options['curl'] = [\CURLOPT_RESOLVE => [$host . ':' . $port . ':' . $resolvedIp]];
+                // CURLOPT_RESOLVE wants IPv6 addresses in brackets; a bare one
+                // makes the entry malformed, and curl then silently ignores the
+                // pin - which would drop the rebinding protection for
+                // IPv6-only hosts.
+                $pinnedIp = filter_var($resolvedIp, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false
+                    ? '[' . $resolvedIp . ']'
+                    : $resolvedIp;
+                $options['curl'] = [\CURLOPT_RESOLVE => [$host . ':' . $port . ':' . $pinnedIp]];
             }
 
             try {

--- a/Classes/MCP/Tool/File/UploadFileTool.php
+++ b/Classes/MCP/Tool/File/UploadFileTool.php
@@ -354,8 +354,12 @@ class UploadFileTool extends AbstractRecordTool
             $ips = [$host];
             $isLiteral = true;
         } else {
-            $ips = gethostbynamel($host) ?: [];
-            foreach (dns_get_record($host, DNS_AAAA) ?: [] as $record) {
+            $ips = @gethostbynamel($host) ?: [];
+            // AAAA lookups fail or time out in plenty of environments (IPv6-less
+            // Docker networks, filtering resolvers). Suppress that so a broken
+            // AAAA lookup cannot kill a download that has usable A records - but
+            // never skip validation of records we did get.
+            foreach (@dns_get_record($host, DNS_AAAA) ?: [] as $record) {
                 if (!empty($record['ipv6'])) {
                     $ips[] = $record['ipv6'];
                 }

--- a/Classes/MCP/Tool/File/UploadFileTool.php
+++ b/Classes/MCP/Tool/File/UploadFileTool.php
@@ -1,0 +1,500 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\MCP\Tool\File;
+
+use Doctrine\DBAL\ParameterType;
+use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\UriResolver;
+use Hn\McpServer\MCP\Tool\Record\AbstractRecordTool;
+use Hn\McpServer\Service\SiteInformationService;
+use Mcp\Types\CallToolResult;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Resource\DefaultUploadFolderResolver;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Resource\Enum\DuplicationBehavior;
+use TYPO3\CMS\Core\Resource\Exception\ExistingTargetFolderException;
+use TYPO3\CMS\Core\Resource\Exception\FolderDoesNotExistException;
+use TYPO3\CMS\Core\Resource\Exception\IllegalFileExtensionException;
+use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderAccessPermissionsException;
+use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderWritePermissionsException;
+use TYPO3\CMS\Core\Resource\Exception\OnlineMediaAlreadyExistsException;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\Folder;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Tool for uploading new files into TYPO3 file storages (FAL).
+ *
+ * Files are deliberately create-only through MCP: physical files are not
+ * workspace-versioned in TYPO3, so overwriting or deleting them would be the
+ * only immediately-live, irreversible operation in this server. Name conflicts
+ * are therefore auto-renamed and identical content is deduplicated instead.
+ */
+class UploadFileTool extends AbstractRecordTool
+{
+    protected const MAX_DOWNLOAD_BYTES = 52428800; // 50 MiB
+    protected const MAX_REDIRECTS = 5;
+
+    /**
+     * Fallback extension per content type for URLs whose path carries no
+     * usable file name (e.g. "https://example.com/image?id=4").
+     */
+    protected const MIME_TO_EXTENSION = [
+        'image/jpeg' => 'jpg',
+        'image/png' => 'png',
+        'image/gif' => 'gif',
+        'image/webp' => 'webp',
+        'image/avif' => 'avif',
+        'image/svg+xml' => 'svg',
+        'application/pdf' => 'pdf',
+        'video/mp4' => 'mp4',
+        'audio/mpeg' => 'mp3',
+    ];
+
+    public function getSchema(): array
+    {
+        return [
+            'description' => 'Upload a new file into the TYPO3 file storage (e.g. fileadmin). '
+                . 'Provide EITHER "url" (the server downloads the file; YouTube/Vimeo URLs create an online media asset instead) '
+                . 'OR "content" (raw text for text-based formats like svg, csv or vtt). '
+                . 'This tool never overwrites anything: name conflicts are resolved by renaming (image.jpg -> image_01.jpg) '
+                . 'and re-uploading identical content returns the already existing file. '
+                . 'The file is stored immediately (files are not workspace-versioned), but it is not visible on the website '
+                . 'until a record references it - create the reference with WriteTable (e.g. tt_content.assets = [{"uid_local": <uid>}]).',
+            'inputSchema' => [
+                'type' => 'object',
+                'properties' => [
+                    'url' => [
+                        'type' => 'string',
+                        'description' => 'HTTP(S) URL to download the file from. '
+                            . 'YouTube and Vimeo video URLs are recognized and stored as TYPO3 online media assets '
+                            . '(a small placeholder file referencing the video - the video itself is not downloaded).',
+                    ],
+                    'content' => [
+                        'type' => 'string',
+                        'description' => 'Raw text content to store as a file. Only for text-based formats (svg, txt, csv, vtt, ...). '
+                            . 'Binary formats cannot be uploaded this way - use "url" instead.',
+                    ],
+                    'fileName' => [
+                        'type' => 'string',
+                        'description' => 'Target file name including extension (e.g. "team-photo.jpg"). '
+                            . 'Required with "content"; optional with "url" (derived from the URL when omitted).',
+                    ],
+                    'targetFolder' => [
+                        'type' => 'string',
+                        'description' => 'Folder path inside the storage, e.g. "/user_upload/campaign/" or "2:/some/folder/" to address '
+                            . 'a specific storage. Missing folders are created. Defaults to the user\'s default upload folder.',
+                    ],
+                ],
+            ],
+            'annotations' => [
+                'readOnlyHint' => false,
+                'destructiveHint' => false,
+                'idempotentHint' => true,
+            ],
+        ];
+    }
+
+    protected function doExecute(array $params): CallToolResult
+    {
+        $url = trim((string)($params['url'] ?? ''));
+        $content = $params['content'] ?? null;
+        $hasContent = is_string($content) && $content !== '';
+        $requestedFileName = trim((string)($params['fileName'] ?? ''));
+
+        if (($url !== '') === $hasContent) {
+            return $this->createErrorResult('Provide exactly one of "url" or "content".');
+        }
+
+        try {
+            $folder = $this->resolveTargetFolder(trim((string)($params['targetFolder'] ?? '')));
+        } catch (InsufficientFolderAccessPermissionsException | InsufficientFolderWritePermissionsException $e) {
+            return $this->createErrorResult('No permission for the target folder: ' . $e->getMessage());
+        }
+
+        if ($url !== '') {
+            // Online media (YouTube/Vimeo) never hits the download path: the URL is
+            // recognized by its pattern and stored as a placeholder file via the core API.
+            $onlineMediaResult = $this->tryCreateOnlineMedia($url, $folder);
+            if ($onlineMediaResult !== null) {
+                return $onlineMediaResult;
+            }
+            [$tempPath, $contentType, $finalUrl] = $this->downloadFile($url);
+            $fileName = $requestedFileName !== '' ? $requestedFileName : $this->deriveFileNameFromUrl($finalUrl, $contentType);
+        } else {
+            if ($requestedFileName === '') {
+                return $this->createErrorResult('"fileName" is required when uploading "content".');
+            }
+            $tempPath = GeneralUtility::tempnam('mcp_upload_');
+            if (@file_put_contents($tempPath, $content) === false) {
+                return $this->createErrorResult('Failed to buffer the uploaded content on the server.');
+            }
+            $fileName = $requestedFileName;
+        }
+
+        try {
+            $fileName = basename($fileName);
+            if ($fileName === '' || !str_contains($fileName, '.')) {
+                return $this->createErrorResult(
+                    'Could not determine a file name with an extension. Pass an explicit "fileName" like "image.jpg".'
+                );
+            }
+
+            // Identical content in this storage? Return the existing file instead of
+            // creating a copy - this also makes retries after timeouts idempotent.
+            $existingFile = $this->findIdenticalFile($folder->getStorage(), sha1_file($tempPath));
+            if ($existingFile !== null) {
+                return $this->buildResult($existingFile, $fileName, deduplicated: true);
+            }
+
+            try {
+                $file = $folder->getStorage()->addFile($tempPath, $folder, $fileName, DuplicationBehavior::RENAME);
+            } catch (IllegalFileExtensionException $e) {
+                return $this->createErrorResult('This file extension is not allowed: ' . $e->getMessage());
+            } catch (InsufficientFolderWritePermissionsException $e) {
+                return $this->createErrorResult('No permission to add files to this folder: ' . $e->getMessage());
+            } catch (\TYPO3\CMS\Core\Validation\ResultException $e) {
+                // TYPO3 >= 14: ResourceConsistencyService rejects files whose content
+                // does not match their extension/mime type.
+                return $this->createErrorResult(
+                    'The file was rejected because its content does not match the file extension "'
+                    . pathinfo($fileName, PATHINFO_EXTENSION) . '". '
+                    . 'Make sure the URL/content actually delivers this file type.'
+                );
+            }
+
+            return $this->buildResult($file, $fileName, deduplicated: false);
+        } finally {
+            if (file_exists($tempPath)) {
+                @unlink($tempPath);
+            }
+        }
+    }
+
+    /**
+     * Resolve the target folder, creating missing folders along the way.
+     * Accepts "" (default upload folder), "/path/in/default/storage" and
+     * combined identifiers like "2:/path".
+     */
+    protected function resolveTargetFolder(string $targetFolder): Folder
+    {
+        $storageRepository = GeneralUtility::makeInstance(StorageRepository::class);
+
+        if ($targetFolder === '') {
+            $folder = GeneralUtility::makeInstance(DefaultUploadFolderResolver::class)->resolve($GLOBALS['BE_USER']);
+            if (!$folder instanceof Folder) {
+                throw new \InvalidArgumentException(
+                    'No default upload folder available for this user. Pass an explicit "targetFolder".'
+                );
+            }
+            $this->applyUserPermissionsToStorage($folder->getStorage());
+            return $folder;
+        }
+
+        if (preg_match('/^(\d+):(.*)$/', $targetFolder, $matches)) {
+            $storage = $storageRepository->getStorageObject((int)$matches[1]);
+            $path = $matches[2];
+        } else {
+            $storage = $storageRepository->getDefaultStorage();
+            $path = $targetFolder;
+        }
+
+        if ($storage === null || !$storage->isOnline()) {
+            throw new \InvalidArgumentException('No usable file storage found for target folder "' . $targetFolder . '".');
+        }
+        $this->applyUserPermissionsToStorage($storage);
+
+        $segments = GeneralUtility::trimExplode('/', $path, true);
+        if (empty($segments)) {
+            return $storage->getRootLevelFolder();
+        }
+
+        // Walk down the existing part of the path, then create the remainder relative
+        // to the deepest existing folder (permission checks apply where creation starts,
+        // which keeps this working for users whose file mount is not the storage root).
+        $existingIdentifier = '/';
+        while (!empty($segments) && $storage->hasFolder($existingIdentifier . $segments[0] . '/')) {
+            $existingIdentifier .= array_shift($segments) . '/';
+        }
+        $folder = $storage->getFolder($existingIdentifier);
+        if (!empty($segments)) {
+            try {
+                $folder = $storage->createFolder(implode('/', $segments), $folder);
+            } catch (ExistingTargetFolderException) {
+                $folder = $storage->getFolder($existingIdentifier . implode('/', $segments) . '/');
+            }
+        }
+        return $folder;
+    }
+
+    /**
+     * Enforce the user's file mounts and file permissions on the storage.
+     *
+     * TYPO3's StoragePermissionsAspect does this only for backend HTTP requests;
+     * MCP tools also run via CLI/stdio where $GLOBALS['TYPO3_REQUEST'] is not a
+     * backend request, so the storage would otherwise be unrestricted for
+     * non-admin users (mirrors the read-side SysFileMountRestrictionListener).
+     */
+    protected function applyUserPermissionsToStorage(ResourceStorage $storage): void
+    {
+        $user = $GLOBALS['BE_USER'] ?? null;
+        if (!$user instanceof BackendUserAuthentication
+            || $user->isAdmin()
+            || $storage->isFallbackStorage()
+            || $storage->getEvaluatePermissions()
+        ) {
+            return;
+        }
+
+        $storage->setEvaluatePermissions(true);
+        // getFilePermissions() merged with per-storage TSconfig overrides,
+        // same as the core aspect's getFilePermissionsForStorage()
+        $permissions = $user->getFilePermissions();
+        $storageOverrides = $user->getTSConfig()['permissions.']['file.']['storage.'][$storage->getUid() . '.'] ?? [];
+        foreach ($storageOverrides as $permission => $value) {
+            $permissions[$permission] = (bool)$value;
+        }
+        $storage->setUserPermissions($permissions);
+        foreach ($user->getFileMountRecords() as $fileMountRow) {
+            if (!str_contains($fileMountRow['identifier'] ?? '', ':')) {
+                continue;
+            }
+            [$base, $path] = GeneralUtility::trimExplode(':', $fileMountRow['identifier'], false, 2);
+            if ((int)$base === $storage->getUid()) {
+                try {
+                    $storage->addFileMount($path, $fileMountRow);
+                } catch (FolderDoesNotExistException) {
+                    // Invalid mount, skip silently (same as the core aspect)
+                }
+            }
+        }
+    }
+
+    /**
+     * Store a YouTube/Vimeo URL as an online media asset via the core helper.
+     * Returns null when the URL is not an online media URL.
+     */
+    protected function tryCreateOnlineMedia(string $url, Folder $folder): ?CallToolResult
+    {
+        $registry = GeneralUtility::makeInstance(OnlineMediaHelperRegistry::class);
+        try {
+            $file = $registry->transformUrlToFile($url, $folder);
+        } catch (OnlineMediaAlreadyExistsException $e) {
+            return $this->buildResult($e->getOnlineMedia(), '', deduplicated: true, onlineMedia: true);
+        }
+        if ($file === null) {
+            return null;
+        }
+        return $this->buildResult($file, $file->getName(), deduplicated: false, onlineMedia: true);
+    }
+
+    /**
+     * Download a remote file to a temp path, following redirects manually so
+     * every hop passes the SSRF checks. Returns [tempPath, contentType, finalUrl].
+     *
+     * @return array{0: string, 1: string, 2: string}
+     */
+    protected function downloadFile(string $url): array
+    {
+        $requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
+        $currentUrl = $url;
+
+        for ($hop = 0; $hop <= self::MAX_REDIRECTS; $hop++) {
+            $resolvedIp = $this->assertPublicHttpUrl($currentUrl);
+
+            $options = [
+                'allow_redirects' => false,
+                'http_errors' => false,
+                'stream' => true,
+                'connect_timeout' => 10,
+                'timeout' => 60,
+                'headers' => ['User-Agent' => 'TYPO3-MCP-Server'],
+            ];
+            // Pin the vetted IP so the actual request cannot be re-routed to an
+            // internal address via DNS rebinding (honored by the curl handler;
+            // harmless elsewhere).
+            $parts = parse_url($currentUrl);
+            $host = $parts['host'] ?? '';
+            if ($resolvedIp !== null && !filter_var($host, FILTER_VALIDATE_IP) && defined('CURLOPT_RESOLVE')) {
+                $port = $parts['port'] ?? (($parts['scheme'] ?? 'https') === 'https' ? 443 : 80);
+                $options['curl'] = [\CURLOPT_RESOLVE => [$host . ':' . $port . ':' . $resolvedIp]];
+            }
+
+            $response = $requestFactory->request($currentUrl, 'GET', $options);
+            $status = $response->getStatusCode();
+
+            if ($status >= 300 && $status < 400) {
+                $location = $response->getHeaderLine('Location');
+                if ($location === '') {
+                    throw new \InvalidArgumentException('The URL redirected without a Location header.');
+                }
+                $currentUrl = (string)UriResolver::resolve(new Uri($currentUrl), new Uri($location));
+                continue;
+            }
+            if ($status !== 200) {
+                throw new \InvalidArgumentException('Downloading the URL failed with HTTP status ' . $status . '.');
+            }
+
+            $tempPath = GeneralUtility::tempnam('mcp_upload_');
+            $handle = fopen($tempPath, 'wb');
+            $body = $response->getBody();
+            $bytes = 0;
+            while (!$body->eof()) {
+                $chunk = $body->read(65536);
+                if ($chunk === '') {
+                    break;
+                }
+                $bytes += strlen($chunk);
+                if ($bytes > self::MAX_DOWNLOAD_BYTES) {
+                    fclose($handle);
+                    @unlink($tempPath);
+                    throw new \InvalidArgumentException(
+                        'The file exceeds the maximum download size of ' . (self::MAX_DOWNLOAD_BYTES / 1048576) . ' MiB.'
+                    );
+                }
+                fwrite($handle, $chunk);
+            }
+            fclose($handle);
+
+            if ($bytes === 0) {
+                @unlink($tempPath);
+                throw new \InvalidArgumentException('The URL returned an empty response body.');
+            }
+
+            return [$tempPath, $response->getHeaderLine('Content-Type'), $currentUrl];
+        }
+
+        throw new \InvalidArgumentException('Too many redirects while downloading the URL.');
+    }
+
+    /**
+     * Validate that a URL is http(s) and does not point at a private or
+     * reserved address. Returns the vetted IP (null for URLs whose host is
+     * already an IP literal).
+     */
+    protected function assertPublicHttpUrl(string $url): ?string
+    {
+        $parts = parse_url($url);
+        $scheme = strtolower($parts['scheme'] ?? '');
+        $host = strtolower(trim($parts['host'] ?? '', '[]'));
+
+        if (!in_array($scheme, ['http', 'https'], true) || $host === '') {
+            throw new \InvalidArgumentException('Only http:// and https:// URLs can be downloaded. Got: ' . $url);
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            $ips = [$host];
+            $isLiteral = true;
+        } else {
+            $ips = gethostbynamel($host) ?: [];
+            foreach (dns_get_record($host, DNS_AAAA) ?: [] as $record) {
+                if (!empty($record['ipv6'])) {
+                    $ips[] = $record['ipv6'];
+                }
+            }
+            if (empty($ips)) {
+                throw new \InvalidArgumentException('Could not resolve host "' . $host . '".');
+            }
+            $isLiteral = false;
+        }
+
+        foreach ($ips as $ip) {
+            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+                throw new \InvalidArgumentException(
+                    'The URL points to a private or reserved network address and cannot be downloaded.'
+                );
+            }
+        }
+
+        return $isLiteral ? null : $ips[0];
+    }
+
+    protected function deriveFileNameFromUrl(string $url, string $contentType): string
+    {
+        $path = parse_url($url, PHP_URL_PATH) ?: '';
+        $fileName = basename(rawurldecode($path));
+
+        if ($fileName !== '' && str_contains($fileName, '.')) {
+            return $fileName;
+        }
+
+        $mimeType = strtolower(trim(explode(';', $contentType)[0]));
+        $extension = self::MIME_TO_EXTENSION[$mimeType] ?? null;
+        if ($extension === null) {
+            throw new \InvalidArgumentException(
+                'Could not derive a file name from the URL (content type "' . $contentType . '"). Pass an explicit "fileName".'
+            );
+        }
+        return ($fileName !== '' ? $fileName : 'download') . '.' . $extension;
+    }
+
+    /**
+     * Find a non-missing file with identical content (same SHA1) in the storage.
+     * Non-admin users only get matches within their file mounts, otherwise the
+     * dedupe would leak (and hand out) files they cannot access.
+     */
+    protected function findIdenticalFile(ResourceStorage $storage, string $sha1): ?File
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_file');
+        $rows = $queryBuilder->select('uid')
+            ->from('sys_file')
+            ->where(
+                $queryBuilder->expr()->eq('storage', $queryBuilder->createNamedParameter($storage->getUid(), ParameterType::INTEGER)),
+                $queryBuilder->expr()->eq('sha1', $queryBuilder->createNamedParameter($sha1)),
+                $queryBuilder->expr()->eq('missing', $queryBuilder->createNamedParameter(0, ParameterType::INTEGER))
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        foreach ($rows as $row) {
+            $uid = (int)$row['uid'];
+            if (!$GLOBALS['BE_USER']->isAdmin() && !$this->tableAccessService->canAccessFileUid($uid)) {
+                continue;
+            }
+            try {
+                return GeneralUtility::makeInstance(ResourceFactory::class)->getFileObject($uid);
+            } catch (\Exception) {
+                continue;
+            }
+        }
+        return null;
+    }
+
+    protected function buildResult(File $file, string $requestedFileName, bool $deduplicated, bool $onlineMedia = false): CallToolResult
+    {
+        $siteInformation = GeneralUtility::makeInstance(SiteInformationService::class);
+
+        $data = [
+            'uid' => $file->getUid(),
+            'fileName' => $file->getName(),
+            'identifier' => $file->getCombinedIdentifier(),
+            'publicUrl' => $siteInformation->makeAbsoluteUrl($file->getPublicUrl()),
+            'mimeType' => $file->getMimeType(),
+            'size' => $file->getSize(),
+        ];
+
+        if ($onlineMedia) {
+            $data['onlineMedia'] = true;
+        }
+        if ($deduplicated) {
+            $data['deduplicated'] = true;
+            $data['note'] = 'An identical file already exists in this storage; it is returned instead of creating a duplicate.';
+        } else {
+            if ($requestedFileName !== '' && $file->getName() !== $requestedFileName) {
+                $data['renamedFrom'] = $requestedFileName;
+                $data['note'] = 'A different file with this name already existed, so the upload was stored under a new name.';
+            }
+            $data['nextStep'] = 'The file is stored but not yet used anywhere. Reference it from a record via WriteTable, '
+                . 'e.g. tt_content field "assets": [{"uid_local": ' . $file->getUid() . ', "alternative": "<alt text>"}].';
+        }
+
+        return $this->createJsonResult($data);
+    }
+}

--- a/Classes/MCP/Tool/File/UploadFileTool.php
+++ b/Classes/MCP/Tool/File/UploadFileTool.php
@@ -142,6 +142,7 @@ class UploadFileTool extends AbstractRecordTool
             }
             $tempPath = GeneralUtility::tempnam('mcp_upload_');
             if (@file_put_contents($tempPath, $content) === false) {
+                @unlink($tempPath);
                 return $this->createErrorResult('Failed to buffer the uploaded content on the server.');
             }
             $fileName = $requestedFileName;
@@ -166,9 +167,21 @@ class UploadFileTool extends AbstractRecordTool
      */
     protected function createPresignedUploadResult(FileUploadService $uploadService, Folder $folder, string $fileName): CallToolResult
     {
-        $tokenData = $uploadService->createUploadToken($folder, $fileName);
+        // Resolve the endpoint URL before minting a token: a relative upload
+        // URL is unusable for the client, so fail hard instead (typically
+        // stdio mode without a fully qualified site base).
         $siteInformation = GeneralUtility::makeInstance(SiteInformationService::class);
-        $uploadUrl = $siteInformation->makeAbsoluteUrl('/mcp_upload?token=' . $tokenData['token']);
+        $endpointUrl = (string)$siteInformation->makeAbsoluteUrl('/mcp_upload');
+        if (!str_starts_with($endpointUrl, 'http://') && !str_starts_with($endpointUrl, 'https://')) {
+            return $this->createErrorResult(
+                'Cannot build an absolute upload URL because no public base URL of this TYPO3 instance is known '
+                . '(no HTTP request context and no site with a fully qualified base URL). '
+                . 'Configure a site base URL including scheme and domain, or upload via "url" or "content" instead.'
+            );
+        }
+
+        $tokenData = $uploadService->createUploadToken($folder, $fileName);
+        $uploadUrl = $endpointUrl . '?token=' . $tokenData['token'];
 
         $curlFileName = $fileName !== '' ? $fileName : 'photo.jpg';
         $curlUrl = $uploadUrl . ($fileName === '' ? '&fileName=' . $curlFileName : '');
@@ -293,11 +306,20 @@ class UploadFileTool extends AbstractRecordTool
             throw new \InvalidArgumentException('The URL returned an empty response body.');
         }
 
-        $fileName = $requestedFileName !== '' ? $requestedFileName : $this->deriveFileName(
-            $finalUrl,
-            $response->getHeaderLine('Content-Disposition'),
-            $response->getHeaderLine('Content-Type')
-        );
+        if ($requestedFileName !== '') {
+            return [$tempPath, $requestedFileName];
+        }
+
+        try {
+            $fileName = $this->deriveFileName(
+                $finalUrl,
+                $response->getHeaderLine('Content-Disposition'),
+                $response->getHeaderLine('Content-Type')
+            );
+        } catch (\Throwable $e) {
+            @unlink($tempPath);
+            throw $e;
+        }
 
         return [$tempPath, $fileName];
     }

--- a/Classes/MCP/Tool/File/UploadFileTool.php
+++ b/Classes/MCP/Tool/File/UploadFileTool.php
@@ -317,6 +317,18 @@ class UploadFileTool extends AbstractRecordTool
             throw new \InvalidArgumentException('The URL returned an empty response body.');
         }
 
+        // A web page is not a file. Without this, the download would be rejected
+        // further down with a message about file extensions or mismatching
+        // content, which sends the caller hunting for the wrong problem.
+        if ($this->looksLikeHtmlDocument($tempPath)) {
+            @unlink($tempPath);
+            throw new \InvalidArgumentException(
+                'The URL returned a web page (HTML), not a file. Pass a direct link to the file itself '
+                . '(e.g. the image address from the page, usually ending in .jpg/.png/.pdf). '
+                . 'YouTube and Vimeo page URLs are the exception - those are recognized and embedded as videos.'
+            );
+        }
+
         if ($requestedFileName !== '') {
             return [$tempPath, $requestedFileName];
         }
@@ -333,6 +345,33 @@ class UploadFileTool extends AbstractRecordTool
         }
 
         return [$tempPath, $fileName];
+    }
+
+    /**
+     * Sniff the downloaded bytes for an HTML document. Deliberately content-based
+     * rather than header-based: servers mislabel real files as text/html often
+     * enough that a Content-Type check alone would reject valid downloads.
+     */
+    protected function looksLikeHtmlDocument(string $tempPath): bool
+    {
+        $handle = @fopen($tempPath, 'rb');
+        if ($handle === false) {
+            return false;
+        }
+        $head = (string)fread($handle, 1024);
+        fclose($handle);
+
+        // Skip a UTF-8 BOM and leading whitespace, then look for the markers a
+        // browser would use to decide it is dealing with a document.
+        $head = strtolower(ltrim(preg_replace('/^\xEF\xBB\xBF/', '', $head) ?? ''));
+        foreach (['<!doctype html', '<html', '<head', '<body'] as $marker) {
+            if (str_starts_with($head, $marker)) {
+                return true;
+            }
+        }
+
+        // Documents that open with a comment or an XML declaration
+        return (bool)preg_match('/^(<\?xml[^>]*\?>|<!--.{0,200}?-->)\s*(<!doctype html|<html)/s', $head);
     }
 
     /**

--- a/Classes/MCP/Tool/File/UploadFileTool.php
+++ b/Classes/MCP/Tool/File/UploadFileTool.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Hn\McpServer\MCP\Tool\File;
 
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\RedirectMiddleware;
+use GuzzleHttp\Psr7\UriResolver;
+use GuzzleHttp\Psr7\Utils;
 use Hn\McpServer\MCP\Tool\Record\AbstractRecordTool;
 use Hn\McpServer\Service\FileUploadService;
 use Hn\McpServer\Service\SiteInformationService;
@@ -16,6 +17,7 @@ use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderWritePermissionsExceptio
 use TYPO3\CMS\Core\Resource\Exception\OnlineMediaAlreadyExistsException;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\Folder;
+use TYPO3\CMS\Core\Resource\MimeTypeDetector;
 use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -35,19 +37,16 @@ class UploadFileTool extends AbstractRecordTool
     protected const MAX_REDIRECTS = 5;
 
     /**
-     * Fallback extension per content type for URLs whose path carries no
-     * usable file name (e.g. "https://example.com/image?id=4").
+     * Internal/special-purpose IPv4 ranges that PHP's NO_PRIV_RANGE/NO_RES_RANGE
+     * filter flags do NOT cover. The documentation ranges (TEST-NET-1..3) stay
+     * allowed on purpose: they are not routable, and the functional tests use
+     * them as safe "public" IP literals.
      */
-    protected const MIME_TO_EXTENSION = [
-        'image/jpeg' => 'jpg',
-        'image/png' => 'png',
-        'image/gif' => 'gif',
-        'image/webp' => 'webp',
-        'image/avif' => 'avif',
-        'image/svg+xml' => 'svg',
-        'application/pdf' => 'pdf',
-        'video/mp4' => 'mp4',
-        'audio/mpeg' => 'mp3',
+    protected const BLOCKED_IPV4_CIDRS = [
+        '100.64.0.0/10', // CGNAT - cloud-internal, e.g. Alibaba metadata 100.100.100.200
+        '192.0.0.0/24',  // IETF protocol assignments
+        '198.18.0.0/15', // benchmarking
+        '224.0.0.0/4',   // multicast
     ];
 
     public function getSchema(): array
@@ -140,6 +139,13 @@ class UploadFileTool extends AbstractRecordTool
             if ($requestedFileName === '') {
                 return $this->createErrorResult('"fileName" is required when uploading "content".');
             }
+            $maxBytes = $uploadService->getMaxFileBytes();
+            if (strlen($content) > $maxBytes) {
+                return $this->createErrorResult(
+                    'The content exceeds the maximum size of ' . round($maxBytes / 1048576) . ' MiB '
+                    . '(configurable via the extension setting "maxFileSizeMb").'
+                );
+            }
             $tempPath = GeneralUtility::tempnam('mcp_upload_');
             if (@file_put_contents($tempPath, $content) === false) {
                 @unlink($tempPath);
@@ -181,20 +187,23 @@ class UploadFileTool extends AbstractRecordTool
         }
 
         $tokenData = $uploadService->createUploadToken($folder, $fileName);
-        $uploadUrl = $endpointUrl . '?token=' . $tokenData['token'];
 
+        // The token travels as an Authorization header, not in the URL: query
+        // strings end up in webserver and proxy logs.
         $curlFileName = $fileName !== '' ? $fileName : 'photo.jpg';
-        $curlUrl = $uploadUrl . ($fileName === '' ? '&fileName=' . $curlFileName : '');
+        $curlUrl = $endpointUrl . ($fileName === '' ? '?fileName=' . rawurlencode($curlFileName) : '');
 
         return $this->createJsonResult([
-            'uploadUrl' => $uploadUrl,
+            'uploadUrl' => $endpointUrl,
+            'uploadToken' => $tokenData['token'],
             'targetFolder' => $folder->getCombinedIdentifier(),
             'fileName' => $fileName !== '' ? $fileName : null,
             'validUntil' => date('c', $tokenData['validUntil']),
-            'instructions' => 'Send the raw file bytes via HTTP PUT (or POST) to the uploadUrl, e.g.: '
-                . "curl -sS -T '" . $curlFileName . "' '" . $curlUrl . "'"
+            'instructions' => 'Send the raw file bytes via HTTP PUT (or POST) to the uploadUrl, '
+                . 'passing the uploadToken as bearer token, e.g.: '
+                . "curl -sS -T '" . $curlFileName . "' -H 'Authorization: Bearer " . $tokenData['token'] . "' '" . $curlUrl . "'"
                 . ($fileName === '' ? ' - replace the fileName query parameter with the actual file name including extension.' : '')
-                . ' The URL is single-use and expires at validUntil. '
+                . ' The token is single-use and expires at validUntil. '
                 . 'The endpoint responds with JSON containing the created file (uid, fileName, publicUrl, ...); '
                 . 'use that uid with WriteTable to reference the file from a record.',
         ]);
@@ -219,65 +228,67 @@ class UploadFileTool extends AbstractRecordTool
     }
 
     /**
-     * Download a remote file to a temp path. Redirects are followed by Guzzle,
-     * but every hop is re-validated against the SSRF rules via on_redirect.
+     * Download a remote file to a temp path. Redirects are followed manually
+     * so that EVERY hop is both validated against the SSRF rules and pinned
+     * to the IP that was validated (DNS rebinding would otherwise allow a
+     * second lookup between the check and the actual connect).
      * Returns [tempPath, fileName].
      *
      * @return array{0: string, 1: string}
      */
     protected function downloadFile(string $url, string $requestedFileName, int $maxBytes): array
     {
-        $resolvedIp = $this->assertPublicHttpUrl($url);
+        $currentUrl = $url;
+        $response = null;
+        for ($hop = 0; $hop <= self::MAX_REDIRECTS; $hop++) {
+            $resolvedIp = $this->assertPublicHttpUrl($currentUrl);
 
-        $options = [
-            'allow_redirects' => [
-                'max' => self::MAX_REDIRECTS,
-                'strict' => true,
-                'referer' => false,
-                'protocols' => ['http', 'https'],
-                'track_redirects' => true,
-                'on_redirect' => function ($request, $response, $uri): void {
-                    $this->assertPublicHttpUrl((string)$uri);
-                },
-            ],
-            'http_errors' => false,
-            'stream' => true,
-            'connect_timeout' => 10,
-            'timeout' => 300,
-            'headers' => ['User-Agent' => 'TYPO3-MCP-Server'],
-        ];
-        // Pin the vetted IP so the actual request cannot be re-routed to an
-        // internal address via DNS rebinding (honored by the curl handler;
-        // harmless elsewhere). Only possible for the first hop - redirect
-        // targets are still host-validated in on_redirect above.
-        $parts = parse_url($url);
-        $host = $parts['host'] ?? '';
-        if ($resolvedIp !== null && !filter_var($host, FILTER_VALIDATE_IP) && defined('CURLOPT_RESOLVE')) {
-            $port = $parts['port'] ?? (($parts['scheme'] ?? 'https') === 'https' ? 443 : 80);
-            $options['curl'] = [\CURLOPT_RESOLVE => [$host . ':' . $port . ':' . $resolvedIp]];
+            $options = [
+                'allow_redirects' => false,
+                'http_errors' => false,
+                'stream' => true,
+                'connect_timeout' => 10,
+                'timeout' => 300,
+                'headers' => ['User-Agent' => 'TYPO3-MCP-Server'],
+            ];
+            // Pin the vetted IP so the actual connect cannot be re-routed to an
+            // internal address via DNS rebinding (honored by the curl handler;
+            // harmless elsewhere). Skipped when TYPO3 routes HTTP through a
+            // proxy: the proxy resolves the host itself, pinning would break it.
+            $parts = parse_url($currentUrl);
+            $host = $parts['host'] ?? '';
+            $proxyConfigured = !empty($GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']);
+            if (!$proxyConfigured && $resolvedIp !== null && !filter_var($host, FILTER_VALIDATE_IP) && defined('CURLOPT_RESOLVE')) {
+                $port = $parts['port'] ?? (($parts['scheme'] ?? 'https') === 'https' ? 443 : 80);
+                $options['curl'] = [\CURLOPT_RESOLVE => [$host . ':' . $port . ':' . $resolvedIp]];
+            }
+
+            try {
+                $response = GeneralUtility::makeInstance(RequestFactory::class)->request($currentUrl, 'GET', $options);
+            } catch (GuzzleException $e) {
+                throw new \InvalidArgumentException('Downloading the URL failed: ' . $e->getMessage(), 0, $e);
+            }
+
+            if (!in_array($response->getStatusCode(), [301, 302, 303, 307, 308], true)) {
+                break;
+            }
+
+            $location = $response->getHeaderLine('Location');
+            if ($location === '') {
+                throw new \InvalidArgumentException('The URL redirected without a Location header.');
+            }
+            $currentUrl = (string)UriResolver::resolve(Utils::uriFor($currentUrl), Utils::uriFor($location));
+            $response = null;
         }
-
-        try {
-            $response = GeneralUtility::makeInstance(RequestFactory::class)->request($url, 'GET', $options);
-        } catch (GuzzleException $e) {
-            // Re-throw SSRF violations from on_redirect with their original message
-            $previous = $e->getPrevious();
-            if ($previous instanceof \InvalidArgumentException) {
-                throw $previous;
-            }
-            if ($e instanceof \InvalidArgumentException) {
-                throw $e;
-            }
-            throw new \InvalidArgumentException('Downloading the URL failed: ' . $e->getMessage(), 0, $e);
+        if ($response === null) {
+            throw new \InvalidArgumentException('The URL redirected more than ' . self::MAX_REDIRECTS . ' times.');
         }
 
         if ($response->getStatusCode() !== 200) {
             throw new \InvalidArgumentException('Downloading the URL failed with HTTP status ' . $response->getStatusCode() . '.');
         }
 
-        // The final URL after redirects (Guzzle records the hops in a response header)
-        $redirectHistory = $response->getHeader(RedirectMiddleware::HISTORY_HEADER);
-        $finalUrl = $redirectHistory !== [] ? (string)end($redirectHistory) : $url;
+        $finalUrl = $currentUrl;
 
         $tempPath = GeneralUtility::tempnam('mcp_upload_');
         $handle = fopen($tempPath, 'wb');
@@ -356,14 +367,55 @@ class UploadFileTool extends AbstractRecordTool
         }
 
         foreach ($ips as $ip) {
-            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
-                throw new \InvalidArgumentException(
-                    'The URL points to a private or reserved network address and cannot be downloaded.'
-                );
-            }
+            $this->assertPublicIp($ip);
         }
 
         return $isLiteral ? null : $ips[0];
+    }
+
+    /**
+     * Reject private, reserved, and cloud-internal addresses, including IPv4
+     * addresses embedded in IPv6 (mapped, NAT64, 6to4), which would otherwise
+     * smuggle e.g. 127.0.0.1 past the IPv4 checks.
+     */
+    protected function assertPublicIp(string $ip): void
+    {
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+            throw new \InvalidArgumentException(
+                'The URL points to a private or reserved network address and cannot be downloaded.'
+            );
+        }
+
+        $binary = inet_pton($ip);
+        if ($binary === false) {
+            throw new \InvalidArgumentException('The URL resolves to an invalid IP address.');
+        }
+
+        if (strlen($binary) === 4) {
+            foreach (self::BLOCKED_IPV4_CIDRS as $cidr) {
+                [$net, $bits] = explode('/', $cidr);
+                $mask = -1 << (32 - (int)$bits);
+                if ((ip2long($ip) & $mask) === (ip2long($net) & $mask)) {
+                    throw new \InvalidArgumentException(
+                        'The URL points to a private or reserved network address and cannot be downloaded.'
+                    );
+                }
+            }
+            return;
+        }
+
+        // IPv6: validate any embedded IPv4 address as well
+        $embedded = null;
+        if (str_starts_with($binary, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff")) {
+            $embedded = substr($binary, 12, 4); // ::ffff:a.b.c.d (IPv4-mapped)
+        } elseif (str_starts_with($binary, "\x00\x64\xff\x9b")) {
+            $embedded = substr($binary, 12, 4); // 64:ff9b::/96 (NAT64)
+        } elseif (str_starts_with($binary, "\x20\x02")) {
+            $embedded = substr($binary, 2, 4);  // 2002::/16 (6to4)
+        }
+        if ($embedded !== null) {
+            $this->assertPublicIp(inet_ntop($embedded));
+        }
     }
 
     /**
@@ -385,7 +437,8 @@ class UploadFileTool extends AbstractRecordTool
         }
 
         $mimeType = strtolower(trim(explode(';', $contentType)[0]));
-        $extension = self::MIME_TO_EXTENSION[$mimeType] ?? null;
+        $extension = GeneralUtility::makeInstance(MimeTypeDetector::class)
+            ->getFileExtensionsForMimeType($mimeType)[0] ?? null;
         if ($extension === null) {
             throw new \InvalidArgumentException(
                 'Could not derive a file name from the URL (content type "' . $contentType . '"). Pass an explicit "fileName".'
@@ -408,7 +461,8 @@ class UploadFileTool extends AbstractRecordTool
         }
         if ($deduplicated) {
             $data['deduplicated'] = true;
-            $data['note'] = 'An identical file already exists in this storage; it is returned instead of creating a duplicate.';
+            $data['note'] = 'A file with identical content already exists in this storage at "' . $file->getCombinedIdentifier()
+                . '" (possibly in a different folder than requested); it is returned instead of creating a duplicate.';
         } else {
             if ($requestedFileName !== '' && $file->getName() !== $requestedFileName) {
                 $data['renamedFrom'] = $requestedFileName;

--- a/Classes/MCP/Tool/File/UploadFileTool.php
+++ b/Classes/MCP/Tool/File/UploadFileTool.php
@@ -4,42 +4,34 @@ declare(strict_types=1);
 
 namespace Hn\McpServer\MCP\Tool\File;
 
-use Doctrine\DBAL\ParameterType;
-use GuzzleHttp\Psr7\Uri;
-use GuzzleHttp\Psr7\UriResolver;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\RedirectMiddleware;
 use Hn\McpServer\MCP\Tool\Record\AbstractRecordTool;
+use Hn\McpServer\Service\FileUploadService;
 use Hn\McpServer\Service\SiteInformationService;
 use Mcp\Types\CallToolResult;
-use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\RequestFactory;
-use TYPO3\CMS\Core\Resource\DefaultUploadFolderResolver;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
-use TYPO3\CMS\Core\Resource\Enum\DuplicationBehavior;
-use TYPO3\CMS\Core\Resource\Exception\ExistingTargetFolderException;
-use TYPO3\CMS\Core\Resource\Exception\FolderDoesNotExistException;
-use TYPO3\CMS\Core\Resource\Exception\IllegalFileExtensionException;
 use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderAccessPermissionsException;
 use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderWritePermissionsException;
 use TYPO3\CMS\Core\Resource\Exception\OnlineMediaAlreadyExistsException;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\Folder;
 use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
-use TYPO3\CMS\Core\Resource\ResourceFactory;
-use TYPO3\CMS\Core\Resource\ResourceStorage;
-use TYPO3\CMS\Core\Resource\StorageRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Tool for uploading new files into TYPO3 file storages (FAL).
  *
- * Files are deliberately create-only through MCP: physical files are not
- * workspace-versioned in TYPO3, so overwriting or deleting them would be the
- * only immediately-live, irreversible operation in this server. Name conflicts
- * are therefore auto-renamed and identical content is deduplicated instead.
+ * Three modes:
+ *  - url:      the server downloads the file (YouTube/Vimeo URLs become online media assets)
+ *  - content:  raw text is stored as a file (svg, csv, vtt, ...)
+ *  - neither:  a pre-signed, single-use upload URL is returned so the client
+ *              can HTTP-PUT a local file directly to the TYPO3 instance
+ *
+ * Files are create-only; see FileUploadService for the rename/dedupe rules.
  */
 class UploadFileTool extends AbstractRecordTool
 {
-    protected const MAX_DOWNLOAD_BYTES = 52428800; // 50 MiB
     protected const MAX_REDIRECTS = 5;
 
     /**
@@ -60,10 +52,24 @@ class UploadFileTool extends AbstractRecordTool
 
     public function getSchema(): array
     {
+        $uploadService = GeneralUtility::makeInstance(FileUploadService::class);
+
+        $targetFolderProperty = [
+            'type' => 'string',
+            'description' => 'Folder path inside the storage, e.g. "/user_upload/campaign/" or "2:/some/folder/" to address '
+                . 'a specific storage. Missing folders are created.',
+        ];
+        $defaultFolder = $uploadService->getDefaultUploadFolderIdentifier();
+        if ($defaultFolder !== null) {
+            $targetFolderProperty['default'] = $defaultFolder;
+        }
+
         return [
             'description' => 'Upload a new file into the TYPO3 file storage (e.g. fileadmin). '
-                . 'Provide EITHER "url" (the server downloads the file; YouTube/Vimeo URLs create an online media asset instead) '
-                . 'OR "content" (raw text for text-based formats like svg, csv or vtt). '
+                . 'Provide "url" (the server downloads the file; YouTube/Vimeo URLs create an online media asset) '
+                . 'or "content" (raw text for text-based formats like svg, csv or vtt). '
+                . 'With NEITHER of them, a pre-signed single-use upload URL is returned to which a local file '
+                . 'can be sent directly via HTTP PUT (e.g. with curl) - use this to upload files from the local machine. '
                 . 'This tool never overwrites anything: name conflicts are resolved by renaming (image.jpg -> image_01.jpg) '
                 . 'and re-uploading identical content returns the already existing file. '
                 . 'The file is stored immediately (files are not workspace-versioned), but it is not visible on the website '
@@ -80,18 +86,15 @@ class UploadFileTool extends AbstractRecordTool
                     'content' => [
                         'type' => 'string',
                         'description' => 'Raw text content to store as a file. Only for text-based formats (svg, txt, csv, vtt, ...). '
-                            . 'Binary formats cannot be uploaded this way - use "url" instead.',
+                            . 'Binary formats cannot be uploaded this way - use "url" or the pre-signed upload URL instead.',
                     ],
                     'fileName' => [
                         'type' => 'string',
                         'description' => 'Target file name including extension (e.g. "team-photo.jpg"). '
-                            . 'Required with "content"; optional with "url" (derived from the URL when omitted).',
+                            . 'Required with "content"; optional otherwise (derived from the URL, Content-Disposition header, '
+                            . 'or provided during the pre-signed upload).',
                     ],
-                    'targetFolder' => [
-                        'type' => 'string',
-                        'description' => 'Folder path inside the storage, e.g. "/user_upload/campaign/" or "2:/some/folder/" to address '
-                            . 'a specific storage. Missing folders are created. Defaults to the user\'s default upload folder.',
-                    ],
+                    'targetFolder' => $targetFolderProperty,
                 ],
             ],
             'annotations' => [
@@ -108,26 +111,31 @@ class UploadFileTool extends AbstractRecordTool
         $content = $params['content'] ?? null;
         $hasContent = is_string($content) && $content !== '';
         $requestedFileName = trim((string)($params['fileName'] ?? ''));
+        $uploadService = GeneralUtility::makeInstance(FileUploadService::class);
 
-        if (($url !== '') === $hasContent) {
-            return $this->createErrorResult('Provide exactly one of "url" or "content".');
+        if ($url !== '' && $hasContent) {
+            return $this->createErrorResult('Provide only one of "url" or "content" (or neither for a pre-signed upload URL).');
         }
 
         try {
-            $folder = $this->resolveTargetFolder(trim((string)($params['targetFolder'] ?? '')));
+            $folder = $uploadService->resolveTargetFolder(trim((string)($params['targetFolder'] ?? '')));
         } catch (InsufficientFolderAccessPermissionsException | InsufficientFolderWritePermissionsException $e) {
             return $this->createErrorResult('No permission for the target folder: ' . $e->getMessage());
+        }
+
+        // No source at all: hand out a pre-signed upload URL instead
+        if ($url === '' && !$hasContent) {
+            return $this->createPresignedUploadResult($uploadService, $folder, $requestedFileName);
         }
 
         if ($url !== '') {
             // Online media (YouTube/Vimeo) never hits the download path: the URL is
             // recognized by its pattern and stored as a placeholder file via the core API.
-            $onlineMediaResult = $this->tryCreateOnlineMedia($url, $folder);
+            $onlineMediaResult = $this->tryCreateOnlineMedia($url, $folder, $uploadService);
             if ($onlineMediaResult !== null) {
                 return $onlineMediaResult;
             }
-            [$tempPath, $contentType, $finalUrl] = $this->downloadFile($url);
-            $fileName = $requestedFileName !== '' ? $requestedFileName : $this->deriveFileNameFromUrl($finalUrl, $contentType);
+            [$tempPath, $fileName] = $this->downloadFile($url, $requestedFileName, $uploadService->getMaxFileBytes());
         } else {
             if ($requestedFileName === '') {
                 return $this->createErrorResult('"fileName" is required when uploading "content".');
@@ -140,37 +148,12 @@ class UploadFileTool extends AbstractRecordTool
         }
 
         try {
-            $fileName = basename($fileName);
-            if ($fileName === '' || !str_contains($fileName, '.')) {
-                return $this->createErrorResult(
-                    'Could not determine a file name with an extension. Pass an explicit "fileName" like "image.jpg".'
-                );
-            }
-
-            // Identical content in this storage? Return the existing file instead of
-            // creating a copy - this also makes retries after timeouts idempotent.
-            $existingFile = $this->findIdenticalFile($folder->getStorage(), sha1_file($tempPath));
-            if ($existingFile !== null) {
-                return $this->buildResult($existingFile, $fileName, deduplicated: true);
-            }
-
             try {
-                $file = $folder->getStorage()->addFile($tempPath, $folder, $fileName, DuplicationBehavior::RENAME);
-            } catch (IllegalFileExtensionException $e) {
-                return $this->createErrorResult('This file extension is not allowed: ' . $e->getMessage());
+                $stored = $uploadService->storeFile($tempPath, $fileName, $folder);
             } catch (InsufficientFolderWritePermissionsException $e) {
                 return $this->createErrorResult('No permission to add files to this folder: ' . $e->getMessage());
-            } catch (\TYPO3\CMS\Core\Validation\ResultException $e) {
-                // TYPO3 >= 14: ResourceConsistencyService rejects files whose content
-                // does not match their extension/mime type.
-                return $this->createErrorResult(
-                    'The file was rejected because its content does not match the file extension "'
-                    . pathinfo($fileName, PATHINFO_EXTENSION) . '". '
-                    . 'Make sure the URL/content actually delivers this file type.'
-                );
             }
-
-            return $this->buildResult($file, $fileName, deduplicated: false);
+            return $this->buildResult($uploadService, $stored['file'], $fileName, $stored['deduplicated']);
         } finally {
             if (file_exists($tempPath)) {
                 @unlink($tempPath);
@@ -179,199 +162,144 @@ class UploadFileTool extends AbstractRecordTool
     }
 
     /**
-     * Resolve the target folder, creating missing folders along the way.
-     * Accepts "" (default upload folder), "/path/in/default/storage" and
-     * combined identifiers like "2:/path".
+     * Create a single-use upload URL the MCP client can PUT a local file to.
      */
-    protected function resolveTargetFolder(string $targetFolder): Folder
+    protected function createPresignedUploadResult(FileUploadService $uploadService, Folder $folder, string $fileName): CallToolResult
     {
-        $storageRepository = GeneralUtility::makeInstance(StorageRepository::class);
+        $tokenData = $uploadService->createUploadToken($folder, $fileName);
+        $siteInformation = GeneralUtility::makeInstance(SiteInformationService::class);
+        $uploadUrl = $siteInformation->makeAbsoluteUrl('/mcp_upload?token=' . $tokenData['token']);
 
-        if ($targetFolder === '') {
-            $folder = GeneralUtility::makeInstance(DefaultUploadFolderResolver::class)->resolve($GLOBALS['BE_USER']);
-            if (!$folder instanceof Folder) {
-                throw new \InvalidArgumentException(
-                    'No default upload folder available for this user. Pass an explicit "targetFolder".'
-                );
-            }
-            $this->applyUserPermissionsToStorage($folder->getStorage());
-            return $folder;
-        }
+        $curlFileName = $fileName !== '' ? $fileName : 'photo.jpg';
+        $curlUrl = $uploadUrl . ($fileName === '' ? '&fileName=' . $curlFileName : '');
 
-        if (preg_match('/^(\d+):(.*)$/', $targetFolder, $matches)) {
-            $storage = $storageRepository->getStorageObject((int)$matches[1]);
-            $path = $matches[2];
-        } else {
-            $storage = $storageRepository->getDefaultStorage();
-            $path = $targetFolder;
-        }
-
-        if ($storage === null || !$storage->isOnline()) {
-            throw new \InvalidArgumentException('No usable file storage found for target folder "' . $targetFolder . '".');
-        }
-        $this->applyUserPermissionsToStorage($storage);
-
-        $segments = GeneralUtility::trimExplode('/', $path, true);
-        if (empty($segments)) {
-            return $storage->getRootLevelFolder();
-        }
-
-        // Walk down the existing part of the path, then create the remainder relative
-        // to the deepest existing folder (permission checks apply where creation starts,
-        // which keeps this working for users whose file mount is not the storage root).
-        $existingIdentifier = '/';
-        while (!empty($segments) && $storage->hasFolder($existingIdentifier . $segments[0] . '/')) {
-            $existingIdentifier .= array_shift($segments) . '/';
-        }
-        $folder = $storage->getFolder($existingIdentifier);
-        if (!empty($segments)) {
-            try {
-                $folder = $storage->createFolder(implode('/', $segments), $folder);
-            } catch (ExistingTargetFolderException) {
-                $folder = $storage->getFolder($existingIdentifier . implode('/', $segments) . '/');
-            }
-        }
-        return $folder;
-    }
-
-    /**
-     * Enforce the user's file mounts and file permissions on the storage.
-     *
-     * TYPO3's StoragePermissionsAspect does this only for backend HTTP requests;
-     * MCP tools also run via CLI/stdio where $GLOBALS['TYPO3_REQUEST'] is not a
-     * backend request, so the storage would otherwise be unrestricted for
-     * non-admin users (mirrors the read-side SysFileMountRestrictionListener).
-     */
-    protected function applyUserPermissionsToStorage(ResourceStorage $storage): void
-    {
-        $user = $GLOBALS['BE_USER'] ?? null;
-        if (!$user instanceof BackendUserAuthentication
-            || $user->isAdmin()
-            || $storage->isFallbackStorage()
-            || $storage->getEvaluatePermissions()
-        ) {
-            return;
-        }
-
-        $storage->setEvaluatePermissions(true);
-        // getFilePermissions() merged with per-storage TSconfig overrides,
-        // same as the core aspect's getFilePermissionsForStorage()
-        $permissions = $user->getFilePermissions();
-        $storageOverrides = $user->getTSConfig()['permissions.']['file.']['storage.'][$storage->getUid() . '.'] ?? [];
-        foreach ($storageOverrides as $permission => $value) {
-            $permissions[$permission] = (bool)$value;
-        }
-        $storage->setUserPermissions($permissions);
-        foreach ($user->getFileMountRecords() as $fileMountRow) {
-            if (!str_contains($fileMountRow['identifier'] ?? '', ':')) {
-                continue;
-            }
-            [$base, $path] = GeneralUtility::trimExplode(':', $fileMountRow['identifier'], false, 2);
-            if ((int)$base === $storage->getUid()) {
-                try {
-                    $storage->addFileMount($path, $fileMountRow);
-                } catch (FolderDoesNotExistException) {
-                    // Invalid mount, skip silently (same as the core aspect)
-                }
-            }
-        }
+        return $this->createJsonResult([
+            'uploadUrl' => $uploadUrl,
+            'targetFolder' => $folder->getCombinedIdentifier(),
+            'fileName' => $fileName !== '' ? $fileName : null,
+            'validUntil' => date('c', $tokenData['validUntil']),
+            'instructions' => 'Send the raw file bytes via HTTP PUT (or POST) to the uploadUrl, e.g.: '
+                . "curl -sS -T '" . $curlFileName . "' '" . $curlUrl . "'"
+                . ($fileName === '' ? ' - replace the fileName query parameter with the actual file name including extension.' : '')
+                . ' The URL is single-use and expires at validUntil. '
+                . 'The endpoint responds with JSON containing the created file (uid, fileName, publicUrl, ...); '
+                . 'use that uid with WriteTable to reference the file from a record.',
+        ]);
     }
 
     /**
      * Store a YouTube/Vimeo URL as an online media asset via the core helper.
      * Returns null when the URL is not an online media URL.
      */
-    protected function tryCreateOnlineMedia(string $url, Folder $folder): ?CallToolResult
+    protected function tryCreateOnlineMedia(string $url, Folder $folder, FileUploadService $uploadService): ?CallToolResult
     {
         $registry = GeneralUtility::makeInstance(OnlineMediaHelperRegistry::class);
         try {
             $file = $registry->transformUrlToFile($url, $folder);
         } catch (OnlineMediaAlreadyExistsException $e) {
-            return $this->buildResult($e->getOnlineMedia(), '', deduplicated: true, onlineMedia: true);
+            return $this->buildResult($uploadService, $e->getOnlineMedia(), '', deduplicated: true, onlineMedia: true);
         }
         if ($file === null) {
             return null;
         }
-        return $this->buildResult($file, $file->getName(), deduplicated: false, onlineMedia: true);
+        return $this->buildResult($uploadService, $file, $file->getName(), deduplicated: false, onlineMedia: true);
     }
 
     /**
-     * Download a remote file to a temp path, following redirects manually so
-     * every hop passes the SSRF checks. Returns [tempPath, contentType, finalUrl].
+     * Download a remote file to a temp path. Redirects are followed by Guzzle,
+     * but every hop is re-validated against the SSRF rules via on_redirect.
+     * Returns [tempPath, fileName].
      *
-     * @return array{0: string, 1: string, 2: string}
+     * @return array{0: string, 1: string}
      */
-    protected function downloadFile(string $url): array
+    protected function downloadFile(string $url, string $requestedFileName, int $maxBytes): array
     {
-        $requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
-        $currentUrl = $url;
+        $resolvedIp = $this->assertPublicHttpUrl($url);
 
-        for ($hop = 0; $hop <= self::MAX_REDIRECTS; $hop++) {
-            $resolvedIp = $this->assertPublicHttpUrl($currentUrl);
-
-            $options = [
-                'allow_redirects' => false,
-                'http_errors' => false,
-                'stream' => true,
-                'connect_timeout' => 10,
-                'timeout' => 60,
-                'headers' => ['User-Agent' => 'TYPO3-MCP-Server'],
-            ];
-            // Pin the vetted IP so the actual request cannot be re-routed to an
-            // internal address via DNS rebinding (honored by the curl handler;
-            // harmless elsewhere).
-            $parts = parse_url($currentUrl);
-            $host = $parts['host'] ?? '';
-            if ($resolvedIp !== null && !filter_var($host, FILTER_VALIDATE_IP) && defined('CURLOPT_RESOLVE')) {
-                $port = $parts['port'] ?? (($parts['scheme'] ?? 'https') === 'https' ? 443 : 80);
-                $options['curl'] = [\CURLOPT_RESOLVE => [$host . ':' . $port . ':' . $resolvedIp]];
-            }
-
-            $response = $requestFactory->request($currentUrl, 'GET', $options);
-            $status = $response->getStatusCode();
-
-            if ($status >= 300 && $status < 400) {
-                $location = $response->getHeaderLine('Location');
-                if ($location === '') {
-                    throw new \InvalidArgumentException('The URL redirected without a Location header.');
-                }
-                $currentUrl = (string)UriResolver::resolve(new Uri($currentUrl), new Uri($location));
-                continue;
-            }
-            if ($status !== 200) {
-                throw new \InvalidArgumentException('Downloading the URL failed with HTTP status ' . $status . '.');
-            }
-
-            $tempPath = GeneralUtility::tempnam('mcp_upload_');
-            $handle = fopen($tempPath, 'wb');
-            $body = $response->getBody();
-            $bytes = 0;
-            while (!$body->eof()) {
-                $chunk = $body->read(65536);
-                if ($chunk === '') {
-                    break;
-                }
-                $bytes += strlen($chunk);
-                if ($bytes > self::MAX_DOWNLOAD_BYTES) {
-                    fclose($handle);
-                    @unlink($tempPath);
-                    throw new \InvalidArgumentException(
-                        'The file exceeds the maximum download size of ' . (self::MAX_DOWNLOAD_BYTES / 1048576) . ' MiB.'
-                    );
-                }
-                fwrite($handle, $chunk);
-            }
-            fclose($handle);
-
-            if ($bytes === 0) {
-                @unlink($tempPath);
-                throw new \InvalidArgumentException('The URL returned an empty response body.');
-            }
-
-            return [$tempPath, $response->getHeaderLine('Content-Type'), $currentUrl];
+        $options = [
+            'allow_redirects' => [
+                'max' => self::MAX_REDIRECTS,
+                'strict' => true,
+                'referer' => false,
+                'protocols' => ['http', 'https'],
+                'track_redirects' => true,
+                'on_redirect' => function ($request, $response, $uri): void {
+                    $this->assertPublicHttpUrl((string)$uri);
+                },
+            ],
+            'http_errors' => false,
+            'stream' => true,
+            'connect_timeout' => 10,
+            'timeout' => 300,
+            'headers' => ['User-Agent' => 'TYPO3-MCP-Server'],
+        ];
+        // Pin the vetted IP so the actual request cannot be re-routed to an
+        // internal address via DNS rebinding (honored by the curl handler;
+        // harmless elsewhere). Only possible for the first hop - redirect
+        // targets are still host-validated in on_redirect above.
+        $parts = parse_url($url);
+        $host = $parts['host'] ?? '';
+        if ($resolvedIp !== null && !filter_var($host, FILTER_VALIDATE_IP) && defined('CURLOPT_RESOLVE')) {
+            $port = $parts['port'] ?? (($parts['scheme'] ?? 'https') === 'https' ? 443 : 80);
+            $options['curl'] = [\CURLOPT_RESOLVE => [$host . ':' . $port . ':' . $resolvedIp]];
         }
 
-        throw new \InvalidArgumentException('Too many redirects while downloading the URL.');
+        try {
+            $response = GeneralUtility::makeInstance(RequestFactory::class)->request($url, 'GET', $options);
+        } catch (GuzzleException $e) {
+            // Re-throw SSRF violations from on_redirect with their original message
+            $previous = $e->getPrevious();
+            if ($previous instanceof \InvalidArgumentException) {
+                throw $previous;
+            }
+            if ($e instanceof \InvalidArgumentException) {
+                throw $e;
+            }
+            throw new \InvalidArgumentException('Downloading the URL failed: ' . $e->getMessage(), 0, $e);
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            throw new \InvalidArgumentException('Downloading the URL failed with HTTP status ' . $response->getStatusCode() . '.');
+        }
+
+        // The final URL after redirects (Guzzle records the hops in a response header)
+        $redirectHistory = $response->getHeader(RedirectMiddleware::HISTORY_HEADER);
+        $finalUrl = $redirectHistory !== [] ? (string)end($redirectHistory) : $url;
+
+        $tempPath = GeneralUtility::tempnam('mcp_upload_');
+        $handle = fopen($tempPath, 'wb');
+        $body = $response->getBody();
+        $bytes = 0;
+        while (!$body->eof()) {
+            $chunk = $body->read(65536);
+            if ($chunk === '') {
+                break;
+            }
+            $bytes += strlen($chunk);
+            if ($bytes > $maxBytes) {
+                fclose($handle);
+                @unlink($tempPath);
+                throw new \InvalidArgumentException(
+                    'The file exceeds the maximum size of ' . round($maxBytes / 1048576) . ' MiB '
+                    . '(configurable via the extension setting "maxFileSizeMb").'
+                );
+            }
+            fwrite($handle, $chunk);
+        }
+        fclose($handle);
+
+        if ($bytes === 0) {
+            @unlink($tempPath);
+            throw new \InvalidArgumentException('The URL returned an empty response body.');
+        }
+
+        $fileName = $requestedFileName !== '' ? $requestedFileName : $this->deriveFileName(
+            $finalUrl,
+            $response->getHeaderLine('Content-Disposition'),
+            $response->getHeaderLine('Content-Type')
+        );
+
+        return [$tempPath, $fileName];
     }
 
     /**
@@ -416,10 +344,19 @@ class UploadFileTool extends AbstractRecordTool
         return $isLiteral ? null : $ips[0];
     }
 
-    protected function deriveFileNameFromUrl(string $url, string $contentType): string
+    /**
+     * Derive the file name: Content-Disposition beats the URL path, the
+     * Content-Type based extension is the last resort.
+     */
+    protected function deriveFileName(string $url, string $contentDisposition, string $contentType): string
     {
-        $path = parse_url($url, PHP_URL_PATH) ?: '';
-        $fileName = basename(rawurldecode($path));
+        $fileName = GeneralUtility::makeInstance(FileUploadService::class)
+            ->extractFileNameFromContentDisposition($contentDisposition);
+
+        if ($fileName === null) {
+            $path = parse_url($url, PHP_URL_PATH) ?: '';
+            $fileName = basename(rawurldecode($path));
+        }
 
         if ($fileName !== '' && str_contains($fileName, '.')) {
             return $fileName;
@@ -435,50 +372,14 @@ class UploadFileTool extends AbstractRecordTool
         return ($fileName !== '' ? $fileName : 'download') . '.' . $extension;
     }
 
-    /**
-     * Find a non-missing file with identical content (same SHA1) in the storage.
-     * Non-admin users only get matches within their file mounts, otherwise the
-     * dedupe would leak (and hand out) files they cannot access.
-     */
-    protected function findIdenticalFile(ResourceStorage $storage, string $sha1): ?File
-    {
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_file');
-        $rows = $queryBuilder->select('uid')
-            ->from('sys_file')
-            ->where(
-                $queryBuilder->expr()->eq('storage', $queryBuilder->createNamedParameter($storage->getUid(), ParameterType::INTEGER)),
-                $queryBuilder->expr()->eq('sha1', $queryBuilder->createNamedParameter($sha1)),
-                $queryBuilder->expr()->eq('missing', $queryBuilder->createNamedParameter(0, ParameterType::INTEGER))
-            )
-            ->executeQuery()
-            ->fetchAllAssociative();
-
-        foreach ($rows as $row) {
-            $uid = (int)$row['uid'];
-            if (!$GLOBALS['BE_USER']->isAdmin() && !$this->tableAccessService->canAccessFileUid($uid)) {
-                continue;
-            }
-            try {
-                return GeneralUtility::makeInstance(ResourceFactory::class)->getFileObject($uid);
-            } catch (\Exception) {
-                continue;
-            }
-        }
-        return null;
-    }
-
-    protected function buildResult(File $file, string $requestedFileName, bool $deduplicated, bool $onlineMedia = false): CallToolResult
-    {
-        $siteInformation = GeneralUtility::makeInstance(SiteInformationService::class);
-
-        $data = [
-            'uid' => $file->getUid(),
-            'fileName' => $file->getName(),
-            'identifier' => $file->getCombinedIdentifier(),
-            'publicUrl' => $siteInformation->makeAbsoluteUrl($file->getPublicUrl()),
-            'mimeType' => $file->getMimeType(),
-            'size' => $file->getSize(),
-        ];
+    protected function buildResult(
+        FileUploadService $uploadService,
+        File $file,
+        string $requestedFileName,
+        bool $deduplicated,
+        bool $onlineMedia = false
+    ): CallToolResult {
+        $data = $uploadService->describeFile($file);
 
         if ($onlineMedia) {
             $data['onlineMedia'] = true;

--- a/Classes/MCP/Tool/File/UploadFileTool.php
+++ b/Classes/MCP/Tool/File/UploadFileTool.php
@@ -116,8 +116,16 @@ class UploadFileTool extends AbstractRecordTool
             return $this->createErrorResult('Provide only one of "url" or "content" (or neither for a pre-signed upload URL).');
         }
 
+        // Check the requested name before touching the storage: resolving the
+        // target folder creates missing directories, and a rejected upload
+        // should not leave an empty folder behind.
+        if ($requestedFileName !== '') {
+            $uploadService->assertFileNameIsAllowed($requestedFileName);
+        }
+
+        $targetFolderPath = trim((string)($params['targetFolder'] ?? ''));
         try {
-            $folder = $uploadService->resolveTargetFolder(trim((string)($params['targetFolder'] ?? '')));
+            $folder = $uploadService->resolveTargetFolder($targetFolderPath);
         } catch (InsufficientFolderAccessPermissionsException | InsufficientFolderWritePermissionsException $e) {
             return $this->createErrorResult('No permission for the target folder: ' . $e->getMessage());
         }
@@ -134,7 +142,13 @@ class UploadFileTool extends AbstractRecordTool
             if ($onlineMediaResult !== null) {
                 return $onlineMediaResult;
             }
-            [$tempPath, $fileName] = $this->downloadFile($url, $requestedFileName, $uploadService->getMaxFileBytes());
+            try {
+                [$tempPath, $fileName] = $this->downloadFile($url, $requestedFileName, $uploadService->getMaxFileBytes());
+            } catch (\Throwable $e) {
+                // A failed download must not leave a freshly created folder behind
+                $uploadService->removeFolderIfCreatedAndEmpty($folder);
+                throw $e;
+            }
         } else {
             if ($requestedFileName === '') {
                 return $this->createErrorResult('"fileName" is required when uploading "content".');

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -951,8 +951,12 @@ class WriteTableTool extends AbstractRecordTool
         // translation behind that would make a corrected retry fail with
         // "Translation already exists".
         if (!empty($fieldValues)) {
-            $probe = $fieldValues;
-            $validationResult = $this->validateRecordData($table, $probe, 'update', $uid);
+            // Validate $fieldValues itself, not a throwaway copy: the method
+            // normalizes by reference (ISO dates to timestamps, arrays to CSV),
+            // and those normalized values are what gets persisted and reported
+            // in the event below. The normalizations are guarded by type checks,
+            // so updateRecord() re-validating them is a no-op.
+            $validationResult = $this->validateRecordData($table, $fieldValues, 'update', $uid);
             if ($validationResult !== true) {
                 return $this->createErrorResult('Validation error: ' . $validationResult);
             }

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -297,7 +297,7 @@ class WriteTableTool extends AbstractRecordTool
             case 'translate':
                 // The language UID has already been converted from ISO code if needed
                 $targetLanguageUid = (int)$data['sys_language_uid'];
-                return $this->translateRecord($table, $uid, $targetLanguageUid);
+                return $this->translateRecord($table, $uid, $targetLanguageUid, $data);
                 
             default:
                 // This should never happen due to earlier validation
@@ -886,7 +886,7 @@ class WriteTableTool extends AbstractRecordTool
     /**
      * Translate a record to another language
      */
-    protected function translateRecord(string $table, int $uid, int $targetLanguageUid): CallToolResult
+    protected function translateRecord(string $table, int $uid, int $targetLanguageUid, array $data = []): CallToolResult
     {
         // Check if table supports translations
         $languageField = $this->tableAccessService->getLanguageFieldName($table);
@@ -978,9 +978,34 @@ class WriteTableTool extends AbstractRecordTool
 
         $targetIsoCode = $this->languageService->getIsoCodeFromUid($targetLanguageUid) ?? $targetLanguageUid;
 
+        // Apply the translated field values that came with the call (the schema
+        // documents `data` as required for translate). DataHandler's localize
+        // only produces "[Translate to ...]" placeholder copies - without this
+        // step the provided translations would be silently dropped and a second
+        // update call would be needed.
+        $fieldValues = $data;
+        $languageField = $GLOBALS['TCA'][$table]['ctrl']['languageField'] ?? '';
+        unset(
+            $fieldValues['sys_language_uid'],
+            $fieldValues[$languageField],
+            $fieldValues[$translationParentField],
+            $fieldValues['pid'],
+            $fieldValues['uid']
+        );
+        if ($newTranslationUid && !empty($fieldValues)) {
+            $updateResult = $this->updateRecord($table, (int)$newTranslationUid, $fieldValues);
+            if ($updateResult->isError) {
+                return $this->createErrorResult(
+                    'Translation record was created (uid ' . $newTranslationUid . '), but applying the translated '
+                    . 'field values failed: ' . ($updateResult->content[0]->text ?? 'unknown error')
+                    . ' Use action "update" on the translation record to set the fields.'
+                );
+            }
+        }
+
         if ($newTranslationUid) {
             $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
-            $eventDispatcher->dispatch(new AfterRecordWriteEvent($table, 'translate', (int)$newTranslationUid, [], null));
+            $eventDispatcher->dispatch(new AfterRecordWriteEvent($table, 'translate', (int)$newTranslationUid, $fieldValues, null));
         }
 
         return $this->createJsonResult([

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -553,7 +553,7 @@ class WriteTableTool extends AbstractRecordTool
     /**
      * Update an existing record
      */
-    protected function updateRecord(string $table, int $uid, array $data, ?string $position = null): CallToolResult
+    protected function updateRecord(string $table, int $uid, array $data, ?string $position = null, bool $dispatchEvent = true): CallToolResult
     {
         // Validate the data
         $validationResult = $this->validateRecordData($table, $data, 'update', $uid);
@@ -672,8 +672,12 @@ class WriteTableTool extends AbstractRecordTool
             }
         }
 
-        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
-        $eventDispatcher->dispatch(new AfterRecordWriteEvent($table, 'update', $uid, $data, null));
+        // Suppressed when called as the inner step of translateRecord(), which
+        // dispatches a single 'translate' event for the whole operation instead.
+        if ($dispatchEvent) {
+            $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+            $eventDispatcher->dispatch(new AfterRecordWriteEvent($table, 'update', $uid, $data, null));
+        }
 
         // Return the result with the original live UID
         return $this->createJsonResult([
@@ -984,7 +988,6 @@ class WriteTableTool extends AbstractRecordTool
         // step the provided translations would be silently dropped and a second
         // update call would be needed.
         $fieldValues = $data;
-        $languageField = $GLOBALS['TCA'][$table]['ctrl']['languageField'] ?? '';
         unset(
             $fieldValues['sys_language_uid'],
             $fieldValues[$languageField],
@@ -993,7 +996,7 @@ class WriteTableTool extends AbstractRecordTool
             $fieldValues['uid']
         );
         if ($newTranslationUid && !empty($fieldValues)) {
-            $updateResult = $this->updateRecord($table, (int)$newTranslationUid, $fieldValues);
+            $updateResult = $this->updateRecord($table, (int)$newTranslationUid, $fieldValues, null, false);
             if ($updateResult->isError) {
                 return $this->createErrorResult(
                     'Translation record was created (uid ' . $newTranslationUid . '), but applying the translated '

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -935,6 +935,29 @@ class WriteTableTool extends AbstractRecordTool
             return $this->createErrorResult('Translation already exists for language "' . $targetIsoCode . '" (UID: ' . $existingTranslation . ')');
         }
 
+        // The field values that will be applied to the new translation
+        // (everything except the language control fields).
+        $fieldValues = $data;
+        unset(
+            $fieldValues['sys_language_uid'],
+            $fieldValues[$languageField],
+            $fieldValues[$translationParentField],
+            $fieldValues['pid'],
+            $fieldValues['uid']
+        );
+
+        // Validate them BEFORE creating the translation: a validation error
+        // (unknown field, bad value) must not leave a half-done placeholder
+        // translation behind that would make a corrected retry fail with
+        // "Translation already exists".
+        if (!empty($fieldValues)) {
+            $probe = $fieldValues;
+            $validationResult = $this->validateRecordData($table, $probe, 'update', $uid);
+            if ($validationResult !== true) {
+                return $this->createErrorResult('Validation error: ' . $validationResult);
+            }
+        }
+
         // Use DataHandler to create the translation
         $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
         $dataHandler->BE_USER = $GLOBALS['BE_USER'];
@@ -986,15 +1009,8 @@ class WriteTableTool extends AbstractRecordTool
         // documents `data` as required for translate). DataHandler's localize
         // only produces "[Translate to ...]" placeholder copies - without this
         // step the provided translations would be silently dropped and a second
-        // update call would be needed.
-        $fieldValues = $data;
-        unset(
-            $fieldValues['sys_language_uid'],
-            $fieldValues[$languageField],
-            $fieldValues[$translationParentField],
-            $fieldValues['pid'],
-            $fieldValues['uid']
-        );
+        // update call would be needed. The values were validated above, before
+        // the translation was created.
         if ($newTranslationUid && !empty($fieldValues)) {
             $updateResult = $this->updateRecord($table, (int)$newTranslationUid, $fieldValues, null, false);
             if ($updateResult->isError) {
@@ -1007,8 +1023,11 @@ class WriteTableTool extends AbstractRecordTool
         }
 
         if ($newTranslationUid) {
+            // Dispatch the same normalized representation that updateRecord()
+            // persists (dates as timestamps etc.), not the raw tool input.
+            $eventFieldValues = !empty($fieldValues) ? $this->convertDataForStorage($table, $fieldValues) : [];
             $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
-            $eventDispatcher->dispatch(new AfterRecordWriteEvent($table, 'translate', (int)$newTranslationUid, $fieldValues, null));
+            $eventDispatcher->dispatch(new AfterRecordWriteEvent($table, 'translate', (int)$newTranslationUid, $eventFieldValues, null));
         }
 
         return $this->createJsonResult([

--- a/Classes/Middleware/McpServerMiddleware.php
+++ b/Classes/Middleware/McpServerMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hn\McpServer\Middleware;
 
 use Hn\McpServer\Http\CorsHeadersTrait;
+use Hn\McpServer\Http\FileUploadEndpoint;
 use Hn\McpServer\Http\McpEndpoint;
 use Hn\McpServer\Http\OAuthAuthorizeEndpoint;
 use Hn\McpServer\Http\OAuthTokenEndpoint;
@@ -41,7 +42,10 @@ class McpServerMiddleware implements MiddlewareInterface
         return match($path) {
             // Main MCP endpoint
             '/mcp' => GeneralUtility::makeInstance(McpEndpoint::class)($request),
-            
+
+            // Pre-signed file upload target (UploadFile tool)
+            '/mcp_upload' => GeneralUtility::makeInstance(FileUploadEndpoint::class)($request),
+
             // OAuth endpoints
             '/mcp_oauth/authorize' => GeneralUtility::makeInstance(OAuthAuthorizeEndpoint::class)($request),
             '/mcp_oauth/token' => GeneralUtility::makeInstance(OAuthTokenEndpoint::class)($request),

--- a/Classes/Service/BackendUserContextService.php
+++ b/Classes/Service/BackendUserContextService.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Service;
+
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Configuration\Tca\TcaFactory;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\UserAspect;
+use TYPO3\CMS\Core\Context\WorkspaceAspect;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Impersonates a backend user outside the regular backend authentication flow.
+ *
+ * MCP reaches TYPO3 through three doors that all bypass the
+ * BackendUserAuthenticator middleware: the /mcp endpoint (token auth), the
+ * pre-signed upload endpoint (upload token) and the CLI commands (stdio). Each
+ * of them needs the same delicate setup, and getting one step wrong has caused
+ * real damage before - a missing uc restore wiped users' backend preferences
+ * (#107). Hence one place instead of four copies.
+ */
+class BackendUserContextService implements SingletonInterface
+{
+    /**
+     * Build the backend user context for the given uid: loads the user record,
+     * restores its stored configuration, computes group permissions, and wires
+     * up $GLOBALS['BE_USER'], $GLOBALS['LANG'], the TCA and the Context API.
+     *
+     * The workspace aspect is set from the user's persisted workspace; callers
+     * that switch workspaces afterwards must update it via
+     * {@see updateWorkspaceAspect()}.
+     *
+     * @throws \InvalidArgumentException when the user does not exist or may not act
+     */
+    public function impersonate(int $userId): BackendUserAuthentication
+    {
+        $userData = $this->loadUserRecord($userId);
+        if ($userData === null) {
+            throw new \InvalidArgumentException(
+                'Backend user ' . $userId . ' does not exist, is deleted, disabled, or outside its validity period.',
+                1753900000
+            );
+        }
+
+        $beUser = GeneralUtility::makeInstance(BackendUserAuthentication::class);
+        $beUser->user = $userData;
+        $this->restoreStoredUserConfiguration($beUser);
+        $GLOBALS['BE_USER'] = $beUser;
+
+        // Normal requests go through the BackendUserAuthenticator middleware,
+        // which wires up a real UserSession. Without one, DataHandler write paths
+        // that touch setAndSaveSessionData() (FlashMessageQueue,
+        // BackendFormProtection) crash with "Call to a member function set() on
+        // null". An anonymous in-memory session is discarded at request end,
+        // which is all a stateless MCP request needs.
+        $beUser->initializeUserSessionManager();
+
+        // Computes tables_select, tables_modify, non_exclude_fields, webmounts,
+        // ... - without it non-admin users have no permissions at all.
+        $beUser->fetchGroupData();
+
+        // Apply uc defaults and TSconfig overrides exactly like
+        // initializeBackendLogin() does after fetchGroupData(). Covers users who
+        // never logged into the backend: their stored uc is empty, and core only
+        // fills in defaults while uc is completely empty, so without this the
+        // first writeUC() would persist a nearly empty uc for good.
+        $beUser->backendSetUC();
+
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)
+            ->createFromUserPreferences($beUser);
+
+        $this->ensureTcaIsLoaded();
+
+        $context = GeneralUtility::makeInstance(Context::class);
+        $context->setAspect('backend.user', new UserAspect($beUser));
+        $context->setAspect('workspace', new WorkspaceAspect((int)$beUser->workspace));
+
+        return $beUser;
+    }
+
+    /**
+     * Keep the workspace aspect in sync after a workspace switch.
+     */
+    public function updateWorkspaceAspect(int $workspaceId): void
+    {
+        GeneralUtility::makeInstance(Context::class)
+            ->setAspect('workspace', new WorkspaceAspect($workspaceId));
+    }
+
+    /**
+     * Restore the user's stored configuration (uc), which the regular
+     * authentication flow unserializes via unpack_uc().
+     *
+     * Without this, $beUser->uc starts out empty and any writeUC() during
+     * request processing - the update signals fired when the MCP workspace is
+     * created, for instance - overwrites the user's backend preferences with a
+     * nearly empty array. Core never repairs that, because backendSetUC() only
+     * fills in defaults while uc is completely empty, so the backend Setup
+     * module stays broken ("Undefined array key titleLen").
+     *
+     * Public because the CLI commands build their user object themselves.
+     */
+    public function restoreStoredUserConfiguration(BackendUserAuthentication $beUser): void
+    {
+        $userId = (int)($beUser->user['uid'] ?? 0);
+        if ($userId <= 0) {
+            return;
+        }
+
+        $storedUc = $beUser->user['uc'] ?? null;
+        if (!is_string($storedUc) || $storedUc === '') {
+            $storedUc = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getConnectionForTable('be_users')
+                ->select(['uc'], 'be_users', ['uid' => $userId])
+                ->fetchOne();
+        }
+
+        if (is_string($storedUc) && $storedUc !== '') {
+            $uc = unserialize($storedUc, ['allowed_classes' => false]);
+            if (is_array($uc)) {
+                $beUser->uc = $uc;
+            }
+        }
+    }
+
+    /**
+     * Load a backend user record, but only when the user may currently act.
+     */
+    protected function loadUserRecord(int $userId): ?array
+    {
+        if ($userId <= 0) {
+            return null;
+        }
+
+        $userData = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('be_users')
+            ->select(['*'], 'be_users', ['uid' => $userId])
+            ->fetchAssociative();
+
+        if (!$userData || !$this->isUserAvailable($userData)) {
+            return null;
+        }
+        return $userData;
+    }
+
+    /**
+     * Deleted, disabled, and not-yet/no-longer-valid users must not act, no
+     * matter how valid the token they present is.
+     */
+    protected function isUserAvailable(array $userData): bool
+    {
+        $now = time();
+        if (!empty($userData['deleted']) || !empty($userData['disable'])) {
+            return false;
+        }
+        $startTime = (int)($userData['starttime'] ?? 0);
+        $endTime = (int)($userData['endtime'] ?? 0);
+
+        return ($startTime === 0 || $startTime <= $now) && ($endTime === 0 || $endTime > $now);
+    }
+
+    /**
+     * The MCP entry points run before the usual TCA bootstrap.
+     */
+    protected function ensureTcaIsLoaded(): void
+    {
+        if (empty($GLOBALS['TCA'])) {
+            $GLOBALS['TCA'] = GeneralUtility::getContainer()->get(TcaFactory::class)->get();
+        }
+    }
+}

--- a/Classes/Service/FileUploadService.php
+++ b/Classes/Service/FileUploadService.php
@@ -36,9 +36,31 @@ class FileUploadService implements SingletonInterface
     protected const UPLOAD_TOKEN_LIFETIME = 900; // 15 minutes
 
     /**
-     * Browser-executable formats; see the check in storeFile().
+     * Formats a browser would execute in the site's origin (stored XSS).
+     * TYPO3's fileDenyPattern does not cover these - it only guards against
+     * server-side execution.
      */
-    protected const DENIED_EXTENSIONS = ['htm', 'html', 'xhtml', 'shtml', 'js', 'mjs', 'svgz', 'swf', 'hta'];
+    protected const BROWSER_EXECUTABLE_EXTENSIONS = ['htm', 'html', 'xhtml', 'js', 'mjs', 'svgz', 'swf', 'hta'];
+
+    /**
+     * Formats the server itself could execute. TYPO3's fileDenyPattern already
+     * blocks these, but it is a configurable setting an integrator can loosen,
+     * so uploads coming in through MCP refuse them independently.
+     */
+    protected const SERVER_EXECUTABLE_EXTENSIONS = [
+        'php', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8', 'phps', 'phpsh', 'phtml', 'phtm', 'pht', 'phar',
+        'shtml', 'shtm', 'cgi', 'pl', 'py', 'rb', 'sh', 'htaccess',
+    ];
+
+    /**
+     * Exact file names that reconfigure the server rather than being executed
+     * themselves. ".user.ini" is the notable one: with PHP running as CGI/FPM it
+     * sets per-directory PHP options such as auto_prepend_file, and unlike
+     * ".htaccess" it is NOT part of TYPO3's fileDenyPattern. Today it is stopped
+     * only incidentally, because the extension "ini" has no matching mime type -
+     * too accidental a defense to rely on.
+     */
+    protected const DENIED_FILE_NAMES = ['.user.ini', '.htaccess', '.htpasswd', 'web.config'];
 
     /**
      * Resolve the target folder, creating missing folders along the way.
@@ -183,16 +205,7 @@ class FileUploadService implements SingletonInterface
             );
         }
 
-        // TYPO3's fileDenyPattern only blocks server-side execution (.php,
-        // .htaccess, ...). Files served from fileadmin share the origin of the
-        // backend, so browser-executable formats are rejected here as well.
-        $extension = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
-        if (in_array($extension, self::DENIED_EXTENSIONS, true)) {
-            throw new \InvalidArgumentException(
-                'Files with the extension ".' . $extension . '" are not allowed because they could run '
-                . 'script code in the browser when served from the file storage.'
-            );
-        }
+        $this->assertFileNameIsAllowed($fileName);
 
         // Identical content in this storage? Return the existing file instead of
         // creating a copy - this also makes retries after timeouts idempotent.
@@ -232,6 +245,48 @@ class FileUploadService implements SingletonInterface
         }
 
         return ['file' => $file, 'deduplicated' => false];
+    }
+
+    /**
+     * Refuse files that could be executed - by the server or by a visitor's
+     * browser - or that reconfigure the server. Deliberately independent of
+     * TYPO3's configurable fileDenyPattern and of the mime-consistency check,
+     * so the guarantee holds no matter how an installation is configured.
+     */
+    protected function assertFileNameIsAllowed(string $fileName): void
+    {
+        $lowerName = strtolower($fileName);
+        if (in_array($lowerName, self::DENIED_FILE_NAMES, true)) {
+            throw new \InvalidArgumentException(
+                'The file name "' . $fileName . '" is not allowed because a file with that name reconfigures '
+                . 'the web server or PHP.'
+            );
+        }
+
+        $extension = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
+        if (in_array($extension, self::SERVER_EXECUTABLE_EXTENSIONS, true)) {
+            throw new \InvalidArgumentException(
+                'Files with the extension ".' . $extension . '" are not allowed because they could be executed '
+                . 'on the server.'
+            );
+        }
+        if (in_array($extension, self::BROWSER_EXECUTABLE_EXTENSIONS, true)) {
+            throw new \InvalidArgumentException(
+                'Files with the extension ".' . $extension . '" are not allowed because they could run '
+                . 'script code in the browser when served from the file storage.'
+            );
+        }
+
+        // "evil.php.jpg" and friends: on servers that map by any extension in
+        // the name, an inner executable extension is enough.
+        foreach (explode('.', $lowerName) as $part) {
+            if (in_array($part, self::SERVER_EXECUTABLE_EXTENSIONS, true)) {
+                throw new \InvalidArgumentException(
+                    'The file name "' . $fileName . '" is not allowed because it contains the potentially '
+                    . 'executable extension ".' . $part . '".'
+                );
+            }
+        }
     }
 
     /**

--- a/Classes/Service/FileUploadService.php
+++ b/Classes/Service/FileUploadService.php
@@ -63,6 +63,14 @@ class FileUploadService implements SingletonInterface
     protected const DENIED_FILE_NAMES = ['.user.ini', '.htaccess', '.htpasswd', 'web.config'];
 
     /**
+     * Combined identifiers of folders created by resolveTargetFolder() in this
+     * request, so a failed upload can clean up after itself.
+     *
+     * @var string[]
+     */
+    protected array $createdFolderIdentifiers = [];
+
+    /**
      * Resolve the target folder, creating missing folders along the way.
      * Accepts "" (default upload folder), "/path/in/default/storage" and
      * combined identifiers like "2:/path".
@@ -117,11 +125,37 @@ class FileUploadService implements SingletonInterface
         if (!empty($segments)) {
             try {
                 $folder = $storage->createFolder(implode('/', $segments), $folder);
+                $this->createdFolderIdentifiers[] = $folder->getCombinedIdentifier();
             } catch (ExistingTargetFolderException) {
                 $folder = $storage->getFolder($existingIdentifier . implode('/', $segments) . '/');
             }
         }
         return $folder;
+    }
+
+    /**
+     * Undo a folder this request created, when the upload it was created for
+     * failed and left it empty. Silently does nothing for pre-existing folders,
+     * non-empty ones, or when the user may not delete folders.
+     */
+    public function removeFolderIfCreatedAndEmpty(Folder $folder): void
+    {
+        if (!in_array($folder->getCombinedIdentifier(), $this->createdFolderIdentifiers, true)) {
+            return;
+        }
+        try {
+            if ($folder->getFileCount() > 0 || count($folder->getSubfolders()) > 0) {
+                return;
+            }
+            $folder->getStorage()->deleteFolder($folder);
+            $this->createdFolderIdentifiers = array_values(array_diff(
+                $this->createdFolderIdentifiers,
+                [$folder->getCombinedIdentifier()]
+            ));
+        } catch (\Exception) {
+            // Leaving an empty folder behind is preferable to failing the
+            // request with a secondary error.
+        }
     }
 
     /**
@@ -253,7 +287,7 @@ class FileUploadService implements SingletonInterface
      * TYPO3's configurable fileDenyPattern and of the mime-consistency check,
      * so the guarantee holds no matter how an installation is configured.
      */
-    protected function assertFileNameIsAllowed(string $fileName): void
+    public function assertFileNameIsAllowed(string $fileName): void
     {
         $lowerName = strtolower($fileName);
         if (in_array($lowerName, self::DENIED_FILE_NAMES, true)) {

--- a/Classes/Service/FileUploadService.php
+++ b/Classes/Service/FileUploadService.php
@@ -64,7 +64,13 @@ class FileUploadService implements SingletonInterface
             $storage = $storageRepository->getStorageObject((int)$matches[1]);
             $path = $matches[2];
         } else {
+            // Prefer the storage flagged is_default; installations without that
+            // flag but a single storage are common, so fall back to that one.
             $storage = $storageRepository->getDefaultStorage();
+            if ($storage === null) {
+                $allStorages = $storageRepository->findAll();
+                $storage = count($allStorages) === 1 ? reset($allStorages) : null;
+            }
             $path = $targetFolder;
         }
 
@@ -125,8 +131,12 @@ class FileUploadService implements SingletonInterface
     public function applyUserPermissionsToStorage(ResourceStorage $storage): void
     {
         $user = $GLOBALS['BE_USER'] ?? null;
-        if (!$user instanceof BackendUserAuthentication
-            || $user->isAdmin()
+        if (!$user instanceof BackendUserAuthentication) {
+            // Fail closed: uploads without an authenticated backend user must
+            // never end up on an unrestricted storage.
+            throw new \RuntimeException('No authenticated backend user in the upload context.', 1753887000);
+        }
+        if ($user->isAdmin()
             || $storage->isFallbackStorage()
             || $storage->getEvaluatePermissions()
         ) {
@@ -336,10 +346,10 @@ class FileUploadService implements SingletonInterface
             ->getConnectionForTable('tx_mcpserver_upload_tokens');
 
         // Lazy garbage collection: drop tokens that expired more than a day ago
-        $connection->executeStatement(
-            'DELETE FROM tx_mcpserver_upload_tokens WHERE expires < ?',
-            [time() - 86400]
-        );
+        $gcQuery = $connection->createQueryBuilder();
+        $gcQuery->delete('tx_mcpserver_upload_tokens')
+            ->where($gcQuery->expr()->lt('expires', $gcQuery->createNamedParameter(time() - 86400, \Doctrine\DBAL\ParameterType::INTEGER)))
+            ->executeStatement();
 
         $connection->insert('tx_mcpserver_upload_tokens', [
                 'token' => hash('sha256', $token),

--- a/Classes/Service/FileUploadService.php
+++ b/Classes/Service/FileUploadService.php
@@ -36,6 +36,11 @@ class FileUploadService implements SingletonInterface
     protected const UPLOAD_TOKEN_LIFETIME = 900; // 15 minutes
 
     /**
+     * Browser-executable formats; see the check in storeFile().
+     */
+    protected const DENIED_EXTENSIONS = ['htm', 'html', 'xhtml', 'shtml', 'js', 'mjs', 'svgz', 'swf', 'hta'];
+
+    /**
      * Resolve the target folder, creating missing folders along the way.
      * Accepts "" (default upload folder), "/path/in/default/storage" and
      * combined identifiers like "2:/path".
@@ -165,6 +170,17 @@ class FileUploadService implements SingletonInterface
         if ($fileName === '' || !str_contains($fileName, '.')) {
             throw new \InvalidArgumentException(
                 'Could not determine a file name with an extension. Pass an explicit "fileName" like "image.jpg".'
+            );
+        }
+
+        // TYPO3's fileDenyPattern only blocks server-side execution (.php,
+        // .htaccess, ...). Files served from fileadmin share the origin of the
+        // backend, so browser-executable formats are rejected here as well.
+        $extension = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
+        if (in_array($extension, self::DENIED_EXTENSIONS, true)) {
+            throw new \InvalidArgumentException(
+                'Files with the extension ".' . $extension . '" are not allowed because they could run '
+                . 'script code in the browser when served from the file storage.'
             );
         }
 
@@ -340,10 +356,15 @@ class FileUploadService implements SingletonInterface
     }
 
     /**
-     * Validate a plain upload token; returns the token row or null when the
-     * token is unknown, expired, or already used.
+     * Validate and atomically consume a plain upload token. Returns the token
+     * row exactly once: parallel or repeated requests with the same token get
+     * null, as do unknown, expired, or already used tokens.
+     *
+     * The token is consumed BEFORE the upload runs, so a failed upload burns
+     * it too - a leaked token is a single attempt, not a 15-minute upload
+     * permit. Clients simply request a fresh URL to retry.
      */
-    public function validateUploadToken(string $token): ?array
+    public function consumeUploadToken(string $token): ?array
     {
         if ($token === '') {
             return null;
@@ -359,16 +380,11 @@ class FileUploadService implements SingletonInterface
         if (!$row || (int)$row['used'] !== 0 || (int)$row['expires'] < time()) {
             return null;
         }
-        return $row;
-    }
 
-    /**
-     * Mark an upload token as consumed (single use).
-     */
-    public function markUploadTokenUsed(int $tokenUid): void
-    {
-        GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getConnectionForTable('tx_mcpserver_upload_tokens')
-            ->update('tx_mcpserver_upload_tokens', ['used' => time(), 'tstamp' => time()], ['uid' => $tokenUid]);
+        $affected = $connection->executeStatement(
+            'UPDATE tx_mcpserver_upload_tokens SET used = ?, tstamp = ? WHERE uid = ? AND used = 0',
+            [time(), time(), (int)$row['uid']]
+        );
+        return $affected === 1 ? $row : null;
     }
 }

--- a/Classes/Service/FileUploadService.php
+++ b/Classes/Service/FileUploadService.php
@@ -1,0 +1,357 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Service;
+
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Resource\DefaultUploadFolderResolver;
+use TYPO3\CMS\Core\Resource\Enum\DuplicationBehavior;
+use TYPO3\CMS\Core\Resource\Exception\ExistingTargetFolderException;
+use TYPO3\CMS\Core\Resource\Exception\FolderDoesNotExistException;
+use TYPO3\CMS\Core\Resource\Exception\IllegalFileExtensionException;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\Folder;
+use TYPO3\CMS\Core\Resource\Index\FileIndexRepository;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Shared logic for adding files to TYPO3 file storages, used by the
+ * UploadFile MCP tool and the pre-signed upload HTTP endpoint.
+ *
+ * Files are deliberately create-only through MCP: physical files are not
+ * workspace-versioned in TYPO3, so overwriting or deleting them would be
+ * immediately live and irreversible. Name conflicts are auto-renamed and
+ * identical content is deduplicated instead.
+ */
+class FileUploadService implements SingletonInterface
+{
+    protected const DEFAULT_MAX_FILE_SIZE_MB = 500;
+    protected const UPLOAD_TOKEN_LIFETIME = 900; // 15 minutes
+
+    /**
+     * Resolve the target folder, creating missing folders along the way.
+     * Accepts "" (default upload folder), "/path/in/default/storage" and
+     * combined identifiers like "2:/path".
+     */
+    public function resolveTargetFolder(string $targetFolder): Folder
+    {
+        $storageRepository = GeneralUtility::makeInstance(StorageRepository::class);
+
+        if ($targetFolder === '') {
+            $folder = GeneralUtility::makeInstance(DefaultUploadFolderResolver::class)->resolve($GLOBALS['BE_USER']);
+            if (!$folder instanceof Folder) {
+                throw new \InvalidArgumentException(
+                    'No default upload folder available for this user. Pass an explicit "targetFolder".'
+                );
+            }
+            $this->applyUserPermissionsToStorage($folder->getStorage());
+            return $folder;
+        }
+
+        if (preg_match('/^(\d+):(.*)$/', $targetFolder, $matches)) {
+            $storage = $storageRepository->getStorageObject((int)$matches[1]);
+            $path = $matches[2];
+        } else {
+            $storage = $storageRepository->getDefaultStorage();
+            $path = $targetFolder;
+        }
+
+        if ($storage === null || !$storage->isOnline()) {
+            throw new \InvalidArgumentException('No usable file storage found for target folder "' . $targetFolder . '".');
+        }
+        $this->applyUserPermissionsToStorage($storage);
+
+        $segments = GeneralUtility::trimExplode('/', $path, true);
+        if (empty($segments)) {
+            return $storage->getRootLevelFolder();
+        }
+
+        // Walk down the existing part of the path, then create the remainder relative
+        // to the deepest existing folder (permission checks apply where creation starts,
+        // which keeps this working for users whose file mount is not the storage root).
+        $existingIdentifier = '/';
+        while (!empty($segments) && $storage->hasFolder($existingIdentifier . $segments[0] . '/')) {
+            $existingIdentifier .= array_shift($segments) . '/';
+        }
+        $folder = $storage->getFolder($existingIdentifier);
+        if (!empty($segments)) {
+            try {
+                $folder = $storage->createFolder(implode('/', $segments), $folder);
+            } catch (ExistingTargetFolderException) {
+                $folder = $storage->getFolder($existingIdentifier . implode('/', $segments) . '/');
+            }
+        }
+        return $folder;
+    }
+
+    /**
+     * The default upload folder shown in tool schemas, e.g. "1:/user_upload/".
+     * Returns null when it cannot be resolved (no storage configured yet).
+     */
+    public function getDefaultUploadFolderIdentifier(): ?string
+    {
+        try {
+            $user = $GLOBALS['BE_USER'] ?? null;
+            if (!$user instanceof BackendUserAuthentication) {
+                return null;
+            }
+            $folder = GeneralUtility::makeInstance(DefaultUploadFolderResolver::class)->resolve($user);
+            return $folder instanceof Folder ? $folder->getCombinedIdentifier() : null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Enforce the user's file mounts and file permissions on the storage.
+     *
+     * TYPO3's StoragePermissionsAspect does this only for backend HTTP requests;
+     * MCP tools also run via CLI/stdio where $GLOBALS['TYPO3_REQUEST'] is not a
+     * backend request, so the storage would otherwise be unrestricted for
+     * non-admin users (mirrors the read-side SysFileMountRestrictionListener).
+     */
+    public function applyUserPermissionsToStorage(ResourceStorage $storage): void
+    {
+        $user = $GLOBALS['BE_USER'] ?? null;
+        if (!$user instanceof BackendUserAuthentication
+            || $user->isAdmin()
+            || $storage->isFallbackStorage()
+            || $storage->getEvaluatePermissions()
+        ) {
+            return;
+        }
+
+        $storage->setEvaluatePermissions(true);
+        // getFilePermissions() merged with per-storage TSconfig overrides,
+        // same as the core aspect's getFilePermissionsForStorage()
+        $permissions = $user->getFilePermissions();
+        $storageOverrides = $user->getTSConfig()['permissions.']['file.']['storage.'][$storage->getUid() . '.'] ?? [];
+        foreach ($storageOverrides as $permission => $value) {
+            $permissions[$permission] = (bool)$value;
+        }
+        $storage->setUserPermissions($permissions);
+        foreach ($user->getFileMountRecords() as $fileMountRow) {
+            if (!str_contains($fileMountRow['identifier'] ?? '', ':')) {
+                continue;
+            }
+            [$base, $path] = GeneralUtility::trimExplode(':', $fileMountRow['identifier'], false, 2);
+            if ((int)$base === $storage->getUid()) {
+                try {
+                    $storage->addFileMount($path, $fileMountRow);
+                } catch (FolderDoesNotExistException) {
+                    // Invalid mount, skip silently (same as the core aspect)
+                }
+            }
+        }
+    }
+
+    /**
+     * Store a local (temp) file in the given folder: deduplicates identical
+     * content, auto-renames on name conflicts, never overwrites.
+     *
+     * @return array{file: File, deduplicated: bool}
+     * @throws \InvalidArgumentException on validation problems (bad extension, content mismatch, missing permission)
+     */
+    public function storeFile(string $tempPath, string $fileName, Folder $folder): array
+    {
+        $fileName = basename($fileName);
+        if ($fileName === '' || !str_contains($fileName, '.')) {
+            throw new \InvalidArgumentException(
+                'Could not determine a file name with an extension. Pass an explicit "fileName" like "image.jpg".'
+            );
+        }
+
+        // Identical content in this storage? Return the existing file instead of
+        // creating a copy - this also makes retries after timeouts idempotent.
+        $existingFile = $this->findIdenticalFile($folder->getStorage(), sha1_file($tempPath));
+        if ($existingFile !== null) {
+            return ['file' => $existingFile, 'deduplicated' => true];
+        }
+
+        try {
+            $file = $folder->getStorage()->addFile($tempPath, $folder, $fileName, DuplicationBehavior::RENAME);
+        } catch (IllegalFileExtensionException $e) {
+            throw new \InvalidArgumentException('This file extension is not allowed: ' . $e->getMessage(), 0, $e);
+        } catch (\TYPO3\CMS\Core\Validation\ResultException $e) {
+            // TYPO3 >= 14: ResourceConsistencyService rejects files whose content
+            // does not match their extension/mime type.
+            throw new \InvalidArgumentException(
+                'The file was rejected because its content does not match the file extension "'
+                . pathinfo($fileName, PATHINFO_EXTENSION) . '". '
+                . 'Make sure the URL/content actually delivers this file type.',
+                0,
+                $e
+            );
+        }
+
+        return ['file' => $file, 'deduplicated' => false];
+    }
+
+    /**
+     * Basic response data for an uploaded file, shared between the MCP tool
+     * result and the upload endpoint's JSON response.
+     */
+    public function describeFile(File $file): array
+    {
+        $siteInformation = GeneralUtility::makeInstance(SiteInformationService::class);
+        return [
+            'uid' => $file->getUid(),
+            'fileName' => $file->getName(),
+            'identifier' => $file->getCombinedIdentifier(),
+            'publicUrl' => $siteInformation->makeAbsoluteUrl($file->getPublicUrl()),
+            'mimeType' => $file->getMimeType(),
+            'size' => $file->getSize(),
+        ];
+    }
+
+    /**
+     * Maximum accepted file size in bytes for downloads and pre-signed uploads,
+     * configurable via the extension setting "maxFileSizeMb".
+     */
+    public function getMaxFileBytes(): int
+    {
+        try {
+            $configured = (int)GeneralUtility::makeInstance(ExtensionConfiguration::class)
+                ->get('mcp_server', 'maxFileSizeMb');
+        } catch (\Throwable) {
+            $configured = 0;
+        }
+        return ($configured > 0 ? $configured : self::DEFAULT_MAX_FILE_SIZE_MB) * 1024 * 1024;
+    }
+
+    /**
+     * Find a non-missing file with identical content (same SHA1) in the storage
+     * via TYPO3's file index. Non-admin users only get matches within their file
+     * mounts, otherwise the dedupe would leak (and hand out) files they cannot
+     * access.
+     */
+    protected function findIdenticalFile(ResourceStorage $storage, string $sha1): ?File
+    {
+        $rows = GeneralUtility::makeInstance(FileIndexRepository::class)->findByContentHash($sha1);
+        $tableAccessService = GeneralUtility::makeInstance(TableAccessService::class);
+        $user = $GLOBALS['BE_USER'] ?? null;
+        $isAdmin = $user instanceof BackendUserAuthentication && $user->isAdmin();
+
+        foreach ($rows as $row) {
+            if ((int)($row['storage'] ?? 0) !== $storage->getUid() || !empty($row['missing'])) {
+                continue;
+            }
+            $uid = (int)$row['uid'];
+            if (!$isAdmin && !$tableAccessService->canAccessFileUid($uid)) {
+                continue;
+            }
+            try {
+                return GeneralUtility::makeInstance(ResourceFactory::class)->getFileObject($uid, $row);
+            } catch (\Exception) {
+                continue;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Parse a file name from a Content-Disposition header, supporting both the
+     * RFC 5987 filename*= form and the plain filename= form.
+     */
+    public function extractFileNameFromContentDisposition(string $header): ?string
+    {
+        if ($header === '') {
+            return null;
+        }
+        if (preg_match("/filename\\*\\s*=\\s*utf-8''([^;]+)/i", $header, $matches)) {
+            $name = basename(rawurldecode(trim($matches[1], " \t\"")));
+            return $name !== '' ? $name : null;
+        }
+        if (preg_match('/filename\s*=\s*"([^"]*)"/', $header, $matches)
+            || preg_match('/filename\s*=\s*([^;]+)/', $header, $matches)
+        ) {
+            $name = basename(trim($matches[1], " \t\""));
+            return $name !== '' ? $name : null;
+        }
+        return null;
+    }
+
+    // -----------------------------------------------------------------
+    // Pre-signed upload tokens
+    // -----------------------------------------------------------------
+
+    /**
+     * Create a single-use upload token bound to the current user and a target
+     * folder. Returns the plain token (only the hash is stored) and expiry.
+     *
+     * @return array{token: string, validUntil: int}
+     */
+    public function createUploadToken(Folder $folder, string $fileName = ''): array
+    {
+        $user = $GLOBALS['BE_USER'] ?? null;
+        $userUid = (int)($user->user['uid'] ?? 0);
+        if ($userUid <= 0) {
+            throw new \InvalidArgumentException('No authenticated backend user for upload token creation.');
+        }
+
+        $token = bin2hex(random_bytes(32));
+        $validUntil = time() + self::UPLOAD_TOKEN_LIFETIME;
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_upload_tokens');
+
+        // Lazy garbage collection: drop tokens that expired more than a day ago
+        $connection->executeStatement(
+            'DELETE FROM tx_mcpserver_upload_tokens WHERE expires < ?',
+            [time() - 86400]
+        );
+
+        $connection->insert('tx_mcpserver_upload_tokens', [
+                'token' => hash('sha256', $token),
+                'be_user_uid' => $userUid,
+                'target_folder' => $folder->getCombinedIdentifier(),
+                'file_name' => basename($fileName),
+                'expires' => $validUntil,
+                'used' => 0,
+                'tstamp' => time(),
+                'crdate' => time(),
+            ]);
+
+        return ['token' => $token, 'validUntil' => $validUntil];
+    }
+
+    /**
+     * Validate a plain upload token; returns the token row or null when the
+     * token is unknown, expired, or already used.
+     */
+    public function validateUploadToken(string $token): ?array
+    {
+        if ($token === '') {
+            return null;
+        }
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_upload_tokens');
+        $row = $connection->select(
+            ['*'],
+            'tx_mcpserver_upload_tokens',
+            ['token' => hash('sha256', $token)]
+        )->fetchAssociative();
+
+        if (!$row || (int)$row['used'] !== 0 || (int)$row['expires'] < time()) {
+            return null;
+        }
+        return $row;
+    }
+
+    /**
+     * Mark an upload token as consumed (single use).
+     */
+    public function markUploadTokenUsed(int $tokenUid): void
+    {
+        GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_upload_tokens')
+            ->update('tx_mcpserver_upload_tokens', ['used' => time(), 'tstamp' => time()], ['uid' => $tokenUid]);
+    }
+}

--- a/Classes/Service/FileUploadService.php
+++ b/Classes/Service/FileUploadService.php
@@ -191,6 +191,20 @@ class FileUploadService implements SingletonInterface
             );
         }
 
+        // Uploads can be rewritten while being stored (e.g. the core SVG
+        // sanitizer), so the pre-upload hash above misses duplicates of such
+        // files. Re-check with the hash of the stored content and drop the
+        // fresh copy when it turns out to be one.
+        $existingFile = $this->findIdenticalFile($folder->getStorage(), $file->getSha1(), $file->getUid());
+        if ($existingFile !== null) {
+            try {
+                $folder->getStorage()->deleteFile($file);
+                return ['file' => $existingFile, 'deduplicated' => true];
+            } catch (\Exception) {
+                // The user may create but not delete files; keep the copy then.
+            }
+        }
+
         return ['file' => $file, 'deduplicated' => false];
     }
 
@@ -232,7 +246,7 @@ class FileUploadService implements SingletonInterface
      * mounts, otherwise the dedupe would leak (and hand out) files they cannot
      * access.
      */
-    protected function findIdenticalFile(ResourceStorage $storage, string $sha1): ?File
+    protected function findIdenticalFile(ResourceStorage $storage, string $sha1, int $excludeFileUid = 0): ?File
     {
         $rows = GeneralUtility::makeInstance(FileIndexRepository::class)->findByContentHash($sha1);
         $tableAccessService = GeneralUtility::makeInstance(TableAccessService::class);
@@ -244,6 +258,9 @@ class FileUploadService implements SingletonInterface
                 continue;
             }
             $uid = (int)$row['uid'];
+            if ($uid === $excludeFileUid) {
+                continue;
+            }
             if (!$isAdmin && !$tableAccessService->canAccessFileUid($uid)) {
                 continue;
             }

--- a/Classes/Service/SiteInformationService.php
+++ b/Classes/Service/SiteInformationService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hn\McpServer\Service;
 
+use Hn\McpServer\Http\RequestUrlTrait;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Site\Entity\Site;
@@ -15,6 +16,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SiteInformationService
 {
+    use RequestUrlTrait;
+
     protected SiteFinder $siteFinder;
     protected ?ServerRequestInterface $currentRequest = null;
 
@@ -69,11 +72,12 @@ class SiteInformationService
     protected function resolveRequestOrSiteBase(): ?string
     {
         if ($this->currentRequest !== null) {
-            $uri = $this->currentRequest->getUri();
-            $host = $uri->getHost() ?: $this->currentRequest->getHeaderLine('Host');
-            $scheme = $uri->getScheme() ?: 'https';
-            if (!empty($host)) {
-                return $scheme . '://' . $host;
+            // Same resolution as the HTTP endpoints: NormalizedParams-based,
+            // which keeps non-standard ports, reverse proxy configuration and
+            // subdirectory installations intact.
+            $base = $this->getRequestBaseUrl($this->currentRequest);
+            if (parse_url($base, PHP_URL_HOST) !== null) {
+                return $base;
             }
         }
 
@@ -82,7 +86,8 @@ class SiteInformationService
                 $siteBase = $site->getBase();
                 if ($siteBase->getHost() !== '') {
                     $scheme = $siteBase->getScheme() ?: 'https';
-                    return $scheme . '://' . $siteBase->getHost();
+                    $port = $siteBase->getPort();
+                    return $scheme . '://' . $siteBase->getHost() . ($port ? ':' . $port : '');
                 }
             }
         } catch (\Throwable) {

--- a/Documentation/Architecture/InlineRelations.md
+++ b/Documentation/Architecture/InlineRelations.md
@@ -144,7 +144,8 @@ $writeTool->execute([
 - `foreign_match_fields` (`tablenames`, `fieldname`) ensure references are scoped to the correct parent field
 - File references are enriched with metadata from `sys_file` (filename, identifier, mime type, public URL)
 - `sys_file` itself is read-only - files are managed through the filesystem, not direct DB edits
-- File uploads are NOT supported - only referencing existing files via `uid_local`
+- New files are created with the `UploadFile` tool (from a URL, a YouTube/Vimeo link, text content,
+  or a pre-signed upload); the resulting `sys_file` uid is then referenced via `uid_local`
 
 ### 3. Automatic Workspace Handling
 - Both ReadTableTool and WriteTableTool automatically initialize workspace context via `WorkspaceContextService`
@@ -199,8 +200,7 @@ $connection->update('child_table', ['parent_field' => $parentUid], ['uid' => $ch
 
 ## Future Improvements
 
-1. **File Uploads**: Allow uploading new files and creating sys_file records (currently only existing files can be referenced)
-2. **Batch Operations**: Support for bulk inline relation updates
-3. **Position Management**: Full support for positioning inline records (before/after specific records)
-4. **Validation Enhancement**: More comprehensive validation for embedded record data
-5. **Performance Optimization**: Batch foreign field updates instead of individual UPDATE queries
+1. **Batch Operations**: Support for bulk inline relation updates
+2. **Position Management**: Full support for positioning inline records (before/after specific records)
+3. **Validation Enhancement**: More comprehensive validation for embedded record data
+4. **Performance Optimization**: Batch foreign field updates instead of individual UPDATE queries

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ All these operations happen safely in workspaces, giving you full control to rev
 | **Page Content Discovery** | ✅ Ready         | Similar to the List or Page module with backend layout support                                                |
 | **Record Reading/Writing** | ✅ Ready         | Read and write any workspace-capable TYPO3 table (core & extensions) with full schema inspection              |
 | **Content Translation**    | ⚠️ Experimental | Implemented, needs real-world testing                                                                         |
-| **Fileadmin Support**      | ❌ Missing       | Not yet implemented                                                                                           |
+| **Fileadmin Support**      | ⚠️ Partial      | Read sys_file, create file references, upload new files (from URL, YouTube/Vimeo, or text). Create-only: files are never overwritten or deleted |
 | **Workspace Selection**    | ❌ Missing       | Currently uses the first writable workspace of the user                                                       |
 
 While there are a lot of automated tests, TYPO3 instances are widely different and Language Models are also widely different. Feel free to [create issues here on GitHub](https://github.com/logiscape/mcp-sdk-php/issues) or [share experiences in the typo3-core-ai channel](https://typo3.slack.com/archives/C091M0M7BL6). 

--- a/README.md
+++ b/README.md
@@ -38,24 +38,46 @@ With the TYPO3 MCP Server, your AI assistant can help you:
 - **Content Migration**: "Copy all news articles from 2023 to the archive folder" - Reorganize content efficiently
 - **Multi-language Management**: "Ensure all German pages have English translations" - Identify and fill translation gaps
 
+### 🖼️ **Images, Videos & Files**
+- **Add Images From the Web**: "Put this image on our homepage: https://example.org/press/team.jpg" - The AI downloads the file into your file storage and creates the content element that shows it
+- **Embed Videos**: "Put this video on the home page: https://www.youtube.com/watch?v=..." - YouTube and Vimeo links become proper TYPO3 online media assets
+- **Add Text-Based Documents**: "Add this price list as a CSV download on the service page" - Text formats like SVG, CSV or subtitles can be uploaded directly as content
+- **Upload From Your Machine**: "Upload the team photo from my Desktop and add it to the about page" - You get a single-use upload link, so the file goes directly to TYPO3 instead of through the AI's context
+
 All these operations happen safely in workspaces, giving you full control to review before publishing!
 
 > 💡 **Want to know how it works?** Check out our [Technical Overview](TECHNICAL_OVERVIEW.md) for detailed information about the implementation, available tools, and real-world examples with actual tool calls.
 
 ## Project Status
 
-| Feature                    | Status          | Notes                                                                                                         |
-  |----------------------------|-----------------|---------------------------------------------------------------------------------------------------------------|
-| **MCP Connection**         | ✅ Ready         | HTTP and stdin/stdout protocols (thanks to [logiscape/mcp-sdk-php](https://github.com/logiscape/mcp-sdk-php)) |
-| **Authentication**         | ✅ Ready         | OAuth for Backend Users                                                                                       |
-| **Page Tree Navigation**   | ✅ Ready         | Page tree view similar to the TYPO3 backend                                                                   |
-| **Page Content Discovery** | ✅ Ready         | Similar to the List or Page module with backend layout support                                                |
-| **Record Reading/Writing** | ✅ Ready         | Read and write any workspace-capable TYPO3 table (core & extensions) with full schema inspection              |
-| **Content Translation**    | ⚠️ Experimental | Implemented, needs real-world testing                                                                         |
-| **Fileadmin Support**      | ⚠️ Partial      | Read sys_file, create file references, upload new files (from URL, YouTube/Vimeo, text, or local files via pre-signed upload URL). Create-only: files are never overwritten or deleted |
-| **Workspace Selection**    | ❌ Missing       | Currently uses the first writable workspace of the user                                                       |
+| Feature                         | Status          | Notes |
+|---------------------------------|-----------------|-------|
+| **MCP Connection**              | ✅ Ready         | HTTP and stdin/stdout protocols (thanks to [logiscape/mcp-sdk-php](https://github.com/logiscape/mcp-sdk-php)) |
+| **Authentication**              | ✅ Ready         | OAuth for Backend Users |
+| **Page Tree Navigation**        | ✅ Ready         | Page tree view similar to the TYPO3 backend |
+| **Page Content Discovery**      | ✅ Ready         | Similar to the List or Page module with backend layout support |
+| **Record Reading/Writing**      | ✅ Ready         | Read and write any workspace-capable TYPO3 table (core & extensions) with full schema inspection |
+| **Content Translation**         | ⚠️ Experimental | Implemented, needs real-world testing |
+| **File Upload**                 | ✅ Ready         | From a URL, a YouTube/Vimeo link, raw text content, or a local file via single-use upload URL. Create-only: never overwrites or deletes, identical content is detected, executable files are refused |
+| **File Discovery & References** | ⚠️ Partial      | Browse `sys_file` and metadata within the user's file mounts (incl. public URLs), edit metadata, create file references. No visual or semantic image search yet |
+| **Workspace Selection**         | ❌ Missing       | Currently uses the first writable workspace of the user |
 
 While there are a lot of automated tests, TYPO3 instances are widely different and Language Models are also widely different. Feel free to [create issues here on GitHub](https://github.com/logiscape/mcp-sdk-php/issues) or [share experiences in the typo3-core-ai channel](https://typo3.slack.com/archives/C091M0M7BL6). 
+
+## 🖼️ Files and Images
+
+Your assistant can bring new files into TYPO3, and it picks the right of these four ways on its own:
+
+- **From a URL**: the TYPO3 server downloads the file itself, so the file never has to pass through the AI.
+- **From YouTube or Vimeo**: those links become proper TYPO3 online media assets — the video itself stays where it is.
+- **Directly as content**: text-based documents like SVG, CSV or subtitle files can be uploaded as content, without a URL or a separate upload.
+- **From your own computer**: the assistant hands out a single-use upload link, and your MCP client sends the file directly to TYPO3. Binary data never travels through the AI's context, which keeps large photos both cheap and private.
+
+Uploading is deliberately **create-only** — nothing you already have can be overwritten or deleted. A name that is already taken is resolved by renaming (`image.jpg` becomes `image_01.jpg`), and uploading content that already exists returns the existing file instead of creating a duplicate. Files that could be executed, by the server or by a visitor's browser, are refused, as are files that reconfigure the web server. Downloads only work from public http(s) addresses, and your backend user's file mounts and file permissions apply throughout.
+
+Unlike records, files are not workspace-versioned in TYPO3, so an uploaded file lands in your file storage right away. It only becomes visible on the website once a record references it — and that reference *is* workspace-staged, so the usual review before publishing still applies.
+
+> 💡 See [Put this image on the homepage](TECHNICAL_OVERVIEW.md#put-this-image-on-the-homepage) in the Technical Overview for the actual tool calls, and [Image/File Handling](TECHNICAL_OVERVIEW.md#imagefile-handling) for the upload-token flow and the current limits.
 
 ## Installation
 
@@ -66,6 +88,17 @@ composer require hn/typo3-mcp-server
 **Requirements:**
 - TYPO3 v13.4+
 - TYPO3 Workspaces extension (automatically installed as dependency)
+
+### Configuration
+
+The defaults work out of the box. All settings live in the extension configuration
+(**Admin Tools → Settings → Extension Configuration → mcp_server**):
+
+| Setting                      | Default             | Purpose |
+|------------------------------|---------------------|---------|
+| `maxFileSizeMb`              | `500`               | Upper limit in MiB for files fetched from a URL or received through an upload link |
+| `additionalReadOnlyTables`   | `sys_file`          | Non-workspace-capable tables exposed read-only — this is what lets the AI browse your files |
+| `additionalStandaloneTables` | `sys_file_metadata` | `hideTable` tables exposed as independent tables — this is what makes file metadata such as titles and alt texts editable |
 
 ## Usage
 
@@ -124,7 +157,7 @@ Build/runTests.sh -h
 
 ### Adding New Tools
 
-Tools are defined in the `Classes/MCP/Tools` directory. Each tool follows the MCP tool specification and maps to specific TYPO3 functionality.
+Tools are defined in the `Classes/MCP/Tool` directory. Each tool follows the MCP tool specification and maps to specific TYPO3 functionality.
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ All these operations happen safely in workspaces, giving you full control to rev
 | **Page Content Discovery** | ✅ Ready         | Similar to the List or Page module with backend layout support                                                |
 | **Record Reading/Writing** | ✅ Ready         | Read and write any workspace-capable TYPO3 table (core & extensions) with full schema inspection              |
 | **Content Translation**    | ⚠️ Experimental | Implemented, needs real-world testing                                                                         |
-| **Fileadmin Support**      | ⚠️ Partial      | Read sys_file, create file references, upload new files (from URL, YouTube/Vimeo, or text). Create-only: files are never overwritten or deleted |
+| **Fileadmin Support**      | ⚠️ Partial      | Read sys_file, create file references, upload new files (from URL, YouTube/Vimeo, text, or local files via pre-signed upload URL). Create-only: files are never overwritten or deleted |
 | **Workspace Selection**    | ❌ Missing       | Currently uses the first writable workspace of the user                                                       |
 
 While there are a lot of automated tests, TYPO3 instances are widely different and Language Models are also widely different. Feel free to [create issues here on GitHub](https://github.com/logiscape/mcp-sdk-php/issues) or [share experiences in the typo3-core-ai channel](https://typo3.slack.com/archives/C091M0M7BL6). 

--- a/TECHNICAL_OVERVIEW.md
+++ b/TECHNICAL_OVERVIEW.md
@@ -121,6 +121,7 @@ The MCP Server provides these tools for interacting with TYPO3:
 
 ### Content Modification
 - **WriteTable** - Create, update, or delete records (safely in workspace)
+- **UploadFile** - Add new files to the file storage from a URL (including YouTube/Vimeo) or from raw text content; never overwrites or deletes existing files
 
 > Each tool provides detailed schema information when called. See the Real-World Scenarios below for practical examples.
 
@@ -253,7 +254,7 @@ Relations are transparently resolved and can be set using simple syntax:
 - **Select relations**: Use comma-separated IDs or arrays
 - **Inline relations**: Provide as nested objects
 - **MM relations**: Handled automatically
-- **File references**: Currently read-only
+- **File references**: Created and updated as embedded inline records (reference existing `sys_file` UIDs via `uid_local`)
 - **Bidirectional**: Updates both sides as needed
 
 ### Language Support
@@ -315,9 +316,9 @@ The MCP Server respects all TYPO3 permissions:
 While the MCP Server is powerful, some features are still in development:
 
 ### Image/File Handling
-- Currently read-only access to file references
-- Cannot upload new files or modify existing ones
-- Workaround: Reference existing files by ID
+- Files are create-only: `UploadFile` adds new files (from URL, YouTube/Vimeo URL, or text content), but existing files can never be overwritten or deleted through MCP. Physical files are not workspace-versioned in TYPO3, so any destructive file operation would be immediately live and irreversible — name conflicts are auto-renamed and identical content is deduplicated instead.
+- File metadata (`sys_file_metadata`) remains editable through WriteTable (workspace-staged).
+- No visual/semantic image search yet — finding images relies on file names and metadata.
 
 ### Direct Workspace Management
 - Cannot create/delete workspaces

--- a/TECHNICAL_OVERVIEW.md
+++ b/TECHNICAL_OVERVIEW.md
@@ -165,6 +165,38 @@ Here are practical examples of how the MCP Server enables AI-powered content man
 }}
 ```
 
+### "Put this image on the homepage"
+
+**User says**: "Put this image on our homepage: https://example.org/press/team.jpg"
+
+**What happens**:
+1. AI uses `UploadFile` with the URL - the TYPO3 server downloads the file into the user's upload folder
+2. The response carries the new `sys_file` uid, its public URL, and a hint on how to reference it
+3. AI uses `GetPage` to find the homepage and its content area
+4. AI uses `WriteTable` to create a content element that references the file via `uid_local`
+
+**Tool calls**:
+```json
+// 1. Upload the file (targetFolder defaults to the user's upload folder)
+{"tool": "UploadFile", "params": {"url": "https://example.org/press/team.jpg"}}
+// -> {"uid": 42, "fileName": "team.jpg", "identifier": "1:/user_upload/team.jpg", ...}
+
+// 2. Find the homepage
+{"tool": "GetPage", "params": {"url": "/"}}
+
+// 3. Create the content element referencing the file
+{"tool": "WriteTable", "params": {
+  "table": "tt_content",
+  "action": "create",
+  "pid": 1,
+  "data": {
+    "CType": "image",
+    "header": "Our team",
+    "image": [{"uid_local": 42, "alternative": "The team in front of the office"}]
+  }
+}}
+```
+
 ### "Create a news article from this Word draft"
 
 **User says**: "Create a news article from this document" [provides Word file]

--- a/TECHNICAL_OVERVIEW.md
+++ b/TECHNICAL_OVERVIEW.md
@@ -121,7 +121,7 @@ The MCP Server provides these tools for interacting with TYPO3:
 
 ### Content Modification
 - **WriteTable** - Create, update, or delete records (safely in workspace)
-- **UploadFile** - Add new files to the file storage from a URL (including YouTube/Vimeo), from raw text content, or via a pre-signed single-use upload URL for local files; never overwrites or deletes existing files
+- **UploadFile** - Add new files to the file storage from a URL (including YouTube/Vimeo), from raw text content, or via a single-use upload token for local files (`/mcp_upload`, see below); never overwrites or deletes existing files
 
 > Each tool provides detailed schema information when called. See the Real-World Scenarios below for practical examples.
 
@@ -317,7 +317,7 @@ While the MCP Server is powerful, some features are still in development:
 
 ### Image/File Handling
 - Files are create-only: `UploadFile` adds new files (from URL, YouTube/Vimeo URL, or text content), but existing files can never be overwritten or deleted through MCP. Physical files are not workspace-versioned in TYPO3, so any destructive file operation would be immediately live and irreversible — name conflicts are auto-renamed and identical content is deduplicated instead.
-- Local files on the MCP client's machine are uploaded out-of-band: calling `UploadFile` without `url`/`content` returns the upload endpoint (`/mcp_upload`) plus a single-use token (15 minute TTL, bound to the user and target folder) to be sent as `Authorization: Bearer` header. The client PUTs the raw bytes there — binary data never travels through the model's context — and receives the created `sys_file` as JSON. The token is consumed by the attempt, so a failed upload requires a fresh one.
+- Local files on the MCP client's machine are uploaded out-of-band: calling `UploadFile` without `url`/`content` returns the upload endpoint (`/mcp_upload`) plus a single-use token (15-minute TTL, bound to the user and target folder) to be sent as `Authorization: Bearer` header. The client PUTs the raw bytes there — binary data never travels through the model's context — and receives the created `sys_file` as JSON. The token is consumed by the attempt, so a failed upload requires a fresh one.
 - The maximum accepted file size (URL downloads and pre-signed uploads) is configurable via the extension setting `maxFileSizeMb` (default 500).
 - File metadata (`sys_file_metadata`) remains editable through WriteTable (workspace-staged).
 - No visual/semantic image search yet — finding images relies on file names and metadata.

--- a/TECHNICAL_OVERVIEW.md
+++ b/TECHNICAL_OVERVIEW.md
@@ -121,7 +121,7 @@ The MCP Server provides these tools for interacting with TYPO3:
 
 ### Content Modification
 - **WriteTable** - Create, update, or delete records (safely in workspace)
-- **UploadFile** - Add new files to the file storage from a URL (including YouTube/Vimeo) or from raw text content; never overwrites or deletes existing files
+- **UploadFile** - Add new files to the file storage from a URL (including YouTube/Vimeo), from raw text content, or via a pre-signed single-use upload URL for local files; never overwrites or deletes existing files
 
 > Each tool provides detailed schema information when called. See the Real-World Scenarios below for practical examples.
 
@@ -317,6 +317,8 @@ While the MCP Server is powerful, some features are still in development:
 
 ### Image/File Handling
 - Files are create-only: `UploadFile` adds new files (from URL, YouTube/Vimeo URL, or text content), but existing files can never be overwritten or deleted through MCP. Physical files are not workspace-versioned in TYPO3, so any destructive file operation would be immediately live and irreversible — name conflicts are auto-renamed and identical content is deduplicated instead.
+- Local files on the MCP client's machine are uploaded out-of-band: calling `UploadFile` without `url`/`content` returns a pre-signed, single-use upload URL (`/mcp_upload?token=...`, 15 minute TTL, bound to the user and target folder). The client PUTs the raw bytes there — binary data never travels through the model's context — and receives the created `sys_file` as JSON.
+- The maximum accepted file size (URL downloads and pre-signed uploads) is configurable via the extension setting `maxFileSizeMb` (default 500).
 - File metadata (`sys_file_metadata`) remains editable through WriteTable (workspace-staged).
 - No visual/semantic image search yet — finding images relies on file names and metadata.
 

--- a/TECHNICAL_OVERVIEW.md
+++ b/TECHNICAL_OVERVIEW.md
@@ -317,7 +317,7 @@ While the MCP Server is powerful, some features are still in development:
 
 ### Image/File Handling
 - Files are create-only: `UploadFile` adds new files (from URL, YouTube/Vimeo URL, or text content), but existing files can never be overwritten or deleted through MCP. Physical files are not workspace-versioned in TYPO3, so any destructive file operation would be immediately live and irreversible — name conflicts are auto-renamed and identical content is deduplicated instead.
-- Local files on the MCP client's machine are uploaded out-of-band: calling `UploadFile` without `url`/`content` returns a pre-signed, single-use upload URL (`/mcp_upload?token=...`, 15 minute TTL, bound to the user and target folder). The client PUTs the raw bytes there — binary data never travels through the model's context — and receives the created `sys_file` as JSON.
+- Local files on the MCP client's machine are uploaded out-of-band: calling `UploadFile` without `url`/`content` returns the upload endpoint (`/mcp_upload`) plus a single-use token (15 minute TTL, bound to the user and target folder) to be sent as `Authorization: Bearer` header. The client PUTs the raw bytes there — binary data never travels through the model's context — and receives the created `sys_file` as JSON. The token is consumed by the attempt, so a failed upload requires a fresh one.
 - The maximum accepted file size (URL downloads and pre-signed uploads) is configurable via the extension setting `maxFileSizeMb` (default 500).
 - File metadata (`sys_file_metadata`) remains editable through WriteTable (workspace-staged).
 - No visual/semantic image search yet — finding images relies on file names and metadata.

--- a/Tests/Functional/Http/FileUploadEndpointTest.php
+++ b/Tests/Functional/Http/FileUploadEndpointTest.php
@@ -216,6 +216,18 @@ class FileUploadEndpointTest extends FunctionalTestCase
         $this->assertEquals(401, $retry->getStatusCode(), 'A token must not survive a failed upload attempt');
     }
 
+    public function testExecutableFileIsRejectedAtTheEndpointToo(): void
+    {
+        // The pre-signed endpoint is a second door into the same storage; the
+        // executable-file guard must apply there as well.
+        $token = $this->createToken();
+        $response = $this->dispatchUpload($token, '<?php echo 1;', ['fileName' => 'evil.php']);
+
+        $this->assertEquals(400, $response->getStatusCode(), (string)$response->getBody());
+        $this->assertStringContainsString('not allowed', json_decode((string)$response->getBody(), true)['error']);
+        $this->assertFileDoesNotExist(Environment::getPublicPath() . '/fileadmin/user_upload/evil.php');
+    }
+
     public function testGetMethodIsRejected(): void
     {
         $response = $this->dispatchUpload($this->createToken(), '', [], 'GET');

--- a/Tests/Functional/Http/FileUploadEndpointTest.php
+++ b/Tests/Functional/Http/FileUploadEndpointTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\Http;
+
+use Hn\McpServer\Http\FileUploadEndpoint;
+use Hn\McpServer\MCP\Tool\File\UploadFileTool;
+use Hn\McpServer\Service\FileUploadService;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Tests for the pre-signed upload endpoint (/mcp_upload).
+ *
+ * Flow under test: the UploadFile MCP tool (or FileUploadService directly)
+ * mints a single-use token; the client PUTs raw file bytes to the endpoint;
+ * the endpoint stores the file as the token's backend user and returns the
+ * created sys_file as JSON.
+ */
+class FileUploadEndpointTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+        'frontend',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'mcp_server',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/pages.csv');
+
+        GeneralUtility::mkdir_deep(Environment::getPublicPath() . '/fileadmin');
+        GeneralUtility::makeInstance(StorageRepository::class)
+            ->createLocalStorage('fileadmin', 'fileadmin/', 'relative', '', true);
+
+        $this->setUpBackendUser(1);
+    }
+
+    /**
+     * Create an upload token for the admin user, targeting /user_upload/.
+     */
+    protected function createToken(string $fileName = ''): string
+    {
+        $service = GeneralUtility::makeInstance(FileUploadService::class);
+        $folder = $service->resolveTargetFolder('/user_upload/');
+        return $service->createUploadToken($folder, $fileName)['token'];
+    }
+
+    protected function dispatchUpload(string $token, string $body, array $extraQuery = [], string $method = 'PUT', array $headers = []): \Psr\Http\Message\ResponseInterface
+    {
+        $stream = new Stream('php://temp', 'rw');
+        $stream->write($body);
+        $stream->rewind();
+
+        $request = (new ServerRequest(
+            new Uri('https://example.com/mcp_upload'),
+            $method,
+            $stream,
+            $headers
+        ))->withQueryParams(array_merge(['token' => $token], $extraQuery));
+
+        return (new FileUploadEndpoint())($request);
+    }
+
+    protected function pngBytes(): string
+    {
+        return base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==');
+    }
+
+    public function testUploadStoresFileAndReturnsJson(): void
+    {
+        $token = $this->createToken();
+        $response = $this->dispatchUpload($token, $this->pngBytes(), ['fileName' => 'uploaded.png']);
+
+        $this->assertEquals(201, $response->getStatusCode(), (string)$response->getBody());
+        $data = json_decode((string)$response->getBody(), true);
+
+        $this->assertEquals('uploaded.png', $data['fileName']);
+        $this->assertEquals('1:/user_upload/uploaded.png', $data['identifier']);
+        $this->assertGreaterThan(0, $data['uid']);
+
+        $file = GeneralUtility::makeInstance(ResourceFactory::class)->getFileObject($data['uid']);
+        $this->assertEquals($this->pngBytes(), $file->getContents());
+    }
+
+    public function testTokenIsSingleUse(): void
+    {
+        $token = $this->createToken();
+
+        $first = $this->dispatchUpload($token, $this->pngBytes(), ['fileName' => 'once.png']);
+        $this->assertEquals(201, $first->getStatusCode());
+
+        $second = $this->dispatchUpload($token, $this->pngBytes(), ['fileName' => 'twice.png']);
+        $this->assertEquals(401, $second->getStatusCode(), 'A used token must be rejected');
+    }
+
+    public function testInvalidTokenIsRejected(): void
+    {
+        $response = $this->dispatchUpload('not-a-real-token', $this->pngBytes(), ['fileName' => 'x.png']);
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testFileNameFromTokenIsUsed(): void
+    {
+        $token = $this->createToken('preset-name.png');
+        $response = $this->dispatchUpload($token, $this->pngBytes());
+
+        $this->assertEquals(201, $response->getStatusCode(), (string)$response->getBody());
+        $data = json_decode((string)$response->getBody(), true);
+        $this->assertEquals('preset-name.png', $data['fileName']);
+    }
+
+    public function testFileNameFromContentDispositionHeader(): void
+    {
+        $token = $this->createToken();
+        $response = $this->dispatchUpload(
+            $token,
+            $this->pngBytes(),
+            [],
+            'PUT',
+            ['Content-Disposition' => 'attachment; filename="from-header.png"']
+        );
+
+        $this->assertEquals(201, $response->getStatusCode(), (string)$response->getBody());
+        $data = json_decode((string)$response->getBody(), true);
+        $this->assertEquals('from-header.png', $data['fileName']);
+    }
+
+    public function testMissingFileNameIsRejected(): void
+    {
+        $token = $this->createToken();
+        $response = $this->dispatchUpload($token, $this->pngBytes());
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertStringContainsString('file name', json_decode((string)$response->getBody(), true)['error']);
+    }
+
+    public function testEmptyBodyIsRejected(): void
+    {
+        $token = $this->createToken();
+        $response = $this->dispatchUpload($token, '', ['fileName' => 'empty.png']);
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testGetMethodIsRejected(): void
+    {
+        $response = $this->dispatchUpload($this->createToken(), '', [], 'GET');
+        $this->assertEquals(405, $response->getStatusCode());
+    }
+
+    /**
+     * Full round trip: the UploadFile tool mints the URL, the endpoint consumes it.
+     */
+    public function testEndToEndFlowFromTool(): void
+    {
+        $result = GeneralUtility::makeInstance(UploadFileTool::class)->execute([
+            'targetFolder' => '/user_upload/',
+            'fileName' => 'roundtrip.png',
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $toolData = json_decode($result->content[0]->text, true);
+
+        parse_str((string)parse_url($toolData['uploadUrl'], PHP_URL_QUERY), $query);
+        $this->assertNotEmpty($query['token']);
+
+        $response = $this->dispatchUpload($query['token'], $this->pngBytes());
+        $this->assertEquals(201, $response->getStatusCode(), (string)$response->getBody());
+
+        $data = json_decode((string)$response->getBody(), true);
+        $this->assertEquals('roundtrip.png', $data['fileName'], 'File name preset in the tool call must be used');
+        $this->assertEquals('1:/user_upload/roundtrip.png', $data['identifier']);
+    }
+}

--- a/Tests/Functional/Http/FileUploadEndpointTest.php
+++ b/Tests/Functional/Http/FileUploadEndpointTest.php
@@ -8,8 +8,10 @@ use Hn\McpServer\Http\FileUploadEndpoint;
 use Hn\McpServer\MCP\Tool\File\UploadFileTool;
 use Hn\McpServer\Service\FileUploadService;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\CMS\Core\Http\UploadedFile;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Resource\StorageRepository;
@@ -159,6 +161,48 @@ class FileUploadEndpointTest extends FunctionalTestCase
         $this->assertEquals(400, $response->getStatusCode());
     }
 
+    public function testTokenFileNameBeatsQueryParameter(): void
+    {
+        // The token authorizes exactly the file it was minted for; the request
+        // must not be able to widen it to another name/type.
+        $token = $this->createToken('bound-name.png');
+        $response = $this->dispatchUpload($token, $this->pngBytes(), ['fileName' => 'sneaky-other.png']);
+
+        $this->assertEquals(201, $response->getStatusCode(), (string)$response->getBody());
+        $data = json_decode((string)$response->getBody(), true);
+        $this->assertEquals('bound-name.png', $data['fileName']);
+    }
+
+    public function testExpiredTokenIsRejected(): void
+    {
+        $token = $this->createToken();
+        GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_upload_tokens')
+            ->update('tx_mcpserver_upload_tokens', ['expires' => time() - 10], []);
+
+        $response = $this->dispatchUpload($token, $this->pngBytes(), ['fileName' => 'late.png']);
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testMultipartUploadIsAccepted(): void
+    {
+        $token = $this->createToken();
+
+        $stream = new Stream('php://temp', 'rw');
+        $stream->write($this->pngBytes());
+        $stream->rewind();
+        $uploadedFile = new UploadedFile($stream, strlen($this->pngBytes()), UPLOAD_ERR_OK, 'from-form.png');
+
+        $request = (new ServerRequest(new Uri('https://example.com/mcp_upload'), 'POST'))
+            ->withQueryParams(['token' => $token])
+            ->withUploadedFiles(['file' => $uploadedFile]);
+
+        $response = (new FileUploadEndpoint())($request);
+        $this->assertEquals(201, $response->getStatusCode(), (string)$response->getBody());
+        $data = json_decode((string)$response->getBody(), true);
+        $this->assertEquals('from-form.png', $data['fileName'], 'The multipart client file name should be used');
+    }
+
     public function testFailedUploadConsumesTheToken(): void
     {
         // The token is consumed on the attempt, not on success: a leaked token
@@ -190,10 +234,13 @@ class FileUploadEndpointTest extends FunctionalTestCase
         $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
         $toolData = json_decode($result->content[0]->text, true);
 
-        parse_str((string)parse_url($toolData['uploadUrl'], PHP_URL_QUERY), $query);
-        $this->assertNotEmpty($query['token']);
+        $this->assertNotEmpty($toolData['uploadToken']);
+        $this->assertStringNotContainsString('token=', $toolData['uploadUrl'], 'The token must not appear in the URL');
 
-        $response = $this->dispatchUpload($query['token'], $this->pngBytes());
+        // Token travels as Authorization header, like the tool instructions say
+        $response = $this->dispatchUpload('', $this->pngBytes(), [], 'PUT', [
+            'Authorization' => 'Bearer ' . $toolData['uploadToken'],
+        ]);
         $this->assertEquals(201, $response->getStatusCode(), (string)$response->getBody());
 
         $data = json_decode((string)$response->getBody(), true);

--- a/Tests/Functional/Http/FileUploadEndpointTest.php
+++ b/Tests/Functional/Http/FileUploadEndpointTest.php
@@ -216,6 +216,44 @@ class FileUploadEndpointTest extends FunctionalTestCase
         $this->assertEquals(401, $retry->getStatusCode(), 'A token must not survive a failed upload attempt');
     }
 
+    /**
+     * Same hazard as #107 on the /mcp endpoint: the upload endpoint impersonates
+     * a backend user without the regular authentication flow, so it has to
+     * restore the stored uc itself. Otherwise a writeUC() during the upload
+     * overwrites the user's backend preferences with a nearly empty array.
+     */
+    public function testStoredUserConfigurationSurvivesAnUpload(): void
+    {
+        $storedUc = ['titleLen' => 77, 'lang' => 'de', 'emailMeAtLogin' => 1];
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('be_users');
+        $connection->update('be_users', ['uc' => serialize($storedUc)], ['uid' => 1]);
+
+        $token = $this->createToken('with-uc.png');
+        $response = $this->dispatchUpload($token, $this->pngBytes());
+        $this->assertEquals(201, $response->getStatusCode(), (string)$response->getBody());
+
+        $this->assertEquals(77, $GLOBALS['BE_USER']->uc['titleLen'] ?? null, 'The impersonated user must carry the stored uc');
+
+        // Persisting now must not wipe what was stored
+        $GLOBALS['BE_USER']->writeUC();
+        $persisted = unserialize((string)$connection->select(['uc'], 'be_users', ['uid' => 1])->fetchOne(), ['allowed_classes' => false]);
+        $this->assertEquals(77, $persisted['titleLen'] ?? null, 'writeUC() must not destroy the stored backend preferences');
+        $this->assertEquals('de', $persisted['lang'] ?? null);
+    }
+
+    public function testDisabledBackendUserCannotUpload(): void
+    {
+        GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('be_users')
+            ->update('be_users', ['disable' => 1], ['uid' => 1]);
+
+        $token = $this->createToken('blocked.png');
+        $response = $this->dispatchUpload($token, $this->pngBytes());
+
+        $this->assertEquals(400, $response->getStatusCode(), (string)$response->getBody());
+        $this->assertStringContainsString('not available', json_decode((string)$response->getBody(), true)['error']);
+    }
+
     public function testExecutableFileIsRejectedAtTheEndpointToo(): void
     {
         // The pre-signed endpoint is a second door into the same storage; the

--- a/Tests/Functional/Http/FileUploadEndpointTest.php
+++ b/Tests/Functional/Http/FileUploadEndpointTest.php
@@ -45,6 +45,12 @@ class FileUploadEndpointTest extends FunctionalTestCase
         GeneralUtility::makeInstance(StorageRepository::class)
             ->createLocalStorage('fileadmin', 'fileadmin/', 'relative', '', true);
 
+        // A site with a fully qualified base URL: without one (and without an
+        // HTTP request context) pre-signed upload URLs cannot be built.
+        $siteDir = $this->instancePath . '/typo3conf/sites/test-site';
+        GeneralUtility::mkdir_deep($siteDir);
+        GeneralUtility::writeFile($siteDir . '/config.yaml', "rootPageId: 1\nbase: 'https://example.com/'\n", true);
+
         $this->setUpBackendUser(1);
     }
 
@@ -151,6 +157,19 @@ class FileUploadEndpointTest extends FunctionalTestCase
         $token = $this->createToken();
         $response = $this->dispatchUpload($token, '', ['fileName' => 'empty.png']);
         $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testFailedUploadConsumesTheToken(): void
+    {
+        // The token is consumed on the attempt, not on success: a leaked token
+        // must be a single attempt, not a 15-minute upload permit with retries.
+        $token = $this->createToken();
+
+        $failed = $this->dispatchUpload($token, '', ['fileName' => 'empty.png']);
+        $this->assertEquals(400, $failed->getStatusCode());
+
+        $retry = $this->dispatchUpload($token, $this->pngBytes(), ['fileName' => 'retry.png']);
+        $this->assertEquals(401, $retry->getStatusCode(), 'A token must not survive a failed upload attempt');
     }
 
     public function testGetMethodIsRejected(): void

--- a/Tests/Functional/MCP/Tool/UploadFileToolTest.php
+++ b/Tests/Functional/MCP/Tool/UploadFileToolTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use Hn\McpServer\MCP\Tool\File\UploadFileTool;
 use Hn\McpServer\Service\SiteInformationService;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -223,6 +224,61 @@ class UploadFileToolTest extends FunctionalTestCase
             ['content' => '<?php echo 1;', 'fileName' => 'evil.php', 'targetFolder' => '/user_upload/'],
             'extension'
         );
+    }
+
+    /**
+     * TYPO3 is a PHP application, so a smuggled-in executable file is the worst
+     * case. The core fileDenyPattern covers most of this, but it is a
+     * configurable setting, so the upload path refuses these independently.
+     */
+    #[DataProvider('executableFileNameProvider')]
+    public function testExecutableAndServerConfigFilesAreRejected(string $fileName, string $content): void
+    {
+        $this->assertUploadError(
+            ['content' => $content, 'fileName' => $fileName, 'targetFolder' => '/user_upload/'],
+            'not allowed'
+        );
+
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_file');
+        $qb->getRestrictions()->removeAll();
+        $this->assertEquals(
+            0,
+            (int)$qb->count('uid')->from('sys_file')->executeQuery()->fetchOne(),
+            'No sys_file record may exist after a rejected upload of "' . $fileName . '"'
+        );
+        $this->assertFileDoesNotExist(
+            Environment::getPublicPath() . '/fileadmin/user_upload/' . $fileName,
+            'The rejected file "' . $fileName . '" must not be on disk'
+        );
+    }
+
+    public static function executableFileNameProvider(): array
+    {
+        $php = '<?php echo 1;';
+        return [
+            // Server-side execution
+            'php' => ['evil.php', $php],
+            'php uppercase' => ['EVIL.PHP', $php],
+            'phtml' => ['evil.phtml', $php],
+            'php5' => ['evil.php5', $php],
+            'phar' => ['evil.phar', $php],
+            'pht' => ['evil.pht', $php],
+            'phps' => ['evil.phps', $php],
+            'shtml' => ['evil.shtml', '<!--#exec cmd="ls"-->'],
+            'cgi' => ['evil.cgi', "#!/bin/sh\nls"],
+            'perl' => ['evil.pl', 'print "x";'],
+            'shell' => ['evil.sh', "#!/bin/sh\nls"],
+            // Double extensions: enough on servers mapping by any extension
+            'php before jpg' => ['evil.php.jpg', $php],
+            'jpg before php' => ['evil.jpg.php', $php],
+            'php in the middle' => ['report.php.txt', $php],
+            // Server/PHP reconfiguration
+            'htaccess' => ['.htaccess', 'AddHandler application/x-httpd-php .jpg'],
+            'user.ini' => ['.user.ini', "[PHP]\nauto_prepend_file = \"/tmp/x\"\n"],
+            'user.ini uppercase' => ['.USER.INI', "[PHP]\nauto_prepend_file = \"/tmp/x\"\n"],
+            'htpasswd' => ['.htpasswd', 'admin:hash'],
+            'web.config' => ['web.config', '<configuration/>'],
+        ];
     }
 
     public function testFileNameWithoutExtensionIsRejected(): void

--- a/Tests/Functional/MCP/Tool/UploadFileToolTest.php
+++ b/Tests/Functional/MCP/Tool/UploadFileToolTest.php
@@ -1,0 +1,416 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Psr7\Response;
+use Hn\McpServer\MCP\Tool\File\UploadFileTool;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Tests for the UploadFile MCP tool.
+ *
+ * HTTP downloads are intercepted by a Guzzle handler middleware registered via
+ * $GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler'], so no real network access
+ * happens. Test URLs use public-range IP literals (203.0.113.0/24, TEST-NET-3)
+ * so the SSRF host validation passes without DNS resolution.
+ */
+class UploadFileToolTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+        'frontend',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'mcp_server',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/sys_filemounts.csv');
+
+        // Create the default "fileadmin" storage (uid 1) with a real directory
+        GeneralUtility::mkdir_deep(Environment::getPublicPath() . '/fileadmin');
+        GeneralUtility::makeInstance(StorageRepository::class)
+            ->createLocalStorage('fileadmin', 'fileadmin/', 'relative', '', true);
+
+        $this->setUpBackendUser(1);
+    }
+
+    /**
+     * Register a fake HTTP layer. Map of url-prefix => Response; anything
+     * unmatched gets a 404.
+     *
+     * @param array<string, Response> $responses
+     */
+    protected function mockHttpResponses(array $responses): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler'] = [
+            'mcp_test_mock' => function (callable $handler) use ($responses) {
+                return function ($request, array $options) use ($responses) {
+                    $url = (string)$request->getUri();
+                    foreach ($responses as $prefix => $response) {
+                        if (str_starts_with($url, $prefix)) {
+                            return new FulfilledPromise($response);
+                        }
+                    }
+                    return new FulfilledPromise(new Response(404, [], 'not mocked: ' . $url));
+                };
+            },
+        ];
+    }
+
+    /**
+     * A real (valid) 1x1 transparent PNG so TYPO3's resource consistency check
+     * (content must match the file extension) passes.
+     */
+    protected function pngBytes(): string
+    {
+        return base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==');
+    }
+
+    protected function executeUpload(array $params): array
+    {
+        $result = GeneralUtility::makeInstance(UploadFileTool::class)->execute($params);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        return json_decode($result->content[0]->text, true);
+    }
+
+    protected function assertUploadError(array $params, string $messagePart): void
+    {
+        $result = GeneralUtility::makeInstance(UploadFileTool::class)->execute($params);
+        $this->assertTrue($result->isError, 'Expected an error result, got: ' . json_encode($result->jsonSerialize()));
+        $this->assertStringContainsStringIgnoringCase($messagePart, $result->content[0]->text);
+    }
+
+    // ---------------------------------------------------------------
+    // content uploads
+    // ---------------------------------------------------------------
+
+    public function testContentUploadCreatesFile(): void
+    {
+        $text = "Some plain text content\nwith a second line.";
+        $data = $this->executeUpload([
+            'content' => $text,
+            'fileName' => 'readme.txt',
+            'targetFolder' => '/user_upload/',
+        ]);
+
+        $this->assertGreaterThan(0, $data['uid']);
+        $this->assertEquals('readme.txt', $data['fileName']);
+        $this->assertEquals('1:/user_upload/readme.txt', $data['identifier']);
+        $this->assertArrayHasKey('nextStep', $data);
+
+        // sys_file row exists and physical file has the content
+        $file = GeneralUtility::makeInstance(ResourceFactory::class)->getFileObject($data['uid']);
+        $this->assertEquals($text, $file->getContents());
+
+        // metadata record was created by the indexer
+        $count = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('sys_file_metadata')
+            ->count('uid', 'sys_file_metadata', ['file' => $data['uid']]);
+        $this->assertEquals(1, $count, 'A sys_file_metadata record should exist for the uploaded file');
+    }
+
+    public function testContentUploadIntoNestedFolderCreatesFolders(): void
+    {
+        $data = $this->executeUpload([
+            'content' => "a;b;c\n1;2;3",
+            'fileName' => 'table.csv',
+            'targetFolder' => '/user_upload/reports/2026/',
+        ]);
+
+        $this->assertEquals('1:/user_upload/reports/2026/table.csv', $data['identifier']);
+        $this->assertFileExists(Environment::getPublicPath() . '/fileadmin/user_upload/reports/2026/table.csv');
+    }
+
+    public function testContentUploadRequiresFileName(): void
+    {
+        $this->assertUploadError(['content' => 'hello'], 'fileName');
+    }
+
+    public function testRequiresExactlyOneSource(): void
+    {
+        $this->assertUploadError([], 'exactly one');
+        $this->assertUploadError(
+            ['url' => 'http://203.0.113.10/a.jpg', 'content' => 'x'],
+            'exactly one'
+        );
+    }
+
+    public function testPhpFileIsRejected(): void
+    {
+        $this->assertUploadError(
+            ['content' => '<?php echo 1;', 'fileName' => 'evil.php', 'targetFolder' => '/user_upload/'],
+            'extension'
+        );
+    }
+
+    public function testFileNameWithoutExtensionIsRejected(): void
+    {
+        $this->assertUploadError(
+            ['content' => 'hello', 'fileName' => 'noextension', 'targetFolder' => '/user_upload/'],
+            'extension'
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // conflict handling: rename + dedupe
+    // ---------------------------------------------------------------
+
+    public function testDuplicateNameIsRenamedNotOverwritten(): void
+    {
+        $first = $this->executeUpload([
+            'content' => 'first content',
+            'fileName' => 'notes.txt',
+            'targetFolder' => '/user_upload/',
+        ]);
+        $second = $this->executeUpload([
+            'content' => 'different content',
+            'fileName' => 'notes.txt',
+            'targetFolder' => '/user_upload/',
+        ]);
+
+        $this->assertNotEquals($first['uid'], $second['uid']);
+        $this->assertNotEquals('notes.txt', $second['fileName'], 'Second upload must not reuse the taken name');
+        $this->assertEquals('notes.txt', $second['renamedFrom']);
+
+        // The first file is untouched
+        $file = GeneralUtility::makeInstance(ResourceFactory::class)->getFileObject($first['uid']);
+        $this->assertEquals('first content', $file->getContents());
+    }
+
+    public function testIdenticalContentIsDeduplicated(): void
+    {
+        $first = $this->executeUpload([
+            'content' => 'identical bytes',
+            'fileName' => 'a.txt',
+            'targetFolder' => '/user_upload/',
+        ]);
+        $second = $this->executeUpload([
+            'content' => 'identical bytes',
+            'fileName' => 'b.txt',
+            'targetFolder' => '/user_upload/',
+        ]);
+
+        $this->assertEquals($first['uid'], $second['uid'], 'Identical content should return the existing file');
+        $this->assertTrue($second['deduplicated']);
+
+        $count = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('sys_file')
+            ->count('uid', 'sys_file', ['storage' => 1]);
+        $this->assertEquals(1, $count, 'No duplicate sys_file record should have been created');
+    }
+
+    // ---------------------------------------------------------------
+    // url uploads
+    // ---------------------------------------------------------------
+
+    public function testUrlUploadDownloadsFile(): void
+    {
+        $bytes = $this->pngBytes();
+        $this->mockHttpResponses([
+            'http://203.0.113.10/images/photo.png' => new Response(200, ['Content-Type' => 'image/png'], $bytes),
+        ]);
+
+        $data = $this->executeUpload([
+            'url' => 'http://203.0.113.10/images/photo.png',
+            'targetFolder' => '/user_upload/',
+        ]);
+
+        $this->assertEquals('photo.png', $data['fileName']);
+        $file = GeneralUtility::makeInstance(ResourceFactory::class)->getFileObject($data['uid']);
+        $this->assertEquals($bytes, $file->getContents());
+    }
+
+    public function testUrlUploadFollowsRedirects(): void
+    {
+        $this->mockHttpResponses([
+            'http://203.0.113.10/start' => new Response(302, ['Location' => '/moved/final.png']),
+            'http://203.0.113.10/moved/final.png' => new Response(200, ['Content-Type' => 'image/png'], $this->pngBytes()),
+        ]);
+
+        $data = $this->executeUpload([
+            'url' => 'http://203.0.113.10/start',
+            'targetFolder' => '/user_upload/',
+        ]);
+
+        // File name is derived from the redirect target
+        $this->assertEquals('final.png', $data['fileName']);
+    }
+
+    public function testUrlUploadDerivesExtensionFromContentType(): void
+    {
+        $this->mockHttpResponses([
+            'http://203.0.113.10/image?id=42' => new Response(200, ['Content-Type' => 'image/png'], $this->pngBytes()),
+        ]);
+
+        $data = $this->executeUpload([
+            'url' => 'http://203.0.113.10/image?id=42',
+            'targetFolder' => '/user_upload/',
+        ]);
+
+        $this->assertStringEndsWith('.png', $data['fileName']);
+    }
+
+    public function testUrlUploadFailsOnHttpError(): void
+    {
+        $this->mockHttpResponses([]);
+        $this->assertUploadError(
+            ['url' => 'http://203.0.113.10/missing.jpg', 'targetFolder' => '/user_upload/'],
+            '404'
+        );
+    }
+
+    public function testPrivateAddressesAreRejected(): void
+    {
+        // No mock registered on purpose: validation must fail before any request
+        foreach (['http://127.0.0.1/x.jpg', 'http://192.168.1.5/x.jpg', 'http://10.0.0.8/x.jpg', 'http://169.254.169.254/latest'] as $url) {
+            $this->assertUploadError(['url' => $url, 'targetFolder' => '/user_upload/'], 'private or reserved');
+        }
+    }
+
+    public function testNonHttpSchemesAreRejected(): void
+    {
+        $this->assertUploadError(['url' => 'ftp://203.0.113.10/x.jpg', 'targetFolder' => '/user_upload/'], 'http');
+        $this->assertUploadError(['url' => 'file:///etc/passwd', 'targetFolder' => '/user_upload/'], 'http');
+    }
+
+    // ---------------------------------------------------------------
+    // online media (YouTube/Vimeo)
+    // ---------------------------------------------------------------
+
+    public function testYoutubeUrlCreatesOnlineMediaAsset(): void
+    {
+        // oEmbed title lookup is unmocked (404) so the file falls back to the video id
+        $this->mockHttpResponses([]);
+
+        $data = $this->executeUpload([
+            'url' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            'targetFolder' => '/user_upload/',
+        ]);
+
+        $this->assertTrue($data['onlineMedia']);
+        $this->assertStringEndsWith('.youtube', $data['fileName']);
+
+        // The placeholder file contains just the video id
+        $file = GeneralUtility::makeInstance(ResourceFactory::class)->getFileObject($data['uid']);
+        $this->assertEquals('dQw4w9WgXcQ', trim($file->getContents()));
+    }
+
+    public function testYoutubeUrlIsDeduplicated(): void
+    {
+        $this->mockHttpResponses([]);
+
+        $first = $this->executeUpload([
+            'url' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            'targetFolder' => '/user_upload/',
+        ]);
+        $second = $this->executeUpload([
+            'url' => 'https://youtu.be/dQw4w9WgXcQ',
+            'targetFolder' => '/user_upload/',
+        ]);
+
+        $this->assertEquals($first['uid'], $second['uid'], 'Same video should not create a second asset');
+        $this->assertTrue($second['deduplicated']);
+    }
+
+    // ---------------------------------------------------------------
+    // default folder + permissions
+    // ---------------------------------------------------------------
+
+    public function testUploadWithoutTargetFolderUsesDefaultUploadFolder(): void
+    {
+        $data = $this->executeUpload([
+            'content' => 'default folder upload',
+            'fileName' => 'default.txt',
+        ]);
+
+        $this->assertGreaterThan(0, $data['uid']);
+        $this->assertStringStartsWith('1:/', $data['identifier']);
+    }
+
+    public function testNonAdminCanUploadIntoMountedFolder(): void
+    {
+        // The mounted folder must exist for the file mount to be resolvable
+        GeneralUtility::mkdir_deep(Environment::getPublicPath() . '/fileadmin/user_upload');
+
+        $uid = $this->createNonAdminUserWithMounts('1'); // mount 1 = "1:/user_upload/"
+        $this->authenticateUser($uid);
+
+        $data = $this->executeUpload([
+            'content' => 'editor upload',
+            'fileName' => 'editor.txt',
+            'targetFolder' => '/user_upload/',
+        ]);
+        $this->assertEquals('1:/user_upload/editor.txt', $data['identifier']);
+    }
+
+    public function testNonAdminCannotUploadOutsideMounts(): void
+    {
+        // Physically create /secret/ so the folder exists but is outside the mount
+        GeneralUtility::mkdir_deep(Environment::getPublicPath() . '/fileadmin/secret');
+
+        $uid = $this->createNonAdminUserWithMounts('1'); // only "1:/user_upload/"
+        $this->authenticateUser($uid);
+
+        $this->assertUploadError(
+            ['content' => 'sneaky', 'fileName' => 'sneaky.txt', 'targetFolder' => '/secret/'],
+            'permission'
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // helpers for non-admin users (mirrors FileMountPermissionTest)
+    // ---------------------------------------------------------------
+
+    protected function createNonAdminUserWithMounts(string $fileMountUids): int
+    {
+        GeneralUtility::makeInstance(CacheManager::class)->getCache('runtime')->flush();
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('be_users');
+        $connection->insert('be_users', [
+            'pid' => 0,
+            'username' => 'editor_' . uniqid(),
+            'password' => '$argon2i$v=19$m=65536,t=16,p=1$dGVzdHNhbHQ$testpasswordhash',
+            'admin' => 0,
+            'file_mountpoints' => $fileMountUids,
+            'deleted' => 0,
+            'disable' => 0,
+            'tstamp' => time(),
+            'crdate' => time(),
+            'email' => 'test' . uniqid() . '@example.com',
+        ]);
+
+        return (int)$connection->lastInsertId();
+    }
+
+    protected function authenticateUser(int $uid): BackendUserAuthentication
+    {
+        $user = $this->setUpBackendUser($uid);
+        $user->groupData['tables_select'] = 'sys_file,pages,tt_content';
+        $user->groupData['tables_modify'] = 'sys_file,pages,tt_content';
+        $user->groupData['filemounts'] = (string)($user->user['file_mountpoints'] ?? '');
+        // FAL write operations check granular file permissions for non-admins
+        $user->groupData['file_permissions'] = 'readFolder,writeFolder,addFolder,readFile,writeFile,addFile,copyFile,moveFile,renameFile';
+        $user->user['admin'] = 0;
+        $GLOBALS['BE_USER'] = $user;
+
+        GeneralUtility::makeInstance(CacheManager::class)->getCache('runtime')->flush();
+
+        return $user;
+    }
+}

--- a/Tests/Functional/MCP/Tool/UploadFileToolTest.php
+++ b/Tests/Functional/MCP/Tool/UploadFileToolTest.php
@@ -142,12 +142,38 @@ class UploadFileToolTest extends FunctionalTestCase
         $this->assertUploadError(['content' => 'hello'], 'fileName');
     }
 
-    public function testRequiresExactlyOneSource(): void
+    public function testUrlAndContentTogetherAreRejected(): void
     {
-        $this->assertUploadError([], 'exactly one');
         $this->assertUploadError(
             ['url' => 'http://203.0.113.10/a.jpg', 'content' => 'x'],
-            'exactly one'
+            'only one'
+        );
+    }
+
+    public function testNoSourceReturnsPresignedUploadUrl(): void
+    {
+        $data = $this->executeUpload(['targetFolder' => '/user_upload/']);
+
+        $this->assertArrayHasKey('uploadUrl', $data);
+        $this->assertStringContainsString('/mcp_upload?token=', $data['uploadUrl']);
+        $this->assertEquals('1:/user_upload/', $data['targetFolder']);
+        $this->assertArrayHasKey('validUntil', $data);
+        $this->assertStringContainsString('curl', $data['instructions']);
+
+        // A hashed single-use token was persisted
+        $count = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_mcpserver_upload_tokens')
+            ->count('uid', 'tx_mcpserver_upload_tokens', ['used' => 0]);
+        $this->assertEquals(1, $count);
+    }
+
+    public function testSchemaOffersDefaultTargetFolder(): void
+    {
+        $schema = GeneralUtility::makeInstance(UploadFileTool::class)->getSchema();
+        $this->assertEquals(
+            '1:/user_upload/',
+            $schema['inputSchema']['properties']['targetFolder']['default'] ?? null,
+            'The schema should advertise the default upload folder'
         );
     }
 
@@ -264,6 +290,23 @@ class UploadFileToolTest extends FunctionalTestCase
         ]);
 
         $this->assertStringEndsWith('.png', $data['fileName']);
+    }
+
+    public function testUrlUploadPrefersContentDispositionFileName(): void
+    {
+        $this->mockHttpResponses([
+            'http://203.0.113.10/download?id=7' => new Response(200, [
+                'Content-Type' => 'image/png',
+                'Content-Disposition' => 'attachment; filename="pretty-name.png"',
+            ], $this->pngBytes()),
+        ]);
+
+        $data = $this->executeUpload([
+            'url' => 'http://203.0.113.10/download?id=7',
+            'targetFolder' => '/user_upload/',
+        ]);
+
+        $this->assertEquals('pretty-name.png', $data['fileName']);
     }
 
     public function testUrlUploadFailsOnHttpError(): void

--- a/Tests/Functional/MCP/Tool/UploadFileToolTest.php
+++ b/Tests/Functional/MCP/Tool/UploadFileToolTest.php
@@ -345,6 +345,59 @@ class UploadFileToolTest extends FunctionalTestCase
         );
     }
 
+    public function testWebPageUrlIsRejectedWithAnActionableMessage(): void
+    {
+        // Pasting a normal website URL is a common mistake; the message must
+        // point at the URL, not at file extensions or content mismatches.
+        $this->mockHttpResponses([
+            'http://203.0.113.10/some-article' => new Response(
+                200,
+                ['Content-Type' => 'text/html; charset=utf-8'],
+                "<!DOCTYPE html>\n<html><head><title>An article</title></head><body><p>Text</p></body></html>"
+            ),
+        ]);
+
+        $this->assertUploadError(
+            ['url' => 'http://203.0.113.10/some-article', 'targetFolder' => '/user_upload/'],
+            'web page'
+        );
+    }
+
+    public function testWebPageCannotBeSmuggledInUnderAnImageFileName(): void
+    {
+        $this->mockHttpResponses([
+            'http://203.0.113.10/page' => new Response(
+                200,
+                ['Content-Type' => 'text/html'],
+                '<html><body>not an image</body></html>'
+            ),
+        ]);
+
+        $this->assertUploadError(
+            ['url' => 'http://203.0.113.10/page', 'fileName' => 'looks-like.jpg', 'targetFolder' => '/user_upload/'],
+            'web page'
+        );
+    }
+
+    public function testMislabeledImageIsStillAccepted(): void
+    {
+        // Servers that declare a real image as text/html must keep working:
+        // the HTML detection looks at the content, not at the header.
+        $this->mockHttpResponses([
+            'http://203.0.113.10/photo.png' => new Response(200, ['Content-Type' => 'text/html'], $this->pngBytes()),
+        ]);
+
+        $data = $this->executeUpload([
+            'url' => 'http://203.0.113.10/photo.png',
+            'targetFolder' => '/user_upload/',
+        ]);
+
+        // The exact name may carry a _01 suffix: the test instance's fileadmin
+        // survives between tests of this class while the database is reset.
+        $this->assertStringEndsWith('.png', $data['fileName']);
+        $this->assertEquals('image/png', $data['mimeType']);
+    }
+
     public function testCgnatAddressIsRejected(): void
     {
         // 100.64.0.0/10 (CGNAT) passes PHP's filter flags but is cloud-internal

--- a/Tests/Functional/MCP/Tool/UploadFileToolTest.php
+++ b/Tests/Functional/MCP/Tool/UploadFileToolTest.php
@@ -252,6 +252,30 @@ class UploadFileToolTest extends FunctionalTestCase
         );
     }
 
+    public function testRejectedFileNameDoesNotCreateTheTargetFolder(): void
+    {
+        // The name is checked before the storage is touched, so a rejected
+        // upload leaves no empty folder behind.
+        $this->assertUploadError(
+            ['content' => '<?php echo 1;', 'fileName' => 'evil.php', 'targetFolder' => '/user_upload/brand-new/'],
+            'not allowed'
+        );
+
+        $this->assertDirectoryDoesNotExist(Environment::getPublicPath() . '/fileadmin/user_upload/brand-new');
+    }
+
+    public function testFailedDownloadDoesNotLeaveAnEmptyFolderBehind(): void
+    {
+        $this->mockHttpResponses([]); // everything 404s
+
+        $this->assertUploadError(
+            ['url' => 'http://203.0.113.10/missing.jpg', 'targetFolder' => '/user_upload/download-fail/'],
+            '404'
+        );
+
+        $this->assertDirectoryDoesNotExist(Environment::getPublicPath() . '/fileadmin/user_upload/download-fail');
+    }
+
     public static function executableFileNameProvider(): array
     {
         $php = '<?php echo 1;';

--- a/Tests/Functional/MCP/Tool/UploadFileToolTest.php
+++ b/Tests/Functional/MCP/Tool/UploadFileToolTest.php
@@ -7,7 +7,11 @@ namespace Hn\McpServer\Tests\Functional\MCP\Tool;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use Hn\McpServer\MCP\Tool\File\UploadFileTool;
+use Hn\McpServer\Service\SiteInformationService;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -160,21 +164,47 @@ class UploadFileToolTest extends FunctionalTestCase
     {
         $data = $this->executeUpload(['targetFolder' => '/user_upload/']);
 
-        $this->assertArrayHasKey('uploadUrl', $data);
-        $this->assertStringStartsWith(
-            'https://example.com/mcp_upload?token=',
+        $this->assertEquals(
+            'https://example.com/mcp_upload',
             $data['uploadUrl'],
-            'The upload URL must be absolute, resolved from the site base'
+            'The upload URL must be absolute, resolved from the site base, and must not carry the token'
         );
+        $this->assertNotEmpty($data['uploadToken']);
         $this->assertEquals('1:/user_upload/', $data['targetFolder']);
         $this->assertArrayHasKey('validUntil', $data);
         $this->assertStringContainsString('curl', $data['instructions']);
+        $this->assertStringContainsString('Authorization: Bearer', $data['instructions']);
 
         // A hashed single-use token was persisted
         $count = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('tx_mcpserver_upload_tokens')
             ->count('uid', 'tx_mcpserver_upload_tokens', ['used' => 0]);
         $this->assertEquals(1, $count);
+    }
+
+    public function testPresignedUploadUrlIncludesSubdirectoryPrefix(): void
+    {
+        // TYPO3 installed at https://example.com/subdir/: the middleware routes
+        // /subdir/mcp_upload, so the generated URL must carry the prefix.
+        $serverParams = [
+            'HTTP_HOST' => 'example.com',
+            'HTTPS' => 'on',
+            'SCRIPT_NAME' => '/subdir/index.php',
+            'SCRIPT_FILENAME' => Environment::getPublicPath() . '/index.php',
+            'REQUEST_URI' => '/subdir/mcp',
+        ];
+        $request = new ServerRequest(new Uri('https://example.com/subdir/mcp'), 'POST', null, [], $serverParams);
+        $request = $request->withAttribute('normalizedParams', NormalizedParams::createFromRequest($request));
+
+        $siteInformation = GeneralUtility::makeInstance(SiteInformationService::class);
+        $siteInformation->setCurrentRequest($request);
+        try {
+            $data = $this->executeUpload(['targetFolder' => '/user_upload/']);
+        } finally {
+            $siteInformation->setCurrentRequest(null);
+        }
+
+        $this->assertEquals('https://example.com/subdir/mcp_upload', $data['uploadUrl']);
     }
 
     public function testSchemaOffersDefaultTargetFolder(): void
@@ -300,6 +330,29 @@ class UploadFileToolTest extends FunctionalTestCase
 
         // File name is derived from the redirect target
         $this->assertEquals('final.png', $data['fileName']);
+    }
+
+    public function testRedirectToPrivateAddressIsRejected(): void
+    {
+        // Every redirect hop must pass the SSRF validation, not just the first URL.
+        $this->mockHttpResponses([
+            'http://203.0.113.10/innocent' => new Response(302, ['Location' => 'http://127.0.0.1/internal.png']),
+        ]);
+
+        $this->assertUploadError(
+            ['url' => 'http://203.0.113.10/innocent', 'targetFolder' => '/user_upload/'],
+            'private or reserved'
+        );
+    }
+
+    public function testCgnatAddressIsRejected(): void
+    {
+        // 100.64.0.0/10 (CGNAT) passes PHP's filter flags but is cloud-internal
+        // (e.g. Alibaba metadata endpoint) and must be blocked explicitly.
+        $this->assertUploadError(
+            ['url' => 'http://100.100.100.200/latest/meta-data', 'targetFolder' => '/user_upload/'],
+            'private or reserved'
+        );
     }
 
     public function testUrlUploadDerivesExtensionFromContentType(): void

--- a/Tests/Functional/MCP/Tool/UploadFileToolTest.php
+++ b/Tests/Functional/MCP/Tool/UploadFileToolTest.php
@@ -354,6 +354,39 @@ class UploadFileToolTest extends FunctionalTestCase
         $this->assertEquals('dQw4w9WgXcQ', trim($file->getContents()));
     }
 
+    public function testContentRewrittenDuringUploadIsStillDeduplicated(): void
+    {
+        // The core SVG sanitizer rewrites SVG content while it is stored, so the
+        // hash of the upload differs from the hash of the stored file. The dedupe
+        // must catch this via the post-store hash check.
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10"/></svg>';
+
+        $first = $this->executeUpload([
+            'content' => $svg,
+            'fileName' => 'shape.svg',
+            'targetFolder' => '/user_upload/',
+        ]);
+        $second = $this->executeUpload([
+            'content' => $svg,
+            'fileName' => 'shape.svg',
+            'targetFolder' => '/user_upload/',
+        ]);
+
+        $storedSha1 = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('sys_file')
+            ->select(['sha1'], 'sys_file', ['uid' => $first['uid']])
+            ->fetchOne();
+        $this->assertNotEquals(sha1($svg), $storedSha1, 'Precondition: the sanitizer must actually rewrite the SVG for this test to be meaningful');
+
+        $this->assertEquals($first['uid'], $second['uid'], 'Identical (sanitizer-rewritten) content should return the existing file');
+        $this->assertTrue($second['deduplicated'] ?? false);
+
+        $count = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('sys_file')
+            ->count('uid', 'sys_file', ['storage' => 1]);
+        $this->assertEquals(1, $count, 'No duplicate sys_file record should have been created');
+    }
+
     public function testYoutubeUrlIsDeduplicated(): void
     {
         $this->mockHttpResponses([]);

--- a/Tests/Functional/MCP/Tool/UploadFileToolTest.php
+++ b/Tests/Functional/MCP/Tool/UploadFileToolTest.php
@@ -47,6 +47,12 @@ class UploadFileToolTest extends FunctionalTestCase
         GeneralUtility::makeInstance(StorageRepository::class)
             ->createLocalStorage('fileadmin', 'fileadmin/', 'relative', '', true);
 
+        // A site with a fully qualified base URL: without one (and without an
+        // HTTP request context) pre-signed upload URLs cannot be built.
+        $siteDir = $this->instancePath . '/typo3conf/sites/test-site';
+        GeneralUtility::mkdir_deep($siteDir);
+        GeneralUtility::writeFile($siteDir . '/config.yaml', "rootPageId: 1\nbase: 'https://example.com/'\n", true);
+
         $this->setUpBackendUser(1);
     }
 
@@ -155,7 +161,11 @@ class UploadFileToolTest extends FunctionalTestCase
         $data = $this->executeUpload(['targetFolder' => '/user_upload/']);
 
         $this->assertArrayHasKey('uploadUrl', $data);
-        $this->assertStringContainsString('/mcp_upload?token=', $data['uploadUrl']);
+        $this->assertStringStartsWith(
+            'https://example.com/mcp_upload?token=',
+            $data['uploadUrl'],
+            'The upload URL must be absolute, resolved from the site base'
+        );
         $this->assertEquals('1:/user_upload/', $data['targetFolder']);
         $this->assertArrayHasKey('validUntil', $data);
         $this->assertStringContainsString('curl', $data['instructions']);
@@ -190,6 +200,20 @@ class UploadFileToolTest extends FunctionalTestCase
         $this->assertUploadError(
             ['content' => 'hello', 'fileName' => 'noextension', 'targetFolder' => '/user_upload/'],
             'extension'
+        );
+    }
+
+    public function testBrowserExecutableFilesAreRejected(): void
+    {
+        // Served from fileadmin these would run script code in the site's origin
+        // (stored XSS); the core fileDenyPattern only covers server-side execution.
+        $this->assertUploadError(
+            ['content' => '<script>alert(1)</script>', 'fileName' => 'page.html', 'targetFolder' => '/user_upload/'],
+            'not allowed'
+        );
+        $this->assertUploadError(
+            ['content' => 'alert(1)', 'fileName' => 'app.js', 'targetFolder' => '/user_upload/'],
+            'not allowed'
         );
     }
 

--- a/Tests/Functional/MCP/Tool/WriteTableLanguageTest.php
+++ b/Tests/Functional/MCP/Tool/WriteTableLanguageTest.php
@@ -34,6 +34,13 @@ class WriteTableLanguageTest extends FunctionalTestCase
         
         // Set up backend user
         $this->setUpBackendUser(1);
+
+        // DataHandler's localize path needs $GLOBALS['LANG'] (for the
+        // "[Translate to ...]" prefix). In full-suite runs another test class
+        // happens to leave it behind; set it explicitly so this class also
+        // works in isolation.
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Localization\LanguageServiceFactory::class)
+            ->create('default');
     }
 
     /**
@@ -222,6 +229,80 @@ class WriteTableLanguageTest extends FunctionalTestCase
         $this->assertEquals(1, $translation['sys_language_uid']); // German
         $this->assertEquals($originalUid, $translation['l18n_parent']); // TYPO3 uses l18n_parent for tt_content
         $this->assertStringContainsString('Original English Content', $translation['header']); // May have translation prefix
+    }
+
+    /**
+     * Translate with field values in data: the schema documents `data` as
+     * required for translate, so the provided translations must actually land
+     * on the new record instead of the "[Translate to ...]" placeholders.
+     */
+    public function testTranslateAppliesProvidedFieldValues(): void
+    {
+        $tool = new WriteTableTool();
+
+        $createResult = $tool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => [
+                'CType' => 'text',
+                'header' => 'Original English Content',
+                'bodytext' => 'This is the original content',
+            ],
+        ]);
+        $this->assertFalse($createResult->isError, json_encode($createResult->jsonSerialize()));
+        $originalUid = json_decode($createResult->content[0]->text, true)['uid'];
+
+        $translateResult = $tool->execute([
+            'action' => 'translate',
+            'table' => 'tt_content',
+            'uid' => $originalUid,
+            'data' => [
+                'sys_language_uid' => 'de',
+                'header' => 'Deutscher Titel',
+                'bodytext' => 'Das ist der übersetzte Inhalt',
+            ],
+        ]);
+        $this->assertFalse($translateResult->isError, json_encode($translateResult->jsonSerialize()));
+        $translationUid = json_decode($translateResult->content[0]->text, true)['translationUid'];
+        $this->assertIsInt($translationUid);
+
+        $translation = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecord('tt_content', $translationUid);
+        $this->assertEquals('Deutscher Titel', $translation['header']);
+        $this->assertEquals('Das ist der übersetzte Inhalt', $translation['bodytext']);
+        $this->assertEquals(1, $translation['sys_language_uid']);
+    }
+
+    /**
+     * Same for pid-0 records (sys_file_metadata is the LLM benchmark's case):
+     * translate with data must create the sys_language_uid=1 row carrying the
+     * provided values in one call.
+     */
+    public function testTranslateSysFileMetadataAppliesProvidedFieldValues(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/sys_file.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/sys_file_metadata.csv');
+
+        $tool = new WriteTableTool();
+        $translateResult = $tool->execute([
+            'action' => 'translate',
+            'table' => 'sys_file_metadata',
+            'uid' => 1,
+            'data' => [
+                'sys_language_uid' => 'de',
+                'title' => 'Personenfoto',
+                'alternative' => 'Foto vom Teamleiter',
+            ],
+        ]);
+        $this->assertFalse($translateResult->isError, json_encode($translateResult->jsonSerialize()));
+        $translationUid = json_decode($translateResult->content[0]->text, true)['translationUid'];
+        $this->assertIsInt($translationUid);
+
+        $translation = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecord('sys_file_metadata', $translationUid);
+        $this->assertEquals('Personenfoto', $translation['title']);
+        $this->assertEquals('Foto vom Teamleiter', $translation['alternative']);
+        $this->assertEquals(1, $translation['sys_language_uid']);
+        $this->assertEquals(1, $translation['l10n_parent']);
     }
 
     /**

--- a/Tests/Functional/MCP/Tool/WriteTableLanguageTest.php
+++ b/Tests/Functional/MCP/Tool/WriteTableLanguageTest.php
@@ -306,6 +306,54 @@ class WriteTableLanguageTest extends FunctionalTestCase
     }
 
     /**
+     * A validation error in the provided field values must be reported BEFORE
+     * the translation is created - otherwise a corrected retry would fail with
+     * "Translation already exists" because of the leftover placeholder record.
+     */
+    public function testTranslateWithInvalidFieldCreatesNoOrphanTranslation(): void
+    {
+        $tool = new WriteTableTool();
+
+        $createResult = $tool->execute([
+            'action' => 'create',
+            'table' => 'tt_content',
+            'pid' => 1,
+            'data' => ['CType' => 'text', 'header' => 'Original'],
+        ]);
+        $this->assertFalse($createResult->isError, json_encode($createResult->jsonSerialize()));
+        $originalUid = json_decode($createResult->content[0]->text, true)['uid'];
+
+        $translateResult = $tool->execute([
+            'action' => 'translate',
+            'table' => 'tt_content',
+            'uid' => $originalUid,
+            'data' => [
+                'sys_language_uid' => 'de',
+                'no_such_field' => 'boom',
+            ],
+        ]);
+        $this->assertTrue($translateResult->isError, 'Invalid field must produce an error');
+
+        // No translation row may exist - a retry with corrected data must succeed
+        $retryResult = $tool->execute([
+            'action' => 'translate',
+            'table' => 'tt_content',
+            'uid' => $originalUid,
+            'data' => [
+                'sys_language_uid' => 'de',
+                'header' => 'Deutscher Titel',
+            ],
+        ]);
+        $this->assertFalse($retryResult->isError, 'Retry after a validation error must succeed: '
+            . json_encode($retryResult->jsonSerialize()));
+        $translationUid = json_decode($retryResult->content[0]->text, true)['translationUid'];
+        $this->assertIsInt($translationUid);
+
+        $translation = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecord('tt_content', $translationUid);
+        $this->assertEquals('Deutscher Titel', $translation['header']);
+    }
+
+    /**
      * Test translate action with invalid language
      */
     public function testTranslateWithInvalidLanguage(): void

--- a/Tests/Llm/FileUploadTest.php
+++ b/Tests/Llm/FileUploadTest.php
@@ -1,0 +1,480 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Llm;
+
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Psr7\Response;
+use Hn\McpServer\Tests\Llm\Client\LlmResponse;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Test whether LLMs discover and use the UploadFile tool for the four ways
+ * files enter TYPO3 through MCP, phrased the way an editor would ask:
+ *
+ *   1. "put this YouTube video on the page"  → url mode, online media asset
+ *   2. "put this image from the web on the page" → url mode, real download
+ *   3. "draw me a chart and put it on the page" → content mode, generated SVG
+ *   4. "the photo is on my computer"          → pre-signed upload URL
+ *
+ * The interesting part is not whether UploadFile works (functional tests cover
+ * that) but whether the model picks the right mode from the description alone,
+ * and whether it then connects the uploaded file to a record - an upload nobody
+ * references is invisible on the website.
+ *
+ * HTTP downloads are intercepted by a Guzzle handler that passes everything
+ * else (notably the OpenRouter API calls of the test harness itself) through
+ * to the real handler.
+ *
+ * @group llm
+ */
+class FileUploadTest extends LlmTestCase
+{
+    /**
+     * Download URL used in the prompts. An IP literal from TEST-NET-3
+     * (203.0.113.0/24, reserved for documentation) on purpose: UploadFile
+     * validates the host against the SSRF rules BEFORE requesting it, and a
+     * literal skips DNS entirely, so the test needs no name resolution at all.
+     * The address counts as public, so validation passes and the mock answers.
+     */
+    protected const IMAGE_URL = 'http://203.0.113.10/press/office-building.jpg';
+
+    /**
+     * Tool errors the model ran into, as "ToolName: message". Surfaced in
+     * failure messages: the friction on the way to a passing run is what tells
+     * us which part of a tool description is unclear.
+     *
+     * @var string[]
+     */
+    protected array $observedToolErrors = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->observedToolErrors = [];
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/backend_layout.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/tt_content.csv');
+
+        // A real fileadmin storage: uploads write actual files
+        GeneralUtility::mkdir_deep(Environment::getPublicPath() . '/fileadmin');
+        GeneralUtility::makeInstance(StorageRepository::class)
+            ->createLocalStorage('fileadmin', 'fileadmin/', 'relative', '', true);
+
+        // Needed so pre-signed upload URLs can be built absolute
+        $siteDir = $this->instancePath . '/typo3conf/sites/test-site';
+        GeneralUtility::mkdir_deep($siteDir);
+        GeneralUtility::writeFile($siteDir . '/config.yaml', "rootPageId: 1\nbase: 'https://example.com/'\n", true);
+
+        $this->mockFileDownloads();
+    }
+
+    /**
+     * Intercept the download URL used in the prompts below and let everything
+     * else (OpenRouter, YouTube metadata lookups) hit the real handler.
+     */
+    protected function mockFileDownloads(): void
+    {
+        // A real 2x2 JPEG: TYPO3 verifies that the content matches the
+        // extension, so PNG bytes behind a .jpg name would be rejected.
+        $mocked = [
+            self::IMAGE_URL => new Response(
+                200,
+                ['Content-Type' => 'image/jpeg'],
+                base64_decode($this->jpegBase64())
+            ),
+        ];
+
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler'] = [
+            'mcp_llm_upload_mock' => function (callable $handler) use ($mocked) {
+                return function ($request, array $options) use ($handler, $mocked) {
+                    $url = (string)$request->getUri();
+                    foreach ($mocked as $prefix => $response) {
+                        if (str_starts_with($url, $prefix)) {
+                            return new FulfilledPromise($response);
+                        }
+                    }
+                    // Everything else keeps working, including the LLM API itself
+                    return $handler($request, $options);
+                };
+            },
+        ];
+    }
+
+    /**
+     * Fail loudly when the mock cannot answer (DNS trouble, changed handler):
+     * otherwise a broken test setup looks like a failing language model. Goes
+     * through RequestFactory only, so no sys_file is created as a side effect.
+     */
+    protected function assertMockedDownloadReachable(): void
+    {
+        try {
+            $response = GeneralUtility::makeInstance(RequestFactory::class)->request(self::IMAGE_URL);
+        } catch (\Throwable $e) {
+            self::fail('Test setup problem: the mocked image URL is unreachable (' . $e->getMessage() . ')');
+        }
+        self::assertEquals(200, $response->getStatusCode(), 'Test setup problem: the download mock did not answer');
+    }
+
+    protected function jpegBase64(): string
+    {
+        return '/9j/4AAQSkZJRgABAQEAYABgAAD//gA7Q1JFQVRPUjogZ2QtanBlZyB2MS4wICh1c2luZyBJSkcgSlBFRyB2ODApLCBxdWFsaXR5'
+            . 'ID0gNjAK/9sAQwANCQoLCggNCwoLDg4NDxMgFRMSEhMnHB4XIC4pMTAuKS0sMzpKPjM2RjcsLUBXQUZMTlJTUjI+WmFaUGBKUVJP'
+            . '/9sAQwEODg4TERMmFRUmTzUtNU9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09P/8AAEQgA'
+            . 'AgACAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUS'
+            . 'ITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0'
+            . 'dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX2'
+            . '9/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXET'
+            . 'IjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKD'
+            . 'hIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwD'
+            . 'AQACEQMRAD8AZRRRX1Z8yf/Z';
+    }
+
+    // ------------------------------------------------------------------
+    // 1. YouTube video
+    // ------------------------------------------------------------------
+
+    #[DataProvider('modelProvider')]
+    #[TestDox('[$modelKey] Prompt "Put this YouTube video on the home page" → UploadFile(url) creating an online media asset, then WriteTable referencing it')]
+    public function testLlmPlacesYoutubeVideoOnPage(string $modelKey): void
+    {
+        $this->setModel($modelKey);
+        $prompt = 'Please put this video on the home page: https://www.youtube.com/watch?v=dQw4w9WgXcQ '
+            . 'Give the element the header "Our Company Film".';
+
+        $response = $this->executeUntilToolFound($this->callLlm($prompt), 'UploadFile', 8);
+
+        $uploadCalls = $response->getToolCallsByName('UploadFile');
+        $this->assertNotEmpty(
+            $uploadCalls,
+            'Expected the LLM to use UploadFile for the YouTube URL instead of writing a raw URL into a field. '
+            . 'History: ' . implode(' → ', $this->getToolCallHistory()) . "\n" . $this->getFailureContext($response)
+        );
+        $this->assertStringContainsString(
+            'dQw4w9WgXcQ',
+            (string)($uploadCalls[0]['arguments']['url'] ?? ''),
+            'The video URL should be passed as "url". ' . $this->getFailureContext($response)
+        );
+
+        $fileUid = $this->runUntilFileUploaded($response);
+        $this->assertNotNull($fileUid, 'No sys_file record was created for the video. ' . $this->toolErrorSummary() . $this->getFailureContext($this->lastResponse));
+
+        $fileRow = $this->fetchFile($fileUid);
+        $this->assertEquals('youtube', $fileRow['extension'], 'The video should become a .youtube online media asset');
+
+        // The upload alone is invisible on the website - the model has to reference it
+        $contentUid = $this->runUntilContentReferencesFile($fileUid);
+        $this->assertNotNull(
+            $contentUid,
+            'The uploaded video was never referenced from a content element, so it stays invisible on the site. '
+            . 'History: ' . implode(' → ', $this->getToolCallHistory()) . $this->toolErrorSummary()
+            . "\n" . $this->getFailureContext($this->lastResponse)
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Image from a URL
+    // ------------------------------------------------------------------
+
+    #[DataProvider('modelProvider')]
+    #[TestDox('[$modelKey] Prompt "Here is an image URL, put it on the About page" → UploadFile(url) downloading it, then WriteTable referencing the new file')]
+    public function testLlmUploadsImageFromUrlAndPlacesItOnPage(string $modelKey): void
+    {
+        $this->setModel($modelKey);
+        $prompt = 'I have an image here: ' . self::IMAGE_URL . ' '
+            . 'Can you put it on the About page? The header should be "Our Office".';
+
+        $response = $this->executeUntilToolFound($this->callLlm($prompt), 'UploadFile', 8);
+
+        $uploadCalls = $response->getToolCallsByName('UploadFile');
+        $this->assertNotEmpty(
+            $uploadCalls,
+            'Expected UploadFile for the image URL. A raw URL in a tt_content field would not create a FAL file. '
+            . 'History: ' . implode(' → ', $this->getToolCallHistory()) . "\n" . $this->getFailureContext($response)
+        );
+        $this->assertStringContainsString(
+            'office-building.jpg',
+            (string)($uploadCalls[0]['arguments']['url'] ?? ''),
+            'The image URL should be passed as "url", not as "content". ' . $this->getFailureContext($response)
+        );
+
+        $this->assertMockedDownloadReachable();
+
+        $fileUid = $this->runUntilFileUploaded($response);
+        $this->assertNotNull($fileUid, 'The image was never stored as a sys_file. ' . $this->toolErrorSummary() . $this->getFailureContext($this->lastResponse));
+
+        $fileRow = $this->fetchFile($fileUid);
+        $this->assertEquals('image/jpeg', $fileRow['mime_type']);
+        $this->assertFileExists(
+            Environment::getPublicPath() . '/fileadmin' . $fileRow['identifier'],
+            'The downloaded image should exist on disk'
+        );
+
+        $contentUid = $this->runUntilContentReferencesFile($fileUid);
+        $this->assertNotNull(
+            $contentUid,
+            'The uploaded image was never referenced from a content element. '
+            . 'History: ' . implode(' → ', $this->getToolCallHistory()) . $this->toolErrorSummary()
+            . "\n" . $this->getFailureContext($this->lastResponse)
+        );
+
+        $contentRow = $this->fetchContent($contentUid);
+        $this->assertEquals(2, (int)$contentRow['pid'], 'The element should be created on the About page (uid=2)');
+    }
+
+    // ------------------------------------------------------------------
+    // 3. Generated SVG (content mode)
+    // ------------------------------------------------------------------
+
+    #[DataProvider('modelProvider')]
+    #[TestDox('[$modelKey] Prompt "Draw a bar chart from these numbers and put it on the page" → UploadFile(content) with an .svg file name, then WriteTable referencing it')]
+    public function testLlmGeneratesSvgChartAndPlacesItOnPage(string $modelKey): void
+    {
+        $this->setModel($modelKey);
+        $prompt = 'Create a simple bar chart as an SVG graphic from these revenue figures and put it on the home page: '
+            . '2023: 1.2 million, 2024: 1.8 million, 2025: 2.4 million. '
+            . 'The content element header should be "Revenue Development".';
+
+        $response = $this->executeUntilToolFound($this->callLlm($prompt), 'UploadFile', 8);
+
+        $uploadCalls = $response->getToolCallsByName('UploadFile');
+        $this->assertNotEmpty(
+            $uploadCalls,
+            'Expected UploadFile with generated SVG content. '
+            . 'History: ' . implode(' → ', $this->getToolCallHistory()) . "\n" . $this->getFailureContext($response)
+        );
+
+        $args = $uploadCalls[0]['arguments'];
+        $this->assertNotEmpty(
+            $args['content'] ?? '',
+            'Generated graphics must go through "content", not "url". Arguments: ' . json_encode($args)
+            . "\n" . $this->getFailureContext($response)
+        );
+        $this->assertStringContainsString('<svg', (string)$args['content'], 'The content should be SVG markup');
+        $this->assertStringEndsWith(
+            '.svg',
+            strtolower((string)($args['fileName'] ?? '')),
+            'The file name must carry the .svg extension, otherwise the content/extension check rejects it. '
+            . $this->getFailureContext($response)
+        );
+
+        $fileUid = $this->runUntilFileUploaded($response);
+        $this->assertNotNull($fileUid, 'The SVG was never stored as a sys_file. ' . $this->toolErrorSummary() . $this->getFailureContext($this->lastResponse));
+        $this->assertEquals('svg', $this->fetchFile($fileUid)['extension']);
+
+        $contentUid = $this->runUntilContentReferencesFile($fileUid);
+        $this->assertNotNull(
+            $contentUid,
+            'The generated chart was never referenced from a content element. '
+            . 'History: ' . implode(' → ', $this->getToolCallHistory()) . $this->toolErrorSummary()
+            . "\n" . $this->getFailureContext($this->lastResponse)
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // 4. Local file → pre-signed upload URL
+    // ------------------------------------------------------------------
+
+    #[DataProvider('modelProvider')]
+    #[TestDox('[$modelKey] Prompt "The photo is on my computer" → UploadFile without url/content, handing the pre-signed upload URL back to the user')]
+    public function testLlmOffersPresignedUploadUrlForLocalFile(string $modelKey): void
+    {
+        $this->setModel($modelKey);
+        $prompt = 'I have a photo of our team on my computer at /Users/anna/Desktop/team-2026.jpg '
+            . 'and I want it in the TYPO3 file storage. How do we do that?';
+
+        $response = $this->executeUntilToolFound($this->callLlm($prompt), 'UploadFile', 6);
+
+        $uploadCalls = $response->getToolCallsByName('UploadFile');
+        $this->assertNotEmpty(
+            $uploadCalls,
+            'Expected UploadFile to request an upload URL for the local file. '
+            . 'History: ' . implode(' → ', $this->getToolCallHistory()) . "\n" . $this->getFailureContext($response)
+        );
+
+        $args = $uploadCalls[0]['arguments'];
+        $this->assertEmpty(
+            $args['url'] ?? '',
+            'A local path is not a downloadable URL - "url" must stay empty so a pre-signed upload URL is issued. '
+            . 'Arguments: ' . json_encode($args) . "\n" . $this->getFailureContext($response)
+        );
+        $this->assertEmpty(
+            $args['content'] ?? '',
+            'The model cannot know the binary content of a local file; "content" must stay empty. '
+            . 'Arguments: ' . json_encode($args) . "\n" . $this->getFailureContext($response)
+        );
+
+        // Execute every call of this round so the conversation stays consistent
+        // (some models pair UploadFile with an exploratory call).
+        $results = [];
+        $uploadResult = null;
+        foreach ($response->getToolCalls() as $call) {
+            $callResult = $this->executeToolCall($call);
+            $results[] = $callResult;
+            if ($call['name'] === 'UploadFile' && $uploadResult === null) {
+                $uploadResult = $callResult;
+            }
+        }
+
+        $this->assertFalse($uploadResult['isError'] ?? false, 'Requesting the upload URL failed: ' . $uploadResult['content']);
+
+        $data = json_decode($uploadResult['content'], true);
+        $this->assertNotEmpty($data['uploadUrl'] ?? '', 'Expected a pre-signed uploadUrl in the result');
+        $this->assertNotEmpty($data['uploadToken'] ?? '', 'Expected a single-use uploadToken in the result');
+
+        // The instructions must reach the user: the client harness has to run
+        // the upload, so the model needs to pass the URL/token on.
+        $final = $this->continueWithToolResult($response, $results);
+        $text = $final->getContent();
+        $this->assertTrue(
+            str_contains($text, $data['uploadToken']) || str_contains($text, 'mcp_upload') || str_contains(strtolower($text), 'curl'),
+            'The model should hand the upload URL/token or the curl command to the user, otherwise the flow dead-ends. '
+            . 'Answer was: ' . $text . "\n" . $this->getFailureContext($final)
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Record every tool error so failures can show what the model struggled
+     * with. Set MCP_LLM_DEBUG=1 to also see them on passing runs.
+     */
+    protected function executeToolCall(array $toolCall): array
+    {
+        $result = parent::executeToolCall($toolCall);
+        if ($result['isError'] ?? false) {
+            $message = ($toolCall['name'] ?? '?') . ': ' . substr(trim((string)$result['content']), 0, 300);
+            $this->observedToolErrors[] = $message;
+            if (getenv('MCP_LLM_DEBUG')) {
+                fwrite(STDERR, "\n[tool error] " . $message . "\n");
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Tool errors collected so far, for appending to assertion messages.
+     */
+    protected function toolErrorSummary(): string
+    {
+        if ($this->observedToolErrors === []) {
+            return '';
+        }
+        return "\nTool errors along the way:\n - " . implode("\n - ", $this->observedToolErrors);
+    }
+
+    /**
+     * Keep executing tool calls until a sys_file row exists, and return its uid.
+     * Models may explore (ListTables, GetTableSchema) before uploading.
+     */
+    protected function runUntilFileUploaded(LlmResponse $response, int $maxRounds = 6): ?int
+    {
+        $current = $response;
+        for ($round = 0; $round < $maxRounds; $round++) {
+            $uid = $this->findUploadedFile();
+            if ($uid !== null) {
+                $this->lastResponse = $current;
+                return $uid;
+            }
+            if (!$current->hasToolCalls()) {
+                break;
+            }
+            $current = $this->executeAndContinue($current);
+        }
+        $this->lastResponse = $current;
+        return $this->findUploadedFile();
+    }
+
+    /**
+     * Keep executing tool calls until some tt_content record references the
+     * given file, and return that content uid.
+     */
+    protected function runUntilContentReferencesFile(int $fileUid, int $maxRounds = 8): ?int
+    {
+        $current = $this->lastResponse;
+        for ($round = 0; $round < $maxRounds; $round++) {
+            $contentUid = $this->findContentReferencingFile($fileUid);
+            if ($contentUid !== null) {
+                return $contentUid;
+            }
+            if ($current === null || !$current->hasToolCalls()) {
+                break;
+            }
+            $current = $this->executeAndContinue($current);
+            $this->lastResponse = $current;
+        }
+        return $this->findContentReferencingFile($fileUid);
+    }
+
+    /**
+     * The newest sys_file that is not part of the seeded fixtures.
+     */
+    protected function findUploadedFile(): ?int
+    {
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_file');
+        $qb->getRestrictions()->removeAll();
+        $uid = $qb->select('uid')
+            ->from('sys_file')
+            ->orderBy('uid', 'DESC')
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchOne();
+
+        return $uid ? (int)$uid : null;
+    }
+
+    protected function fetchFile(int $uid): array
+    {
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_file');
+        $qb->getRestrictions()->removeAll();
+        return $qb->select('*')
+            ->from('sys_file')
+            ->where($qb->expr()->eq('uid', $uid))
+            ->executeQuery()
+            ->fetchAssociative() ?: [];
+    }
+
+    protected function fetchContent(int $uid): array
+    {
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
+        $qb->getRestrictions()->removeAll();
+        return $qb->select('*')
+            ->from('tt_content')
+            ->where($qb->expr()->eq('uid', $uid))
+            ->executeQuery()
+            ->fetchAssociative() ?: [];
+    }
+
+    /**
+     * Find a tt_content record (live or workspace version) that references the
+     * given file through any sys_file_reference field.
+     */
+    protected function findContentReferencingFile(int $fileUid): ?int
+    {
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_file_reference');
+        $qb->getRestrictions()->removeAll();
+        $row = $qb->select('uid_foreign')
+            ->from('sys_file_reference')
+            ->where(
+                $qb->expr()->eq('uid_local', $qb->createNamedParameter($fileUid, \Doctrine\DBAL\ParameterType::INTEGER)),
+                $qb->expr()->eq('tablenames', $qb->createNamedParameter('tt_content')),
+                $qb->expr()->eq('deleted', 0)
+            )
+            ->orderBy('uid', 'DESC')
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchOne();
+
+        return $row ? (int)$row : null;
+    }
+}

--- a/Tests/Llm/SysFileMetadataTest.php
+++ b/Tests/Llm/SysFileMetadataTest.php
@@ -29,6 +29,13 @@ class SysFileMetadataTest extends LlmTestCase
     {
         parent::setUp();
 
+        // A site configuration with a German language. Without it, TYPO3 has no
+        // language support at all, and WriteTable's translate action can never
+        // succeed on the pid-0 metadata records ("Language ID 1 not found for
+        // page 0") - the translation test would then only pass for models that
+        // avoid the canonical translate path and hand-create the l10n row.
+        $this->createSiteWithGerman();
+
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/pages.csv');
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/backend_layout.csv');
         $this->importCSVDataSet(__DIR__ . '/../Functional/Fixtures/sys_file.csv');
@@ -42,6 +49,28 @@ class SysFileMetadataTest extends LlmTestCase
         $this->insertMetadata(3, 'Person Photo', 'Original alt for person');
         $this->insertMetadata(4, 'Company Logo', '');
         $this->insertMetadata(5, 'Team Group Photo', '');
+    }
+
+    private function createSiteWithGerman(): void
+    {
+        $siteConfiguration = [
+            'rootPageId' => 1,
+            'base' => 'https://example.com/',
+            'websiteTitle' => 'Test Site',
+            'languages' => [
+                0 => ['title' => 'English', 'enabled' => true, 'languageId' => 0, 'base' => '/', 'locale' => 'en_US.UTF-8', 'iso-639-1' => 'en', 'hreflang' => 'en-us', 'direction' => 'ltr', 'flag' => 'us', 'navigationTitle' => 'English'],
+                1 => ['title' => 'German', 'enabled' => true, 'languageId' => 1, 'base' => '/de/', 'locale' => 'de_DE.UTF-8', 'iso-639-1' => 'de', 'hreflang' => 'de-de', 'direction' => 'ltr', 'flag' => 'de', 'navigationTitle' => 'Deutsch'],
+            ],
+            'routes' => [],
+            'errorHandling' => [],
+        ];
+        $configPath = $this->instancePath . '/typo3conf/sites/test-site';
+        GeneralUtility::mkdir_deep($configPath);
+        GeneralUtility::writeFile(
+            $configPath . '/config.yaml',
+            \Symfony\Component\Yaml\Yaml::dump($siteConfiguration, 99, 2),
+            true
+        );
     }
 
     private function insertMetadata(int $fileUid, string $title, string $alternative, string $description = ''): int

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -3,3 +3,6 @@ additionalReadOnlyTables = sys_file
 
 # cat=mcp/tables; type=string; label=Additional standalone tables: Comma-separated list of tables marked as hideTable=true in TCA that should still be exposed as independent tables instead of being embedded into their parent's inline relation. Use this for hideTable tables whose inline structure is too complex (translations, mounts, ...) to be safely edited through the parent. Example: sys_file_metadata,tx_myext_complex_child
 additionalStandaloneTables = sys_file_metadata
+
+# cat=mcp/files; type=int+; label=Maximum file size (MiB): Upper limit for files fetched from URLs or received through pre-signed uploads via the UploadFile tool. Default: 500
+maxFileSizeMb = 500

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -48,3 +48,23 @@ CREATE TABLE tx_mcpserver_access_tokens (
 	KEY be_user_uid (be_user_uid),
 	KEY expires (expires)
 );
+#
+# Pre-signed single-use upload tokens (UploadFile MCP tool)
+#
+CREATE TABLE tx_mcpserver_upload_tokens (
+	uid int(11) NOT NULL auto_increment,
+	pid int(11) DEFAULT '0' NOT NULL,
+	tstamp int(11) unsigned DEFAULT '0' NOT NULL,
+	crdate int(11) unsigned DEFAULT '0' NOT NULL,
+
+	token varchar(64) DEFAULT '' NOT NULL,
+	be_user_uid int(11) unsigned DEFAULT '0' NOT NULL,
+	target_folder varchar(255) DEFAULT '' NOT NULL,
+	file_name varchar(255) DEFAULT '' NOT NULL,
+	expires int(11) unsigned DEFAULT '0' NOT NULL,
+	used int(11) unsigned DEFAULT '0' NOT NULL,
+
+	PRIMARY KEY (uid),
+	KEY token (token),
+	KEY expires (expires)
+);

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -92,6 +92,6 @@ CREATE TABLE tx_mcpserver_upload_tokens (
 	used int(11) unsigned DEFAULT '0' NOT NULL,
 
 	PRIMARY KEY (uid),
-	KEY token (token),
+	UNIQUE KEY token (token),
 	KEY expires (expires)
 );


### PR DESCRIPTION
## Summary
Adds a new **UploadFile** MCP tool that enables uploading files to TYPO3's file storage (FAL) through three modes: downloading from HTTP URLs (including YouTube/Vimeo as online media), storing raw text content, or issuing pre-signed single-use upload URLs for direct client uploads.

## Key Changes

### New MCP Tool
- **UploadFileTool** (`Classes/MCP/Tool/File/UploadFileTool.php`): Implements three upload modes:
  - URL downloads with SSRF protection (validates public IPs, follows redirects, derives file names from Content-Disposition headers or MIME types)
  - Raw text content storage (for SVG, CSV, VTT, etc.)
  - Pre-signed upload tokens for out-of-band binary uploads via HTTP PUT/POST
  - YouTube/Vimeo URLs are recognized and stored as TYPO3 online media assets (placeholder files, not full downloads)

### Shared Upload Service
- **FileUploadService** (`Classes/Service/FileUploadService.php`): Core upload logic used by both the MCP tool and HTTP endpoint:
  - Folder resolution with automatic creation of missing directories
  - File deduplication by SHA1 content hash (identical uploads return existing file)
  - Automatic renaming on name conflicts (never overwrites)
  - User permission enforcement (file mounts, storage permissions)
  - Configurable max file size via extension settings
  - Single-use token generation and validation

### HTTP Endpoint
- **FileUploadEndpoint** (`Classes/Http/FileUploadEndpoint.php`): Handles pre-signed upload requests:
  - Accepts raw file bytes via PUT or multipart POST
  - Authenticates via single-use tokens bound to backend user and target folder
  - Supports file name from query parameter, Content-Disposition header, or token
  - Returns created sys_file as JSON (uid, fileName, publicUrl, mimeType, size)
  - Integrated into middleware routing at `/mcp_upload`

### Database Schema
- **tx_mcpserver_upload_tokens** table: Stores single-use upload tokens with:
  - Hashed token for security
  - Backend user and target folder binding
  - Expiration (15 minutes) and single-use enforcement
  - Automatic cleanup of expired tokens

### Testing
- **UploadFileToolTest** (459 lines): Comprehensive functional tests covering:
  - Content uploads with nested folder creation
  - URL downloads with redirect following and SSRF validation
  - Online media (YouTube/Vimeo) recognition
  - File deduplication and conflict renaming
  - Pre-signed upload URL generation
  - Extension validation and error handling
  - Private/reserved IP rejection
  - Content-Type to extension mapping

- **FileUploadEndpointTest**: Tests the HTTP endpoint:
  - Token validation and single-use enforcement
  - File name resolution from multiple sources
  - Multipart and raw PUT uploads
  - Permission checks

## Notable Implementation Details

- **SSRF Protection**: URL validation uses public IP ranges (TEST-NET-3: 203.0.113.0/24) and rejects private/reserved addresses. Redirects are re-validated via `on_redirect` callback. DNS rebinding is mitigated by pinning resolved IPs to curl requests.
- **Deduplication**: Identical content is detected via SHA1 hash lookup in TYPO3's file index, making retries after timeouts idempotent.
- **User Permissions**: File mounts and storage permissions are explicitly applied (mirrors core's StoragePermissionsAspect for CLI/stdio contexts where `TYPO3_REQUEST` is not a backend request).
- **Online Media**: YouTube/Vimeo URLs bypass download logic and use TYPO3's OnlineMediaHelperRegistry to create placeholder files.
- **Token Security**: Upload tokens are hashed in the database; the plain token is only returned once to the client.
- **File Validation**: TYPO3's ResourceConsistencyService validates that file content matches the extension/MIME type (prevents misnamed uploads).

## Documentation Updates
- Updated TECHNICAL_OVERVIEW.md to list UploadFile

https://claude.ai/code/session_01BYM9MJXnkwMoPRRJnP7GHD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload files from URLs, YouTube/Vimeo links, text content, or local files using single-use pre-signed links.
  * Support multipart and authenticated uploads through the dedicated upload endpoint.
  * Configure maximum upload and download size limits.

* **Bug Fixes**
  * Strengthened SSRF, filename, executable-file, token, and deduplication protections.
  * Improved translation field handling and cleanup after failed uploads.

* **Documentation**
  * Expanded file-upload guidance and configuration details.

* **Tests**
  * Added coverage for upload, security, deduplication, and translation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->