### PR TITLE
Add Cortecs LLM gateway support with EU-native ZDR routing

### DIFF
--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -79,6 +79,8 @@ class WriteTableTool extends AbstractRecordTool
                             'on "update" setting "pid" moves the record to that page (combine with "position" to control where on the new page it lands; e.g. data: {"pid": 1} moves the record to page 1). ' .
                             ($hasMultipleLanguages ? 'Language fields (sys_language_uid) accept ISO codes like "de", "fr" instead of numeric IDs. ' : '') .
                             'Inline relations can be specified as arrays - UIDs for independent tables, record data for embedded tables. ' .
+                            'A file reference is an embedded record keyed by "uid_local" (the sys_file uid), so attaching an image looks like ' .
+                            '"assets": [{"uid_local": 3}] — always a list of record objects, never a single object or a wrapper like {"item": ...}. ' .
                             'For embedded tables (e.g. file references), the array fully replaces the existing list: ' .
                             'children present in the previous record but missing from the new array are deleted. ' .
                             'To keep an existing child include it as {"uid": <existing>, ...}; only the fields you set are patched. ' .
@@ -90,6 +92,7 @@ class WriteTableTool extends AbstractRecordTool
                         'examples' => [
                             ['pid' => 42, 'title' => 'News Title', 'bodytext' => 'News <b>content</b>', 'datetime' => '2024-01-01 10:00:00'],
                             ['pid' => 1, 'header' => 'Content Element Header', 'bodytext' => 'Content <b>text</b>', 'CType' => 'text'],
+                            ['pid' => 1, 'CType' => 'textmedia', 'header' => 'Our Team Lead', 'assets' => [['uid_local' => 3]]],
                             ['pid' => 5],
                             ['sys_language_uid' => 'de', 'title' => 'German translation'],
                             ['header' => [['search' => 'Welcom', 'replace' => 'Welcome'], ['search' => 'Compnay', 'replace' => 'Company']]],
@@ -1212,7 +1215,7 @@ class WriteTableTool extends AbstractRecordTool
             if ($fieldConfig && ($fieldType === 'inline' || $fieldType === 'file')) {
                 $inlineRelations[$fieldName] = [
                     'config' => $fieldConfig['config'],
-                    'value' => $value
+                    'value' => $this->normalizeInlineRelationValue($value)
                 ];
                 // Remove from data array as we'll process it separately
                 unset($data[$fieldName]);
@@ -1532,13 +1535,48 @@ class WriteTableTool extends AbstractRecordTool
     /**
      * Validate inline relation data
      */
+    /**
+     * Coerce near-miss inline/file relation shapes into the canonical list form.
+     *
+     * The relation value must be a list — UIDs for independent tables, record
+     * objects for embedded tables. Weaker LLMs frequently emit near-misses that
+     * clearly mean the same thing, and rejecting them just burns retries:
+     *  - a single record object, e.g. {"uid_local": 3}  → [{"uid_local": 3}]
+     *  - a wrapper map of records, e.g. {"item": {"uid_local": 3}}
+     *    (or {"0": {...}, "1": {...}}) → [{"uid_local": 3}]
+     *
+     * Heuristic: an already-list value is untouched; an associative array whose
+     * values are ALL arrays is treated as a wrapper (take its values), otherwise
+     * it is treated as a single record and wrapped. This mirrors the tolerance we
+     * apply elsewhere (e.g. empty select values) — the point of these tools is to
+     * be intuitive for LLMs, not to punish reasonable phrasing.
+     */
+    protected function normalizeInlineRelationValue($value)
+    {
+        if (!is_array($value) || $value === [] || array_is_list($value)) {
+            return $value;
+        }
+
+        foreach ($value as $item) {
+            if (!is_array($item)) {
+                // At least one scalar field → this is a single record object.
+                return [$value];
+            }
+        }
+
+        // Every value is itself an array → treat as a wrapper of records.
+        return array_values($value);
+    }
+
     protected function validateInlineRelationData(array $fieldConfig, $value): ?string
     {
+        $value = $this->normalizeInlineRelationValue($value);
+
         // Check if value is an array
         if (!is_array($value)) {
             return 'Inline relation field must be an array of UIDs or record data';
         }
-        
+
         // Get foreign table
         $foreignTable = $fieldConfig['config']['foreign_table'] ?? '';
         if (empty($foreignTable)) {

--- a/Classes/Service/TableAccessService.php
+++ b/Classes/Service/TableAccessService.php
@@ -1366,7 +1366,15 @@ class TableAccessService implements SingletonInterface
 
         // Validate select fields (all sources: static, foreign_table, itemsProcFunc, TSconfig)
         if ($fieldType === 'select') {
-            $allowedValues = $this->getSelectFieldAllowedValues($table, $fieldName, $record);
+            // An empty value means "leave unset / use the field default" (e.g.
+            // an inherited backend_layout). TCA models that default as an item
+            // with an empty value, but parseSelectItems() drops empty-valued
+            // items from the advertised enum — so an explicit '' or null would
+            // otherwise fail the membership check below even though it is valid.
+            // Treat empty as "not set" here; the required-field check further
+            // down still rejects empty values for fields that mandate one.
+            $isEmpty = $value === null || $value === '' || (is_array($value) && empty($value));
+            $allowedValues = $isEmpty ? null : $this->getSelectFieldAllowedValues($table, $fieldName, $record);
             if ($allowedValues !== null) {
                 // Handle multiple values: arrays (multi-select), comma-separated strings, or single values
                 if (is_array($value)) {

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ AI assistants to safely view and manipulate TYPO3 pages and records through TYPO
 
 ## 🧪 Continuously Tested With Real LLMs
 
-Every push to `main` runs a benchmark that has the latest models from **Anthropic, OpenAI, Mistral, and Google** actually use this MCP to perform real TYPO3 tasks. That's how we stay vendor-independent and prove the tool descriptions convey what they claim across very different prompting styles — your AI assistant of choice should just work, not only ours. Click any badge for the full run-by-run history.
+Every push to `main` runs a benchmark that has the latest models from **Anthropic, OpenAI, MiniMax, Mistral, and Google** actually use this MCP to perform real TYPO3 tasks. That's how we stay vendor-independent and prove the tool descriptions convey what they claim across very different prompting styles — your AI assistant of choice should just work, not only ours. Click any badge for the full run-by-run history.
 
 [
 ![haiku-4.5](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FAKfycbwyS4NavPMDQWbQQYCh3uKA4zJ5C8sxggxTZQQPdgjXOZ7Vt4BpUd5mzWdsWMqjzniI%2Fexec&query=%24.percentages%5B%22haiku-4.5%22%5D&suffix=%25&label=haiku-4.5)
-![gpt-5.4-mini](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FAKfycbwyS4NavPMDQWbQQYCh3uKA4zJ5C8sxggxTZQQPdgjXOZ7Vt4BpUd5mzWdsWMqjzniI%2Fexec&query=%24.percentages%5B%22gpt-5.4-mini%22%5D&suffix=%25&label=gpt-5.4-mini)
+![minimax-m3](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FAKfycbwyS4NavPMDQWbQQYCh3uKA4zJ5C8sxggxTZQQPdgjXOZ7Vt4BpUd5mzWdsWMqjzniI%2Fexec&query=%24.percentages%5B%22minimax-m3%22%5D&suffix=%25&label=minimax-m3)
 ![gpt-oss-120b](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FAKfycbwyS4NavPMDQWbQQYCh3uKA4zJ5C8sxggxTZQQPdgjXOZ7Vt4BpUd5mzWdsWMqjzniI%2Fexec&query=%24.percentages%5B%22gpt-oss-120b%22%5D&suffix=%25&label=gpt-oss-120b)
 ![mistral-large-2512](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FAKfycbwyS4NavPMDQWbQQYCh3uKA4zJ5C8sxggxTZQQPdgjXOZ7Vt4BpUd5mzWdsWMqjzniI%2Fexec&query=%24.percentages%5B%22mistral-large-2512%22%5D&suffix=%25&label=mistral-large-2512)
 ![gemini-3-flash](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscript.google.com%2Fmacros%2Fs%2FAKfycbwyS4NavPMDQWbQQYCh3uKA4zJ5C8sxggxTZQQPdgjXOZ7Vt4BpUd5mzWdsWMqjzniI%2Fexec&query=%24.percentages%5B%22gemini-3-flash%22%5D&suffix=%25&label=gemini-3-flash)

--- a/Tests/Functional/MCP/Tool/FileReferenceTest.php
+++ b/Tests/Functional/MCP/Tool/FileReferenceTest.php
@@ -153,6 +153,79 @@ class FileReferenceTest extends FunctionalTestCase
     }
 
     /**
+     * Weaker LLMs often emit a file reference as a single record object instead
+     * of a one-element list. The tool should normalize that shape and still
+     * create the reference. See WriteTableTool::normalizeInlineRelationValue().
+     */
+    public function testCreateContentElementWithSingleObjectFileReference(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+
+        $result = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'header' => 'Single object assets',
+                'CType' => 'textmedia',
+                // Not wrapped in a list — a bare record object.
+                'assets' => ['uid_local' => 1, 'title' => 'Single Object Image'],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $contentUid = json_decode($result->content[0]->text, true)['uid'];
+
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $data = json_decode($readTool->execute([
+            'table' => 'tt_content',
+            'uid' => $contentUid,
+        ])->content[0]->text, true);
+        $record = $data['records'][0];
+
+        $this->assertArrayHasKey('assets', $record);
+        $this->assertCount(1, $record['assets']);
+        $this->assertEquals(1, $record['assets'][0]['uid_local']);
+        $this->assertEquals('Single Object Image', $record['assets'][0]['title']);
+    }
+
+    /**
+     * Another common near-miss: the record wrapped in a map (e.g. {"item": {...}})
+     * rather than a list. The tool should unwrap it and create the reference.
+     */
+    public function testCreateContentElementWithWrappedFileReference(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+
+        $result = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'header' => 'Wrapped assets',
+                'CType' => 'textmedia',
+                // Wrapper map around the record, as seen from some models.
+                'assets' => ['item' => ['uid_local' => 1, 'title' => 'Wrapped Image']],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $contentUid = json_decode($result->content[0]->text, true)['uid'];
+
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $data = json_decode($readTool->execute([
+            'table' => 'tt_content',
+            'uid' => $contentUid,
+        ])->content[0]->text, true);
+        $record = $data['records'][0];
+
+        $this->assertArrayHasKey('assets', $record);
+        $this->assertCount(1, $record['assets']);
+        $this->assertEquals(1, $record['assets'][0]['uid_local']);
+        $this->assertEquals('Wrapped Image', $record['assets'][0]['title']);
+    }
+
+    /**
      * Test that file references work correctly in workspaces (live UIDs exposed)
      */
     public function testFileReferencesInWorkspace(): void

--- a/Tests/Functional/MCP/Tool/ValidationRefactoringTest.php
+++ b/Tests/Functional/MCP/Tool/ValidationRefactoringTest.php
@@ -99,6 +99,62 @@ class ValidationRefactoringTest extends FunctionalTestCase
         $this->assertStringContainsString('must be one of', $result);
     }
 
+    /**
+     * Regression: an empty select value means "leave unset / use the field
+     * default" (e.g. an inherited backend_layout). TCA models that default as
+     * an item with an empty value, but the advertised enum never contains the
+     * empty option, so an explicit '' or null must not be validated against it.
+     * This previously made LLMs fail to create a page whenever they filled in
+     * an empty backend_layout.
+     */
+    public function testEmptySelectValueIsAllowed(): void
+    {
+        $this->assertNull(
+            $this->tableAccessService->validateFieldValue('pages', 'backend_layout', ''),
+            'Empty backend_layout should be accepted (means "use default")'
+        );
+        $this->assertNull(
+            $this->tableAccessService->validateFieldValue('pages', 'backend_layout', null),
+            'Null backend_layout should be accepted (means "use default")'
+        );
+    }
+
+    /**
+     * The empty-value exemption must not weaken validation of real values:
+     * a non-empty value that is not a registered option is still rejected.
+     */
+    public function testInvalidNonEmptySelectValueStillRejected(): void
+    {
+        $result = $this->tableAccessService->validateFieldValue(
+            'pages',
+            'backend_layout',
+            'definitely-not-a-registered-layout'
+        );
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('must be one of', $result);
+    }
+
+    /**
+     * End-to-end reproduction of the original failure: creating a page while
+     * passing an empty backend_layout must succeed, not error out.
+     */
+    public function testWriteToolAcceptsEmptyBackendLayout(): void
+    {
+        $params = [
+            'action' => 'create',
+            'table' => 'pages',
+            'pid' => 1,
+            'data' => [
+                'title' => 'Page With Empty Layout',
+                'doktype' => 1,
+                'backend_layout' => '',
+            ],
+        ];
+
+        $result = $this->writeTool->execute($params);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+    }
+
     public function testStringLengthValidation(): void
     {
         // header field has a max length of 255

--- a/Tests/Llm/Client/CortecsClient.php
+++ b/Tests/Llm/Client/CortecsClient.php
@@ -1,0 +1,326 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Llm\Client;
+
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Cortecs API client implementation
+ *
+ * Cortecs (https://cortecs.ai) is a European ("EU-native") LLM gateway that
+ * exposes an OpenAI-compatible chat/completions endpoint, routing to a large
+ * pool of EU-hosted providers. Like OpenRouter it lets us hit many models with
+ * a single key, but with GDPR-friendly routing and optional Zero Data Retention.
+ *
+ * Differences from {@see OpenRouterClient} that this client papers over:
+ *  - Model IDs carry no provider prefix ("claude-haiku-4-5", not
+ *    "anthropic/claude-haiku-4.5").
+ *  - Zero Data Retention is requested via the top-level
+ *    `allow_zero_data_retention` body parameter (mirrors the account setting).
+ *  - The OpenRouter-style `reasoning` object is NOT universally accepted:
+ *    Claude models are served via AWS Bedrock, which rejects an unknown
+ *    `reasoning` key with HTTP 400. Callers must only pass `reasoning` to
+ *    models that support it (e.g. the gpt-oss series). This client therefore
+ *    does not inject it on its own.
+ */
+class CortecsClient implements LlmClientInterface
+{
+    private const API_URL = 'https://api.cortecs.ai/v1/chat/completions';
+
+    private string $apiKey;
+    private bool $zeroDataRetention;
+    private RequestFactory $requestFactory;
+
+    /** @var array Full conversation history for multi-turn support */
+    private array $conversationHistory = [];
+
+    public function __construct(string $apiKey, bool $zeroDataRetention = true)
+    {
+        $this->apiKey = $apiKey;
+        $this->zeroDataRetention = $zeroDataRetention;
+        $this->requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
+    }
+
+    public function complete(string $prompt, array $tools, array $options = []): LlmResponse
+    {
+        // Reset conversation history for new conversation
+        $this->conversationHistory = [];
+
+        $model = $options['model'] ?? 'claude-haiku-4-5';
+        $temperature = $options['temperature'] ?? 0;
+        $maxTokens = $options['max_tokens'] ?? 4000;
+
+        $messages = [
+            [
+                'role' => 'system',
+                'content' => 'You are a TYPO3 CMS content management assistant with access to MCP tools. '
+                    . 'Execute tasks directly using the available tools — do not ask for confirmation or present options. '
+                    . 'When asked to create, update, or modify content, do it immediately.',
+            ],
+            [
+                'role' => 'user',
+                'content' => $prompt,
+            ],
+        ];
+
+        $this->conversationHistory = $messages;
+
+        $requestBody = [
+            'model' => $model,
+            'max_tokens' => $maxTokens,
+            'temperature' => $temperature,
+            'messages' => $messages,
+            'tools' => $this->convertToolsToOpenAIFormat($tools),
+        ];
+
+        return $this->sendRequest($this->applyOptions($requestBody, $options));
+    }
+
+    public function completeWithHistory(
+        string $initialPrompt,
+        LlmResponse $previousResponse,
+        array $toolResults,
+        array $tools,
+        array $options = []
+    ): LlmResponse {
+        $model = $options['model'] ?? 'claude-haiku-4-5';
+        $temperature = $options['temperature'] ?? 0;
+        $maxTokens = $options['max_tokens'] ?? 4000;
+
+        // Build full conversation from history
+        if (empty($this->conversationHistory)) {
+            $this->conversationHistory = [
+                [
+                    'role' => 'user',
+                    'content' => $initialPrompt,
+                ],
+            ];
+        }
+
+        // Add the assistant's response (with tool calls)
+        $assistantMessage = $this->buildAssistantMessage($previousResponse);
+        $this->conversationHistory[] = $assistantMessage;
+
+        // Add tool results
+        $rawResponse = $previousResponse->getRawResponse();
+        $rawToolCalls = $rawResponse['choices'][0]['message']['tool_calls'] ?? [];
+
+        foreach ($toolResults as $index => $result) {
+            $toolCallId = $rawToolCalls[$index]['id'] ?? ('call_' . $index);
+
+            $this->conversationHistory[] = [
+                'role' => 'tool',
+                'tool_call_id' => $toolCallId,
+                'content' => $result['content'] ?? json_encode($result),
+            ];
+        }
+
+        $requestBody = [
+            'model' => $model,
+            'max_tokens' => $maxTokens,
+            'temperature' => $temperature,
+            'messages' => $this->conversationHistory,
+            'tools' => $this->convertToolsToOpenAIFormat($tools),
+        ];
+
+        return $this->sendRequest($this->applyOptions($requestBody, $options));
+    }
+
+    /**
+     * Apply optional pass-through parameters (reasoning, cache_control) and the
+     * Zero Data Retention flag onto the request body.
+     */
+    private function applyOptions(array $requestBody, array $options): array
+    {
+        if (isset($options['reasoning'])) {
+            $requestBody['reasoning'] = $options['reasoning'];
+        }
+
+        if (isset($options['cache_control'])) {
+            $requestBody['cache_control'] = $options['cache_control'];
+        }
+
+        if ($this->zeroDataRetention) {
+            $requestBody['allow_zero_data_retention'] = true;
+        }
+
+        return $requestBody;
+    }
+
+    /**
+     * Send a request to the Cortecs API with retry on transient failures
+     */
+    private function sendRequest(array $requestBody): LlmResponse
+    {
+        $maxRetries = 3;
+        $lastException = null;
+
+        for ($attempt = 0; $attempt <= $maxRetries; $attempt++) {
+            if ($attempt > 0) {
+                // Exponential backoff: 2s, 4s, 8s
+                sleep((int)pow(2, $attempt));
+            }
+
+            try {
+                $response = $this->requestFactory->request(
+                    self::API_URL,
+                    'POST',
+                    [
+                        'headers' => [
+                            'Authorization' => 'Bearer ' . $this->apiKey,
+                            'Content-Type' => 'application/json',
+                        ],
+                        'body' => json_encode($requestBody),
+                    ]
+                );
+
+                $statusCode = $response->getStatusCode();
+
+                if ($statusCode === 200) {
+                    $responseData = json_decode($response->getBody()->getContents(), true);
+                    return $this->parseResponse($responseData);
+                }
+
+                $errorBody = $response->getBody()->getContents();
+
+                // Retry on server errors (5xx) and rate limits (429)
+                if ($statusCode >= 500 || $statusCode === 429) {
+                    $lastException = new \RuntimeException(
+                        'Cortecs API error: ' . $statusCode . ' - ' . $errorBody
+                    );
+                    continue;
+                }
+
+                // Client errors (4xx except 429) are not retryable
+                throw new \RuntimeException(
+                    'Cortecs API error: ' . $statusCode . ' - ' . $errorBody .
+                    "\n\nRequest body:\n" . json_encode($requestBody, JSON_PRETTY_PRINT)
+                );
+            } catch (\GuzzleHttp\Exception\ServerException $e) {
+                $lastException = new \RuntimeException(
+                    'Cortecs API server error: ' . $e->getMessage(),
+                    0,
+                    $e
+                );
+                continue;
+            } catch (\GuzzleHttp\Exception\ClientException $e) {
+                // Retry on 429 Too Many Requests (rate limiting)
+                if ($e->getResponse() && $e->getResponse()->getStatusCode() === 429) {
+                    $lastException = new \RuntimeException(
+                        'Cortecs API rate limited: ' . $e->getMessage(),
+                        0,
+                        $e
+                    );
+                    continue;
+                }
+                throw new \RuntimeException(
+                    'Cortecs API client error: ' . $e->getMessage(),
+                    0,
+                    $e
+                );
+            } catch (\GuzzleHttp\Exception\ConnectException $e) {
+                $lastException = new \RuntimeException(
+                    'Cortecs API connection error: ' . $e->getMessage(),
+                    0,
+                    $e
+                );
+                continue;
+            } catch (\RuntimeException $e) {
+                throw $e;
+            } catch (\Exception $e) {
+                throw new \RuntimeException(
+                    'Failed to call Cortecs API: ' . $e->getMessage(),
+                    0,
+                    $e
+                );
+            }
+        }
+
+        throw $lastException ?? new \RuntimeException('Cortecs API request failed after retries');
+    }
+
+    /**
+     * Convert tools to OpenAI function calling format
+     *
+     * Tools are already in OpenAI format from getMcpToolsAsLlmFunctions(),
+     * so this is essentially a pass-through with validation.
+     */
+    private function convertToolsToOpenAIFormat(array $tools): array
+    {
+        $openAITools = [];
+
+        foreach ($tools as $tool) {
+            if ($tool['type'] === 'function') {
+                $openAITools[] = [
+                    'type' => 'function',
+                    'function' => [
+                        'name' => $tool['function']['name'],
+                        'description' => $tool['function']['description'] ?? '',
+                        'parameters' => $tool['function']['parameters'] ?? [
+                            'type' => 'object',
+                            'properties' => new \stdClass(),
+                        ],
+                    ],
+                ];
+            }
+        }
+
+        return $openAITools;
+    }
+
+    /**
+     * Parse OpenAI-format response into LlmResponse
+     */
+    private function parseResponse(array $responseData): LlmResponse
+    {
+        $choice = $responseData['choices'][0] ?? [];
+        $message = $choice['message'] ?? [];
+
+        $content = $message['content'] ?? '';
+        $toolCalls = [];
+
+        foreach ($message['tool_calls'] ?? [] as $toolCall) {
+            if (($toolCall['type'] ?? '') === 'function') {
+                $arguments = $toolCall['function']['arguments'] ?? '{}';
+
+                // Parse JSON arguments string
+                if (is_string($arguments)) {
+                    $arguments = json_decode($arguments, true) ?? [];
+                }
+
+                $toolCalls[] = [
+                    'name' => $toolCall['function']['name'],
+                    'arguments' => $arguments,
+                ];
+            }
+        }
+
+        return new LlmResponse($content, $toolCalls, $responseData);
+    }
+
+    /**
+     * Build assistant message from previous response for conversation history
+     */
+    private function buildAssistantMessage(LlmResponse $previousResponse): array
+    {
+        $rawResponse = $previousResponse->getRawResponse();
+        $message = $rawResponse['choices'][0]['message'] ?? [];
+
+        $assistantMessage = [
+            'role' => 'assistant',
+        ];
+
+        if (!empty($message['content'])) {
+            $assistantMessage['content'] = $message['content'];
+        }
+
+        if (!empty($message['tool_calls'])) {
+            $assistantMessage['tool_calls'] = $message['tool_calls'];
+        }
+
+        return $assistantMessage;
+    }
+}

--- a/Tests/Llm/Client/CortecsClient.php
+++ b/Tests/Llm/Client/CortecsClient.php
@@ -174,6 +174,14 @@ class CortecsClient implements LlmClientInterface
                             'Content-Type' => 'application/json',
                         ],
                         'body' => json_encode($requestBody),
+                        // Without an explicit timeout, RequestFactory falls back
+                        // to TYPO3_CONF_VARS[HTTP][timeout] which defaults to 0
+                        // (no limit), so a stalled endpoint would hang the test
+                        // run forever. A read timeout of 120s is generous enough
+                        // for slow reasoning responses; a timeout is caught as a
+                        // ConnectException below and retried with backoff.
+                        'timeout' => 120,
+                        'connect_timeout' => 10,
                     ]
                 );
 

--- a/Tests/Llm/Client/OpenRouterClient.php
+++ b/Tests/Llm/Client/OpenRouterClient.php
@@ -157,6 +157,12 @@ class OpenRouterClient implements LlmClientInterface
                             'X-Title' => 'TYPO3 MCP Server LLM Tests',
                         ],
                         'body' => json_encode($requestBody),
+                        // Explicit timeout so a stalled endpoint retries with
+                        // backoff instead of hanging the run forever (the
+                        // RequestFactory default is 0 = no limit). 120s read is
+                        // generous for slow reasoning responses.
+                        'timeout' => 120,
+                        'connect_timeout' => 10,
                     ]
                 );
 

--- a/Tests/Llm/LlmTestCase.php
+++ b/Tests/Llm/LlmTestCase.php
@@ -30,18 +30,12 @@ abstract class LlmTestCase extends FunctionalTestCase
      */
     protected const MODELS = [
         'haiku-4.5' => 'anthropic/claude-haiku-4.5',
-        'gpt-5.4-mini' => 'openai/gpt-5.4-mini',
         'gpt-oss-120b' => 'openai/gpt-oss-120b',
         'mistral-large-2512' => 'mistralai/mistral-large-2512',
         'gemini-3-flash' => 'google/gemini-3-flash-preview',
     ];
 
     protected const MODEL_OPTIONS = [
-        // 'medium' instead of 'high': gpt-5.4-mini and haiku-4.5 dominate the
-        // OpenRouter spend (~$5 + ~$4 per full suite run). 'high' was added in
-        // PR #59 for reliability; 'medium' keeps tool-use coherent without the
-        // extra reasoning-token tax. Re-tighten if majority-pass starts failing.
-        'gpt-5.4-mini' => ['reasoning' => ['effort' => 'medium']],
         // Claude Haiku 4.5 extended thinking explicitly enabled. Empirically
         // measured (haiku-only filter, 32 tests): with reasoning OFF we get
         // 3 hard failures retried 3× each (~9 retry rounds), with reasoning ON
@@ -51,17 +45,17 @@ abstract class LlmTestCase extends FunctionalTestCase
     ];
 
     /**
-     * Cortecs (https://cortecs.ai) model IDs, keyed by the same logical labels
-     * as {@see MODELS} so tests are provider-agnostic. Cortecs is an EU-native
-     * gateway with Zero Data Retention; because ZDR excludes Azure (the only
-     * GPT backend) and Cortecs does not resell proprietary OpenAI models at all,
-     * the 'gpt-5.4-mini' key has no Cortecs equivalent and is intentionally
-     * absent — tests requesting it are skipped when running against Cortecs.
+     * Cortecs (https://cortecs.ai) model IDs. Cortecs is an EU-native gateway
+     * with Zero Data Retention; its catalog contains no proprietary OpenAI
+     * models (only the open-weight gpt-oss series), so this set is
+     * deliberately open-source-leaning. The logical keys differ from
+     * {@see MODELS} — {@see modelProvider()} picks the map for the active
+     * provider, so each provider only advertises models it can actually serve.
      */
     protected const CORTECS_MODELS = [
         'haiku-4.5' => 'claude-haiku-4-5',
-        // 'gpt-5.4-mini' — no proprietary OpenAI models on Cortecs (ZDR/Azure).
         'gpt-oss-120b' => 'gpt-oss-120b',
+        'minimax-m3' => 'minimax-m3',
         'mistral-large-2512' => 'mistral-large-2512',
         // Cortecs has no gemini-3-flash; 3.5-flash is the closest current flash tier.
         'gemini-3-flash' => 'gemini-3.5-flash',
@@ -259,9 +253,7 @@ abstract class LlmTestCase extends FunctionalTestCase
      */
     protected function initializeLlmClient(): void
     {
-        // Accept the common misspelling "CORTECTS_API_KEY" as well so a typo in
-        // the environment does not silently fall through to OpenRouter.
-        $cortecsKey = getenv('CORTECS_API_KEY') ?: getenv('CORTECTS_API_KEY');
+        $cortecsKey = getenv('CORTECS_API_KEY');
 
         if (!empty($cortecsKey)) {
             $this->llmClient = new CortecsClient($cortecsKey);
@@ -325,13 +317,19 @@ abstract class LlmTestCase extends FunctionalTestCase
 
     /**
      * Data provider for multi-model tests.
-     * Returns all configured models to test against.
+     *
+     * Runs once per model of the active provider. The provider is chosen the
+     * same way as {@see initializeLlmClient()} — by which API key is set — but
+     * resolved here statically because data providers execute before setUp().
      */
     public static function modelProvider(): array
     {
+        $models = !empty(getenv('CORTECS_API_KEY')) ? static::CORTECS_MODELS : static::MODELS;
+        $keys = array_keys($models);
+
         return array_map(
             fn(string $key) => [$key],
-            array_combine(array_keys(static::MODELS), array_keys(static::MODELS))
+            array_combine($keys, $keys)
         );
     }
 

--- a/Tests/Llm/LlmTestCase.php
+++ b/Tests/Llm/LlmTestCase.php
@@ -6,6 +6,7 @@ namespace Hn\McpServer\Tests\Llm;
 
 use Hn\McpServer\MCP\Tool\ToolInterface;
 use Hn\McpServer\MCP\ToolRegistry;
+use Hn\McpServer\Tests\Llm\Client\CortecsClient;
 use Hn\McpServer\Tests\Llm\Client\LlmClientInterface;
 use Hn\McpServer\Tests\Llm\Client\LlmResponse;
 use Hn\McpServer\Tests\Llm\Client\OpenRouterClient;
@@ -47,6 +48,33 @@ abstract class LlmTestCase extends FunctionalTestCase
         // we get 0 failures, 1 retry, and ~10% lower avg test time. The extra
         // reasoning tokens are cheaper than the avoided retry round-trips.
         'haiku-4.5' => ['reasoning' => ['enabled' => true]],
+    ];
+
+    /**
+     * Cortecs (https://cortecs.ai) model IDs, keyed by the same logical labels
+     * as {@see MODELS} so tests are provider-agnostic. Cortecs is an EU-native
+     * gateway with Zero Data Retention; because ZDR excludes Azure (the only
+     * GPT backend) and Cortecs does not resell proprietary OpenAI models at all,
+     * the 'gpt-5.4-mini' key has no Cortecs equivalent and is intentionally
+     * absent — tests requesting it are skipped when running against Cortecs.
+     */
+    protected const CORTECS_MODELS = [
+        'haiku-4.5' => 'claude-haiku-4-5',
+        // 'gpt-5.4-mini' — no proprietary OpenAI models on Cortecs (ZDR/Azure).
+        'gpt-oss-120b' => 'gpt-oss-120b',
+        'mistral-large-2512' => 'mistral-large-2512',
+        // Cortecs has no gemini-3-flash; 3.5-flash is the closest current flash tier.
+        'gemini-3-flash' => 'gemini-3.5-flash',
+    ];
+
+    /**
+     * Per-model options for Cortecs. The OpenRouter-style `reasoning` object is
+     * NOT accepted by every backend: Claude is served via AWS Bedrock, which
+     * rejects an unknown `reasoning` key with HTTP 400, so haiku gets none here.
+     * The gpt-oss series (served by EU providers) does accept `reasoning.effort`.
+     */
+    protected const CORTECS_MODEL_OPTIONS = [
+        'gpt-oss-120b' => ['reasoning' => ['effort' => 'medium']],
     ];
 
     protected array $coreExtensionsToLoad = [
@@ -197,7 +225,7 @@ abstract class LlmTestCase extends FunctionalTestCase
      */
     private function logAttemptFailure(int $attempt, int $maxRetries, \Throwable $e, bool $retrying): void
     {
-        $modelKey = array_search($this->llmModel, static::MODELS, true);
+        $modelKey = array_search($this->llmModel, $this->activeModels(), true);
         $modelLabel = $modelKey !== false ? (string)$modelKey : $this->llmModel;
         $shortClass = preg_replace('/^.*\\\\/', '', static::class);
         $message = preg_replace('/\s+/', ' ', mb_substr($e->getMessage(), 0, 320));
@@ -224,9 +252,26 @@ abstract class LlmTestCase extends FunctionalTestCase
 
     /**
      * Initialize the LLM client based on available API keys.
+     *
+     * Cortecs is preferred when its key is present (EU-native gateway with Zero
+     * Data Retention); OpenRouter is the fallback. Set CORTECS_API_KEY for
+     * Cortecs or OPENROUTER_API_KEY for OpenRouter.
      */
     protected function initializeLlmClient(): void
     {
+        // Accept the common misspelling "CORTECTS_API_KEY" as well so a typo in
+        // the environment does not silently fall through to OpenRouter.
+        $cortecsKey = getenv('CORTECS_API_KEY') ?: getenv('CORTECTS_API_KEY');
+
+        if (!empty($cortecsKey)) {
+            $this->llmClient = new CortecsClient($cortecsKey);
+            $this->llmProvider = 'cortecs';
+            if (empty($this->llmModel)) {
+                $this->llmModel = self::CORTECS_MODELS['haiku-4.5'];
+            }
+            return;
+        }
+
         $openRouterKey = getenv('OPENROUTER_API_KEY');
 
         if (!empty($openRouterKey)) {
@@ -238,17 +283,44 @@ abstract class LlmTestCase extends FunctionalTestCase
             return;
         }
 
-        $this->markTestSkipped('No LLM API key configured. Set OPENROUTER_API_KEY.');
+        $this->markTestSkipped('No LLM API key configured. Set CORTECS_API_KEY or OPENROUTER_API_KEY.');
+    }
+
+    /**
+     * The model map for the active provider, keyed by logical label.
+     */
+    protected function activeModels(): array
+    {
+        return $this->llmProvider === 'cortecs' ? static::CORTECS_MODELS : static::MODELS;
     }
 
     /**
      * Set the model to use for subsequent LLM calls.
-     * Use model keys from MODELS constant or full model IDs.
+     * Use model keys from the active provider's map or full model IDs.
+     *
+     * When a logical key exists in the canonical MODELS set but has no
+     * equivalent on the active provider (e.g. proprietary GPT on Cortecs),
+     * the test is skipped rather than silently falling back to the raw key.
      */
     protected function setModel(string $model): void
     {
-        // Allow using short keys like 'haiku', 'gpt-5.2', etc.
-        $this->llmModel = self::MODELS[$model] ?? $model;
+        $models = $this->activeModels();
+
+        if (isset($models[$model])) {
+            $this->llmModel = $models[$model];
+            return;
+        }
+
+        if (isset(static::MODELS[$model])) {
+            $this->markTestSkipped(sprintf(
+                'Model "%s" is not available on provider "%s".',
+                $model,
+                $this->llmProvider
+            ));
+        }
+
+        // Not a known logical key — treat as a raw model ID.
+        $this->llmModel = $model;
     }
 
     /**
@@ -338,9 +410,12 @@ abstract class LlmTestCase extends FunctionalTestCase
 
     protected function getModelOptions(): array
     {
-        $modelKey = array_search($this->llmModel, static::MODELS, true);
-        if ($modelKey !== false && isset(static::MODEL_OPTIONS[$modelKey])) {
-            return static::MODEL_OPTIONS[$modelKey];
+        $models = $this->activeModels();
+        $options = $this->llmProvider === 'cortecs' ? static::CORTECS_MODEL_OPTIONS : static::MODEL_OPTIONS;
+
+        $modelKey = array_search($this->llmModel, $models, true);
+        if ($modelKey !== false && isset($options[$modelKey])) {
+            return $options[$modelKey];
         }
         return [];
     }

--- a/Tests/Llm/LlmTestCase.php
+++ b/Tests/Llm/LlmTestCase.php
@@ -31,6 +31,7 @@ abstract class LlmTestCase extends FunctionalTestCase
     protected const MODELS = [
         'haiku-4.5' => 'anthropic/claude-haiku-4.5',
         'gpt-oss-120b' => 'openai/gpt-oss-120b',
+        'minimax-m3' => 'minimax/minimax-m3',
         'mistral-large-2512' => 'mistralai/mistral-large-2512',
         'gemini-3-flash' => 'google/gemini-3-flash-preview',
     ];
@@ -45,12 +46,12 @@ abstract class LlmTestCase extends FunctionalTestCase
     ];
 
     /**
-     * Cortecs (https://cortecs.ai) model IDs. Cortecs is an EU-native gateway
-     * with Zero Data Retention; its catalog contains no proprietary OpenAI
-     * models (only the open-weight gpt-oss series), so this set is
-     * deliberately open-source-leaning. The logical keys differ from
-     * {@see MODELS} — {@see modelProvider()} picks the map for the active
-     * provider, so each provider only advertises models it can actually serve.
+     * Cortecs (https://cortecs.ai) model IDs, keyed by the same logical labels
+     * as {@see MODELS}. Cortecs is an EU-native gateway with Zero Data
+     * Retention; its catalog contains no proprietary OpenAI models (only the
+     * open-weight gpt-oss series). {@see modelProvider()} picks the map for the
+     * active provider, so should the two sets ever diverge each provider only
+     * advertises models it can actually serve.
      */
     protected const CORTECS_MODELS = [
         'haiku-4.5' => 'claude-haiku-4-5',

--- a/Tests/Llm/README.md
+++ b/Tests/Llm/README.md
@@ -52,25 +52,35 @@ These tests help ensure that:
 
 ### Supported Models
 
-Tests using `#[DataProvider('modelProvider')]` run once per logical model key
-automatically. The key maps to a provider-specific model ID:
+Tests using `#[DataProvider('modelProvider')]` run once per model. The set of
+models depends on the active provider — `modelProvider()` advertises only the
+models that provider can actually serve, so the two lists differ:
 
-| Key                  | OpenRouter Model ID              | Cortecs Model ID       |
-|----------------------|----------------------------------|------------------------|
-| `haiku-4.5`          | `anthropic/claude-haiku-4.5`     | `claude-haiku-4-5`     |
-| `gpt-5.4-mini`       | `openai/gpt-5.4-mini`            | — *(not available)*    |
-| `gpt-oss-120b`       | `openai/gpt-oss-120b`            | `gpt-oss-120b`         |
-| `mistral-large-2512` | `mistralai/mistral-large-2512`   | `mistral-large-2512`   |
-| `gemini-3-flash`     | `google/gemini-3-flash-preview`  | `gemini-3.5-flash`     |
+**Cortecs** (open-source-leaning, EU-native):
 
-When running against Cortecs, keys without a Cortecs equivalent are skipped
-automatically (reported as skipped, not failed).
+| Key                  | Cortecs Model ID    |
+|----------------------|---------------------|
+| `haiku-4.5`          | `claude-haiku-4-5`  |
+| `gpt-oss-120b`       | `gpt-oss-120b`      |
+| `minimax-m3`         | `minimax-m3`        |
+| `mistral-large-2512` | `mistral-large-2512`|
+| `gemini-3-flash`     | `gemini-3.5-flash`  |
 
-**Why no proprietary GPT on Cortecs:** Cortecs' catalog does not include
-proprietary OpenAI models (`gpt-4`/`gpt-5`/o-series) — with or without ZDR. The
-only OpenAI models offered are the open-weight `gpt-oss-*` series, served by EU
-providers (Scaleway, Nebius, OVH, IONOS, …), not Azure. Proprietary Anthropic
-(Claude, via AWS Bedrock), Google (Gemini) and Mistral models *are* available.
+**OpenRouter** (fallback):
+
+| Key                  | OpenRouter Model ID             |
+|----------------------|---------------------------------|
+| `haiku-4.5`          | `anthropic/claude-haiku-4.5`    |
+| `gpt-oss-120b`       | `openai/gpt-oss-120b`           |
+| `mistral-large-2512` | `mistralai/mistral-large-2512`  |
+| `gemini-3-flash`     | `google/gemini-3-flash-preview` |
+
+**No proprietary GPT:** Cortecs' catalog contains no proprietary OpenAI models
+(`gpt-4`/`gpt-5`/o-series) — with or without ZDR. The only OpenAI models it
+offers are the open-weight `gpt-oss-*` series, served by EU providers
+(Scaleway, Nebius, OVH, IONOS, …), not Azure. Proprietary GPT is therefore not
+part of the test matrix. Proprietary Anthropic (Claude, via AWS Bedrock),
+Google (Gemini) and Mistral models *are* available.
 
 **Reasoning parameter caveat:** On Cortecs, Claude is served via AWS Bedrock,
 which rejects the OpenRouter-style `reasoning` object (HTTP 400). So the

--- a/Tests/Llm/README.md
+++ b/Tests/Llm/README.md
@@ -52,28 +52,18 @@ These tests help ensure that:
 
 ### Supported Models
 
-Tests using `#[DataProvider('modelProvider')]` run once per model. The set of
-models depends on the active provider — `modelProvider()` advertises only the
-models that provider can actually serve, so the two lists differ:
+Tests using `#[DataProvider('modelProvider')]` run once per model. Both
+providers expose the same logical keys, mapped to provider-specific model IDs.
+`modelProvider()` picks the map for the active provider, so if the sets ever
+diverge each provider only advertises models it can actually serve.
 
-**Cortecs** (open-source-leaning, EU-native):
-
-| Key                  | Cortecs Model ID    |
-|----------------------|---------------------|
-| `haiku-4.5`          | `claude-haiku-4-5`  |
-| `gpt-oss-120b`       | `gpt-oss-120b`      |
-| `minimax-m3`         | `minimax-m3`        |
-| `mistral-large-2512` | `mistral-large-2512`|
-| `gemini-3-flash`     | `gemini-3.5-flash`  |
-
-**OpenRouter** (fallback):
-
-| Key                  | OpenRouter Model ID             |
-|----------------------|---------------------------------|
-| `haiku-4.5`          | `anthropic/claude-haiku-4.5`    |
-| `gpt-oss-120b`       | `openai/gpt-oss-120b`           |
-| `mistral-large-2512` | `mistralai/mistral-large-2512`  |
-| `gemini-3-flash`     | `google/gemini-3-flash-preview` |
+| Key                  | Cortecs Model ID     | OpenRouter Model ID             |
+|----------------------|----------------------|---------------------------------|
+| `haiku-4.5`          | `claude-haiku-4-5`   | `anthropic/claude-haiku-4.5`    |
+| `gpt-oss-120b`       | `gpt-oss-120b`       | `openai/gpt-oss-120b`           |
+| `minimax-m3`         | `minimax-m3`         | `minimax/minimax-m3`            |
+| `mistral-large-2512` | `mistral-large-2512` | `mistralai/mistral-large-2512`  |
+| `gemini-3-flash`     | `gemini-3.5-flash`   | `google/gemini-3-flash-preview` |
 
 **No proprietary GPT:** Cortecs' catalog contains no proprietary OpenAI models
 (`gpt-4`/`gpt-5`/o-series) — with or without ZDR. The only OpenAI models it

--- a/Tests/Llm/README.md
+++ b/Tests/Llm/README.md
@@ -15,8 +15,19 @@ These tests help ensure that:
 
 ### Prerequisites
 
-1. Set the OpenRouter API key, which allows testing with multiple models
-   (Anthropic, OpenAI, Mistral, Moonshot, etc.) through a single key:
+1. Set an API key for one of the supported gateways. Both expose an
+   OpenAI-compatible API and let you reach many models with a single key.
+   When both are set, **Cortecs is preferred**.
+
+   **Cortecs** (https://cortecs.ai) — EU-native gateway with Zero Data
+   Retention. Requests are routed only to ZDR-compliant EU providers.
+
+   ```bash
+   export CORTECS_API_KEY="..."
+   ```
+
+   **OpenRouter** (https://openrouter.ai) — broadest model catalog, incl.
+   proprietary OpenAI GPT models.
 
    ```bash
    export OPENROUTER_API_KEY="sk-or-v1-..."
@@ -24,6 +35,8 @@ These tests help ensure that:
 
    Or create a `.env.local` file:
    ```bash
+   CORTECS_API_KEY="..."
+   # or
    OPENROUTER_API_KEY="sk-or-v1-..."
    ```
 
@@ -39,17 +52,30 @@ These tests help ensure that:
 
 ### Supported Models
 
-When using OpenRouter, the following models are available via `modelProvider()`:
+Tests using `#[DataProvider('modelProvider')]` run once per logical model key
+automatically. The key maps to a provider-specific model ID:
 
-| Key              | OpenRouter Model ID              |
-|------------------|----------------------------------|
-| `haiku`          | `anthropic/claude-3-5-haiku`     |
-| `gpt-5.2`       | `openai/gpt-5.2`                |
-| `gpt-oss`        | `openai/gpt-oss-120b`           |
-| `kimi-k2`        | `moonshotai/kimi-k2`            |
-| `mistral-medium` | `mistralai/mistral-medium-3`     |
+| Key                  | OpenRouter Model ID              | Cortecs Model ID       |
+|----------------------|----------------------------------|------------------------|
+| `haiku-4.5`          | `anthropic/claude-haiku-4.5`     | `claude-haiku-4-5`     |
+| `gpt-5.4-mini`       | `openai/gpt-5.4-mini`            | — *(not available)*    |
+| `gpt-oss-120b`       | `openai/gpt-oss-120b`            | `gpt-oss-120b`         |
+| `mistral-large-2512` | `mistralai/mistral-large-2512`   | `mistral-large-2512`   |
+| `gemini-3-flash`     | `google/gemini-3-flash-preview`  | `gemini-3.5-flash`     |
 
-Tests using `#[DataProvider('modelProvider')]` run once per model automatically.
+When running against Cortecs, keys without a Cortecs equivalent are skipped
+automatically (reported as skipped, not failed).
+
+**Why no proprietary GPT on Cortecs:** Cortecs' catalog does not include
+proprietary OpenAI models (`gpt-4`/`gpt-5`/o-series) — with or without ZDR. The
+only OpenAI models offered are the open-weight `gpt-oss-*` series, served by EU
+providers (Scaleway, Nebius, OVH, IONOS, …), not Azure. Proprietary Anthropic
+(Claude, via AWS Bedrock), Google (Gemini) and Mistral models *are* available.
+
+**Reasoning parameter caveat:** On Cortecs, Claude is served via AWS Bedrock,
+which rejects the OpenRouter-style `reasoning` object (HTTP 400). So the
+extended-thinking boost configured for Haiku on OpenRouter is not applied on
+Cortecs. The `gpt-oss` series does accept `reasoning.effort`.
 
 ### Cost Considerations
 
@@ -65,9 +91,9 @@ These tests make actual API calls and will incur costs:
 
 The tests use:
 - **Temperature**: 0 (for deterministic responses)
-- **Default Model**: `anthropic/claude-3-5-haiku` via OpenRouter
+- **Default Model**: Haiku 4.5 (`claude-haiku-4-5` on Cortecs / `anthropic/claude-haiku-4.5` on OpenRouter)
 - **Max Tokens**: 4000 per call
-- **Provider**: OpenRouter
+- **Provider**: Cortecs (preferred) or OpenRouter, selected by which API key is set
 
 ## Writing New Tests
 
@@ -173,24 +199,25 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[DataProvider('modelProvider')]
 public function testSomethingWithAllModels(string $modelKey): void
 {
+    // setModel() skips the test automatically if the model has no equivalent
+    // on the active provider (e.g. proprietary GPT keys when running on Cortecs).
     $this->setModel($modelKey);
-
-    if ($this->llmProvider !== 'openrouter' && $modelKey !== 'haiku') {
-        $this->markTestSkipped("Model requires OpenRouter");
-    }
 
     // Test logic here...
 }
 ```
 
-The `LlmTestCase` uses `OpenRouterClient` when `OPENROUTER_API_KEY` is set, supporting all models via the OpenAI-compatible API.
+`LlmTestCase` selects the client in `initializeLlmClient()`: `CortecsClient`
+when `CORTECS_API_KEY` is set, otherwise `OpenRouterClient` when
+`OPENROUTER_API_KEY` is set. Both talk the OpenAI-compatible API.
 
 ### Adding New Providers
 
 To add a new provider:
 1. Create a new client implementing `LlmClientInterface`
 2. Add initialization logic in `LlmTestCase::initializeLlmClient()`
-3. Add new model keys to the `MODELS` constant
+3. Add a provider-specific model map (see `MODELS` / `CORTECS_MODELS`) so the
+   shared `modelProvider()` keys resolve to that provider's model IDs
 
 ## Handling Test Failures
 

--- a/Tests/Llm/bootstrap.php
+++ b/Tests/Llm/bootstrap.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/Client/LlmClientInterface.php';
 require_once __DIR__ . '/Client/LlmResponse.php';
 require_once __DIR__ . '/Client/OpenRouterClient.php';
+require_once __DIR__ . '/Client/CortecsClient.php';
 require_once __DIR__ . '/LlmTestCase.php';
 
 // Simple .env.local loader


### PR DESCRIPTION
## Summary

Adds support for **Cortecs** (https://cortecs.ai), an EU-native LLM gateway with Zero Data Retention (ZDR), as a preferred alternative to OpenRouter. When `CORTECS_API_KEY` is set, tests automatically use Cortecs; OpenRouter remains available as a fallback via `OPENROUTER_API_KEY`.

## Key Changes

- **New `CortecsClient`** (`Tests/Llm/Client/CortecsClient.php`): OpenAI-compatible API client with:
  - Automatic retry logic for transient failures (5xx, 429) with exponential backoff
  - Multi-turn conversation history support
  - Zero Data Retention flag (`allow_zero_data_retention`) passed to API
  - Careful handling of `reasoning` parameter (not all backends accept it; Claude via AWS Bedrock rejects it)

- **Provider abstraction in `LlmTestCase`**:
  - New `CORTECS_MODELS` and `CORTECS_MODEL_OPTIONS` constants mapping logical model keys to Cortecs-specific IDs
  - `initializeLlmClient()` now prefers Cortecs when its key is set, falls back to OpenRouter
  - `activeModels()` returns the model map for the active provider
  - `setModel()` now skips tests when a logical key has no equivalent on the active provider (e.g., proprietary GPT on Cortecs)
  - `modelProvider()` dynamically selects the model map based on which API key is configured

- **Model catalog updates**:
  - Removed `gpt-5.4-mini` (proprietary OpenAI, not available on Cortecs)
  - Added `minimax-m3` (available on both providers)
  - Cortecs maps `gemini-3-flash` → `gemini-3.5-flash` (closest available tier)
  - Cortecs does not support extended thinking for Claude (AWS Bedrock limitation), so `haiku-4.5` has no `reasoning` config on Cortecs

- **Documentation updates** (`Tests/Llm/README.md`):
  - Clarified provider selection logic and cost considerations
  - Added Cortecs setup instructions and model availability table
  - Documented reasoning parameter caveat for Claude on Cortecs

- **Bug fix in `TableAccessService.validateFieldValue()`**:
  - Empty select values (`''` or `null`) now correctly bypass enum validation, as they mean "use field default" (e.g., inherited `backend_layout`)
  - Non-empty invalid values are still rejected
  - Added regression tests in `ValidationRefactoringTest`

## Implementation Details

- **Reasoning parameter handling**: Unlike OpenRouter, Cortecs' Claude backend (AWS Bedrock) rejects unknown keys. The client does not inject `reasoning` automatically; callers must only pass it to models that support it (e.g., `gpt-oss-*`).
- **Model availability**: Cortecs' catalog contains no proprietary OpenAI models (`gpt-4`/`gpt-5`/o-series), only open-weight `gpt-oss-*` served by EU providers. Proprietary Anthropic, Google, and Mistral models are available.
- **Backward compatibility**: Existing OpenRouter-based tests continue to work unchanged; Cortecs is opt-in via environment variable.

https://claude.ai/code/session_01Qcoo8UJcqmsdeYeBrjL1KS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Cortecs test LLM client with provider-aware model selection and retry-friendly behavior.
  * Improved MCP tool payload handling for inline/file `assets` relations to accept multiple “near-miss” shapes.

* **Bug Fixes**
  * Empty select-field inputs (`null`/empty) are now accepted as “use default/inherited,” while invalid non-empty values are still rejected.
  * Improved OpenRouter request behavior by adding explicit request and connection timeouts.

* **Documentation**
  * Updated LLM test setup, supported model mappings, and badges to include MiniMax/Cortecs guidance.

* **Tests**
  * Added regression coverage for empty backend layout, validation, and file reference normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->