### PR TITLE
fix: preserve backend user settings (uc) when impersonating users

### DIFF
--- a/Classes/Command/McpServerCommand.php
+++ b/Classes/Command/McpServerCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Configuration\Tca\TcaFactory;
 use Hn\McpServer\MCP\McpServerFactory;
@@ -80,6 +81,7 @@ class McpServerCommand extends Command
             $beUser->user['uid'] = 1; // Add a UID for the fake user to prevent DataHandler errors
             $beUser->user['workspace_id'] = 0; // Set workspace ID to live workspace
             $beUser->workspace = 0; // Set workspace to live workspace
+            $this->restoreStoredUserConfiguration($beUser);
             $GLOBALS['BE_USER'] = $beUser;
         } elseif (!$beUser->isAdmin()) {
             // If user exists but is not admin, set admin flag directly
@@ -89,6 +91,26 @@ class McpServerCommand extends Command
             }
             $beUser->user['workspace_id'] = 0; // Set workspace ID to live workspace
             $beUser->workspace = 0; // Set workspace to live workspace
+        }
+    }
+
+    /**
+     * Load the stored user configuration (uc) of the impersonated backend user.
+     * If $beUser->uc stayed empty, a writeUC() triggered during tool execution
+     * (e.g. by the update signals fired on workspace creation) would overwrite
+     * the real user's backend preferences in the be_users record.
+     */
+    protected function restoreStoredUserConfiguration(BackendUserAuthentication $beUser): void
+    {
+        $storedUc = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('be_users')
+            ->select(['uc'], 'be_users', ['uid' => (int)$beUser->user['uid']])
+            ->fetchOne();
+        if (is_string($storedUc)) {
+            $uc = unserialize($storedUc, ['allowed_classes' => false]);
+            if (is_array($uc)) {
+                $beUser->uc = $uc;
+            }
         }
     }
 }

--- a/Classes/Command/McpTestCommand.php
+++ b/Classes/Command/McpTestCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Hn\McpServer\MCP\ToolRegistry;
 use Hn\McpServer\Service\WorkspaceContextService;
@@ -159,6 +160,7 @@ class McpTestCommand extends Command
             // Set admin flag directly since setTemporaryAdminFlag doesn't exist in TYPO3 v12
             $beUser->user['admin'] = 1;
             $beUser->user['uid'] = 1; // Add a UID for the fake user to prevent DataHandler errors
+            $this->restoreStoredUserConfiguration($beUser);
             $GLOBALS['BE_USER'] = $beUser;
             
             // Set up workspace context
@@ -180,7 +182,27 @@ class McpTestCommand extends Command
             $workspaceId = $workspaceService->switchToOptimalWorkspace($beUser);
         }
     }
-    
+
+    /**
+     * Load the stored user configuration (uc) of the impersonated backend user.
+     * If $beUser->uc stayed empty, a writeUC() triggered during tool execution
+     * (e.g. by the update signals fired on workspace creation) would overwrite
+     * the real user's backend preferences in the be_users record.
+     */
+    protected function restoreStoredUserConfiguration(BackendUserAuthentication $beUser): void
+    {
+        $storedUc = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('be_users')
+            ->select(['uc'], 'be_users', ['uid' => (int)$beUser->user['uid']])
+            ->fetchOne();
+        if (is_string($storedUc)) {
+            $uc = unserialize($storedUc, ['allowed_classes' => false]);
+            if (is_array($uc)) {
+                $beUser->uc = $uc;
+            }
+        }
+    }
+
     /**
      * Ensure TCA is loaded
      */

--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -279,6 +279,15 @@ class McpEndpoint
             // Without this, non-admin users have no permissions computed from their groups
             $beUser->fetchGroupData();
 
+            // Apply the uc defaults and TSconfig overrides, exactly like
+            // initializeBackendLogin() does after fetchGroupData() on a regular
+            // login. This covers users who never logged into the backend: their
+            // stored uc is empty, and without the defaults the first writeUC()
+            // would persist a nearly empty uc - which core never repairs, since
+            // backendSetUC() only fills in the defaults while uc is completely
+            // empty.
+            $beUser->backendSetUC();
+
             // Initialize language service (required for DataHandler and other core components)
             $this->initializeLanguageService($beUser);
 

--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -250,6 +250,20 @@ class McpEndpoint
 
         if ($userData) {
             $beUser->user = $userData;
+
+            // CRITICAL: Restore the user's stored configuration (uc). The regular
+            // authentication flow unserializes it via unpack_uc(), which token auth
+            // bypasses. Without this, $beUser->uc stays empty and any writeUC()
+            // triggered during request processing (e.g. the update signals fired
+            // when the MCP workspace is created below) overwrites the user's
+            // stored backend preferences with a nearly empty array. That in turn
+            // breaks the backend Setup module, which expects keys like 'titleLen'
+            // to exist ("Undefined array key" warning in SetupModuleController).
+            $storedUc = unserialize((string)($userData['uc'] ?? ''), ['allowed_classes' => false]);
+            if (is_array($storedUc)) {
+                $beUser->uc = $storedUc;
+            }
+
             $GLOBALS['BE_USER'] = $beUser;
 
             // CRITICAL: Initialize an (anonymous) user session.

--- a/Tests/Functional/Http/McpEndpointUcPreservationTest.php
+++ b/Tests/Functional/Http/McpEndpointUcPreservationTest.php
@@ -77,7 +77,15 @@ class McpEndpointUcPreservationTest extends AbstractFunctionalTest
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         $endpoint = new McpEndpoint();
-        $endpoint($request);
+        $response = $endpoint($request);
+
+        // The JSON-RPC processing itself cannot succeed in this environment:
+        // the SDK's StandardPhpAdapter builds its request via
+        // HttpMessage::fromGlobals(), and PHPUnit's CLI process provides
+        // neither REQUEST_METHOD nor a fillable php://input. A 401 however
+        // would mean the token authentication - and with it the impersonation
+        // path under test - never ran.
+        $this->assertNotSame(401, $response->getStatusCode());
 
         // The impersonated backend user must carry the stored configuration
         // in memory, exactly like a regularly authenticated user would.
@@ -105,5 +113,57 @@ class McpEndpointUcPreservationTest extends AbstractFunctionalTest
             'Persisting the uc during an MCP request must not wipe the stored backend preferences'
         );
         $this->assertSame('de', $persistedUc['lang'] ?? null);
+    }
+
+    public function testDefaultsAreAppliedForUserWithoutStoredConfiguration(): void
+    {
+        // Simulate a user who never logged into the backend: no stored uc yet.
+        // Such a user must get the uc defaults applied during impersonation,
+        // exactly like initializeBackendLogin() does on a first regular login.
+        // Otherwise the first writeUC() persists a nearly empty uc, and core
+        // never re-applies the defaults afterwards (backendSetUC() only fills
+        // them in while uc is completely empty).
+        $this->getConnectionForTable('be_users')->update(
+            'be_users',
+            ['uc' => ''],
+            ['uid' => 1]
+        );
+
+        $oauthService = GeneralUtility::makeInstance(OAuthService::class);
+        $tokenData = $oauthService->createToken(1, 'uc-defaults-test-client');
+
+        $request = new ServerRequest(
+            new Uri('https://example.com/mcp'),
+            'POST',
+            'php://input',
+            [
+                'Authorization' => 'Bearer ' . $tokenData['access_token'],
+                'Content-Type' => 'application/json',
+            ]
+        );
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        $endpoint = new McpEndpoint();
+        $response = $endpoint($request);
+        $this->assertNotSame(401, $response->getStatusCode());
+
+        $this->assertArrayHasKey(
+            'titleLen',
+            $GLOBALS['BE_USER']->uc,
+            'A user without stored settings must get the uc defaults applied'
+        );
+
+        $persistedUc = unserialize(
+            (string)$this->getConnectionForTable('be_users')
+                ->select(['uc'], 'be_users', ['uid' => 1])
+                ->fetchOne(),
+            ['allowed_classes' => false]
+        );
+        $this->assertIsArray($persistedUc);
+        $this->assertArrayHasKey(
+            'titleLen',
+            $persistedUc,
+            'The persisted uc of a first-time user must contain the defaults, not a nearly empty array'
+        );
     }
 }

--- a/Tests/Functional/Http/McpEndpointUcPreservationTest.php
+++ b/Tests/Functional/Http/McpEndpointUcPreservationTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\Http;
+
+use Hn\McpServer\Http\McpEndpoint;
+use Hn\McpServer\Service\OAuthService;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The token-authenticated /mcp endpoint impersonates a backend user without
+ * going through the regular authentication flow. That flow normally restores
+ * the user's stored configuration (uc) via unpack_uc(). If the endpoint skips
+ * this, $beUser->uc starts out empty and any writeUC() triggered during
+ * request processing (e.g. the update signals fired when the MCP workspace is
+ * created) overwrites the user's stored backend preferences with a nearly
+ * empty array. Afterwards the backend Setup module crashes with
+ * 'Undefined array key "titleLen"' because the defaults are only re-applied
+ * when uc is completely empty.
+ */
+class McpEndpointUcPreservationTest extends AbstractFunctionalTest
+{
+    private mixed $previousRequest;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousRequest = $GLOBALS['TYPO3_REQUEST'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = $this->previousRequest;
+        parent::tearDown();
+    }
+
+    public function testStoredUserConfigurationSurvivesMcpRequest(): void
+    {
+        // Simulate a user who has personal backend settings stored in be_users.uc
+        $storedUc = [
+            'titleLen' => 77,
+            'lang' => 'de',
+            'emailMeAtLogin' => 1,
+        ];
+        $this->getConnectionForTable('be_users')->update(
+            'be_users',
+            ['uc' => serialize($storedUc)],
+            ['uid' => 1]
+        );
+
+        $oauthService = GeneralUtility::makeInstance(OAuthService::class);
+        $tokenData = $oauthService->createToken(1, 'uc-preservation-test-client');
+
+        $body = new Stream('php://temp', 'rw');
+        $body->write(json_encode([
+            'jsonrpc' => '2.0',
+            'method' => 'tools/list',
+            'id' => 1,
+        ]));
+        $body->rewind();
+
+        $request = new ServerRequest(
+            new Uri('https://example.com/mcp'),
+            'POST',
+            $body,
+            [
+                'Authorization' => 'Bearer ' . $tokenData['access_token'],
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+            ]
+        );
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        $endpoint = new McpEndpoint();
+        $endpoint($request);
+
+        // The impersonated backend user must carry the stored configuration
+        // in memory, exactly like a regularly authenticated user would.
+        $this->assertSame(
+            77,
+            $GLOBALS['BE_USER']->uc['titleLen'] ?? null,
+            'The stored uc must be loaded into the impersonated backend user'
+        );
+
+        // Simulate any code path that persists the uc during request
+        // processing (workspace creation signals, pushModuleData, ...).
+        $GLOBALS['BE_USER']->writeUC();
+
+        $persistedUc = unserialize(
+            (string)$this->getConnectionForTable('be_users')
+                ->select(['uc'], 'be_users', ['uid' => 1])
+                ->fetchOne(),
+            ['allowed_classes' => false]
+        );
+
+        $this->assertIsArray($persistedUc);
+        $this->assertSame(
+            77,
+            $persistedUc['titleLen'] ?? null,
+            'Persisting the uc during an MCP request must not wipe the stored backend preferences'
+        );
+        $this->assertSame('de', $persistedUc['lang'] ?? null);
+    }
+}


### PR DESCRIPTION
## Problem

Connecting an MCP client to the `/mcp` endpoint **destroys the backend user's stored preferences** (`be_users.uc`). Afterwards, saving the User Settings module crashes with:

```
(1/1) #1476107295 TYPO3\CMS\Core\Error\Exception
PHP Warning: Undefined array key "titleLen" in .../cms-backend/Classes/Controller/SetupModuleController.php line 300
```

This happened on a real TYPO3 13.4/14.3 installation right after installing the extension and connecting Claude: the admin's `uc` was reduced to just `moduleData` + `moduleSessionID` — all defaults (`titleLen`, `lang`, `colorScheme`, …) gone.

## Root cause

`McpEndpoint::setupBackendUserContext()` impersonates the token's backend user via `$beUser->user = $userData` but bypasses the regular authentication flow, which restores the stored user configuration via `unpack_uc()`. So `$beUser->uc` starts out **empty**.

During request processing, the update signals fired when the MCP workspace is created (`BackendUtility::setUpdateSignal()` → `pushModuleData()` → `writeUC()`) persist that nearly empty array to `be_users.uc`, overwriting the user's stored preferences.

The damage is permanent: core's `backendSetUC()` only re-applies the defaults when `uc` is *completely* empty — and after the wipe it still contains `moduleData`, so keys like `titleLen` never come back. `SetupModuleController` accesses `$backendUser->uc['titleLen']` without null coalescing → the exception above.

The CLI commands (`McpServerCommand`, `McpTestCommand`) have the same hazard: their fallback path fakes a backend user with `uid = 1` and an empty `uc`, so any `writeUC()` during tool execution would wipe the real uid-1 user's preferences.

## Fix

* `McpEndpoint::setupBackendUserContext()`: unserialize `$userData['uc']` into `$beUser->uc` right after loading the user record (mirroring core's `unpack_uc()` semantics, `['allowed_classes' => false]`).
* `McpServerCommand` / `McpTestCommand`: load the stored `uc` of the impersonated user from the database before the user context is used.

## Test

New functional test `Tests/Functional/Http/McpEndpointUcPreservationTest.php`:

1. stores a known `uc` (with `titleLen`) for be_user 1,
2. performs a token-authenticated `/mcp` request (which also exercises the natural wipe path — workspace creation fires the update signals),
3. asserts the impersonated user carries the stored settings in memory, and
4. asserts an explicit `writeUC()` does not destroy the persisted settings.

* Without the fix the test fails, with the fix it passes.
* Full suite: `composer test` → 614 tests, 3294 assertions, 0 failures (remaining warnings/deprecations are pre-existing core deprecations, unrelated to this change).

---

**Update (b442672):** `setupBackendUserContext()` now also calls `backendSetUC()` after `fetchGroupData()`, mirroring `initializeBackendLogin()` completely. This covers users who never logged into the backend (empty stored `uc`): without it, their first `writeUC()` would persist a nearly empty `uc`, which core never repairs. Covered by a second functional test; the tests now also assert the response is not a 401. Full suite: 615 tests, 3299 assertions, 0 failures.
