### PR TITLE
fix: add CORS headers to /mcp success and error responses (#105)

### DIFF
--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -143,11 +143,13 @@ class McpEndpoint
             $stream->write($output);
             $stream->rewind();
 
-            return new Response(
+            $response = new Response(
                 $stream,
                 $statusCode,
                 ['Content-Type' => $contentType]
             );
+
+            return $this->addCorsHeaders($response, $request);
 
         } catch (\Throwable $e) {
             $stream = new Stream('php://temp', 'rw');
@@ -157,11 +159,13 @@ class McpEndpoint
             ]));
             $stream->rewind();
 
-            return new Response(
+            $response = new Response(
                 $stream,
                 500,
                 ['Content-Type' => 'application/json']
             );
+
+            return $this->addCorsHeaders($response, $request);
         }
     }
 

--- a/Tests/Functional/Http/CorsHeadersTest.php
+++ b/Tests/Functional/Http/CorsHeadersTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Hn\McpServer\Tests\Functional\Http;
 
+use Hn\McpServer\Http\McpEndpoint;
 use Hn\McpServer\Http\OAuthTokenEndpoint;
+use Hn\McpServer\Service\OAuthService;
 use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Tests for CORS header security
@@ -62,6 +65,46 @@ class CorsHeadersTest extends AbstractFunctionalTest
         $this->assertFalse(
             $response->hasHeader('Access-Control-Allow-Origin'),
             'No CORS headers should be set for non-CORS requests'
+        );
+    }
+
+    /**
+     * The authenticated /mcp data response must carry CORS headers, just like
+     * the error responses in the same class already do. Without this, browser-
+     * and Electron-based MCP clients have the successful response blocked by
+     * the browser before the application ever sees it. See issue #105.
+     */
+    public function testMcpSuccessResponseIncludesCorsHeaders(): void
+    {
+        $oauthService = GeneralUtility::makeInstance(OAuthService::class);
+        $tokenData = $oauthService->createToken(1, 'cors-test-client');
+
+        $endpoint = new McpEndpoint();
+
+        $request = new ServerRequest(
+            new Uri('https://example.com/mcp'),
+            'POST',
+            'php://input',
+            [
+                'Origin' => 'https://claude.ai',
+                'Authorization' => 'Bearer ' . $tokenData['access_token'],
+                'Content-Type' => 'application/json',
+            ]
+        );
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        $response = $endpoint($request);
+
+        // Regardless of the JSON-RPC payload the MCP runner produces, the HTTP
+        // response for an authenticated, CORS request must reflect the Origin.
+        $this->assertTrue(
+            $response->hasHeader('Access-Control-Allow-Origin'),
+            'Authenticated /mcp response must include CORS headers'
+        );
+        $this->assertEquals(
+            'https://claude.ai',
+            $response->getHeaderLine('Access-Control-Allow-Origin'),
+            'CORS origin must reflect the request Origin, not a wildcard'
         );
     }
 }


### PR DESCRIPTION
McpEndpoint::__invoke() returned its successful JSON-RPC response (and the internal-error catch-block response) as a plain Response without CORS headers, unlike createUnauthorizedResponse() and handleAuthHeaderTest() in the same class. Browser- and Electron-based MCP clients (e.g. Claude Desktop) had the successful response blocked by the browser before the application saw it, surfacing only a generic connection failure.

Route both the success-path and the catch-block responses through the existing addCorsHeaders() helper so the Origin is reflected consistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CORS headers are now consistently included in successful and error responses from the MCP endpoint.
  * Allowed origins are correctly reflected in successful cross-origin requests instead of using a wildcard.

* **Tests**
  * Added coverage to verify CORS headers on successful MCP requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->