### PR TITLE
Make the MCP session timeout configurable

### DIFF
--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -14,6 +14,7 @@ use Mcp\Server\Transport\Http\FileSessionStore;
 use Mcp\Server\Transport\Http\HttpMessage;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Context\WorkspaceAspect;
@@ -29,6 +30,11 @@ class McpEndpoint
 {
     use CorsHeadersTrait;
     use RequestUrlTrait;
+
+    /**
+     * Fallback for the sessionTimeout extension setting, in seconds.
+     */
+    private const DEFAULT_SESSION_TIMEOUT = 14400;
 
     /**
      * Header and query parameter names whose values must never reach a log file.
@@ -155,7 +161,7 @@ class McpEndpoint
 
             // Configure HTTP options
             $httpOptions = [
-                'session_timeout' => 1800, // 30 minutes
+                'session_timeout' => $this->getSessionTimeout(),
                 'max_queue_size' => 500,
                 'enable_sse' => false,
                 'shared_hosting' => false,
@@ -239,6 +245,29 @@ class McpEndpoint
 
             return $this->addCorsHeaders($response, $request);
         }
+    }
+
+    /**
+     * How long an idle MCP session is kept alive on the server, in seconds.
+     *
+     * Only clients using the session-based lifecycle (protocol revisions
+     * before 2026-07-28) are affected: once their session expired, the next
+     * request is answered with 404 and they have to start over. How well a
+     * client recovers from that varies - mcp-remote, for example, does not
+     * re-initialize, so the tool call appears to hang. Session files are
+     * tiny, so keeping them around longer costs next to nothing.
+     */
+    private function getSessionTimeout(): int
+    {
+        try {
+            $timeout = (int)GeneralUtility::makeInstance(ExtensionConfiguration::class)
+                ->get('mcp_server', 'sessionTimeout');
+        } catch (\Exception) {
+            // Extension configuration not synchronized yet
+            $timeout = 0;
+        }
+
+        return $timeout > 0 ? $timeout : self::DEFAULT_SESSION_TIMEOUT;
     }
 
     /**

--- a/Tests/Functional/Http/McpEndpointSessionTimeoutTest.php
+++ b/Tests/Functional/Http/McpEndpointSessionTimeoutTest.php
@@ -64,7 +64,7 @@ class McpEndpointSessionTimeoutTest extends AbstractFunctionalTest
             ['Mcp-Session-Id' => $sessionId]
         );
 
-        $this->assertSame(200, $response->getStatusCode(), (string)$response->getBody());
+        $this->assertToolsListSucceeded($response);
     }
 
     public function testSessionExpiresAfterTheConfiguredTimeout(): void
@@ -100,7 +100,22 @@ class McpEndpointSessionTimeoutTest extends AbstractFunctionalTest
             ['Mcp-Session-Id' => $sessionId]
         );
 
-        $this->assertSame(200, $response->getStatusCode(), (string)$response->getBody());
+        $this->assertToolsListSucceeded($response);
+    }
+
+    /**
+     * A session that is still alive answers the call - and answers it
+     * properly: a JSON-RPC error would come back as 200 as well.
+     */
+    private function assertToolsListSucceeded(ResponseInterface $response): void
+    {
+        $raw = (string)$response->getBody();
+        $this->assertSame(200, $response->getStatusCode(), $raw);
+
+        $body = json_decode($raw, true);
+        $this->assertIsArray($body, $raw);
+        $this->assertArrayNotHasKey('error', $body, $raw);
+        $this->assertNotEmpty($body['result']['tools'] ?? [], $raw);
     }
 
     /**

--- a/Tests/Functional/Http/McpEndpointSessionTimeoutTest.php
+++ b/Tests/Functional/Http/McpEndpointSessionTimeoutTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\Http;
+
+use Hn\McpServer\Http\McpEndpoint;
+use Hn\McpServer\Service\OAuthService;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Covers the sessionTimeout extension setting.
+ *
+ * Sessions only exist for clients on the pre-2026-07-28 lifecycle. For those
+ * the timeout decides when a connection that is still in use dies: the server
+ * answers the next request with 404 (spec 5.8.4) and the client has to run a
+ * fresh initialize - if it handles that at all. The tests age the stored
+ * session instead of waiting, which is what an editor pausing their work
+ * does to it.
+ */
+class McpEndpointSessionTimeoutTest extends AbstractFunctionalTest
+{
+    private mixed $previousRequest;
+    private mixed $previousExtensionConfiguration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousRequest = $GLOBALS['TYPO3_REQUEST'] ?? null;
+        $this->previousExtensionConfiguration = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['mcp_server'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = $this->previousRequest;
+        if ($this->previousExtensionConfiguration === null) {
+            unset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['mcp_server']);
+        } else {
+            $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['mcp_server'] = $this->previousExtensionConfiguration;
+        }
+        parent::tearDown();
+    }
+
+    public function testSessionOutlivesAnIdleHourWithTheDefaultTimeout(): void
+    {
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['mcp_server']['sessionTimeout']);
+
+        $token = $this->createAccessToken();
+        $sessionId = $this->initializeSession($token);
+
+        // An hour of thinking, reading or meetings: expired under the former
+        // hard-coded 1800 seconds, still well inside the 14400 second default.
+        $this->ageSession($sessionId, 3600);
+
+        $response = $this->dispatch(
+            ['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list'],
+            $token,
+            ['Mcp-Session-Id' => $sessionId]
+        );
+
+        $this->assertSame(200, $response->getStatusCode(), (string)$response->getBody());
+    }
+
+    public function testSessionExpiresAfterTheConfiguredTimeout(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['mcp_server']['sessionTimeout'] = '60';
+
+        $token = $this->createAccessToken();
+        $sessionId = $this->initializeSession($token);
+
+        $this->ageSession($sessionId, 120);
+
+        $response = $this->dispatch(
+            ['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list'],
+            $token,
+            ['Mcp-Session-Id' => $sessionId]
+        );
+
+        $this->assertSame(404, $response->getStatusCode(), (string)$response->getBody());
+    }
+
+    public function testNonPositiveTimeoutFallsBackToTheDefault(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['mcp_server']['sessionTimeout'] = '0';
+
+        $token = $this->createAccessToken();
+        $sessionId = $this->initializeSession($token);
+
+        $this->ageSession($sessionId, 3600);
+
+        $response = $this->dispatch(
+            ['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list'],
+            $token,
+            ['Mcp-Session-Id' => $sessionId]
+        );
+
+        $this->assertSame(200, $response->getStatusCode(), (string)$response->getBody());
+    }
+
+    /**
+     * Run the classic handshake of a session-based client and return the
+     * session id the server handed out.
+     */
+    private function initializeSession(string $token): string
+    {
+        $response = $this->dispatch([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'initialize',
+            'params' => [
+                'protocolVersion' => '2025-06-18',
+                'capabilities' => new \stdClass(),
+                'clientInfo' => ['name' => 'session-timeout-test', 'version' => '1.0'],
+            ],
+        ], $token);
+
+        $this->assertSame(200, $response->getStatusCode(), (string)$response->getBody());
+        $sessionId = $response->getHeaderLine('mcp-session-id');
+        $this->assertNotSame('', $sessionId, 'initialize must hand out a session id');
+
+        $this->dispatch(
+            ['jsonrpc' => '2.0', 'method' => 'notifications/initialized'],
+            $token,
+            ['Mcp-Session-Id' => $sessionId]
+        );
+
+        return $sessionId;
+    }
+
+    /**
+     * Backdate the stored session so it looks idle for the given time.
+     */
+    private function ageSession(string $sessionId, int $seconds): void
+    {
+        $path = Environment::getVarPath() . '/mcp_sessions/session-' . $sessionId . '.json';
+        $this->assertFileExists($path);
+
+        $data = json_decode((string)file_get_contents($path), true);
+        $this->assertIsArray($data, 'Session file must contain a JSON object');
+        $data['last_activity'] -= $seconds;
+        file_put_contents($path, json_encode($data));
+    }
+
+    private function createAccessToken(): string
+    {
+        $oauthService = GeneralUtility::makeInstance(OAuthService::class);
+        return $oauthService->createToken(1, 'session-timeout-test')['access_token'];
+    }
+
+    /**
+     * Dispatch a JSON-RPC message to the endpoint the way the middleware
+     * would: as a PSR-7 request.
+     */
+    private function dispatch(array $jsonRpc, string $token, array $extraHeaders = []): ResponseInterface
+    {
+        $body = new Stream('php://temp', 'rw');
+        $body->write(json_encode($jsonRpc));
+        $body->rewind();
+
+        $request = new ServerRequest(
+            new Uri('https://example.com/mcp'),
+            'POST',
+            $body,
+            array_merge([
+                'Authorization' => 'Bearer ' . $token,
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+            ], $extraHeaders)
+        );
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        return (new McpEndpoint())($request);
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -6,3 +6,6 @@ additionalStandaloneTables = sys_file_metadata
 
 # cat=mcp/files; type=int+; label=Maximum file size (MiB): Upper limit for files fetched from URLs or received through pre-signed uploads via the UploadFile tool. Default: 500
 maxFileSizeMb = 500
+
+# cat=mcp/http; type=int+; label=Session timeout (seconds): How long an idle MCP session is kept alive. Only affects clients using the session-based lifecycle (protocol revisions before 2026-07-28); after the timeout their next request is answered with HTTP 404 and they have to start a new session. Default: 14400 (4 hours)
+sessionTimeout = 14400


### PR DESCRIPTION
## What changed since this PR was opened

The atomic session store is gone from this branch. With `logiscape/mcp-sdk-php` ^2.0 on `main`, the SDK's own `FileSessionStore` guards its writes, so the corruption half of the original problem is covered upstream. What remains is the second half: the idle session timeout, still hard-coded to 1800 seconds in `McpEndpoint`.

The branch is rebased onto current `main` and now carries a single commit.

## Problem

Sessions still exist for every client on the pre-2026-07-28 lifecycle. For those, half an hour of idling is enough to lose the session: the next request is answered with 404 ("session not found"), and per spec the client has to run a fresh `initialize`. Not every client does — mcp-remote, for one, neither re-initializes nor propagates the error, so the bridged tool call simply waits. What the editor sees is an ordinary break turning into a tool call that hangs.

## Change

* New `sessionTimeout` extension setting, default 14400 seconds (4 hours), read through `ExtensionConfiguration`. Setting it to 1800 restores the previous behaviour; a non-positive or not-yet-synchronized value falls back to the default.
* Session files are a few hundred bytes, so keeping them around longer costs nothing worth measuring.

## Tests

`Tests/Functional/Http/McpEndpointSessionTimeoutTest.php` drives the endpoint over PSR-7 the way `McpEndpointAuthTest` does, and ages the stored session instead of waiting:

* an idle hour survives with the default — it would not have under the hard-coded 1800s,
* a configured 60s timeout expires and the endpoint answers 404,
* a non-positive value falls back to the default.

All three fail when `session_timeout` is put back to a constant. Full functional suite green locally (695 tests, TYPO3 14.3 / PHP 8.3).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable MCP session timeouts through the extension settings.
  * Set the default session timeout to four hours.
  * Added a configurable maximum MCP file size of 500 MiB.
  * Sessions exceeding the configured timeout now return HTTP 404.

* **Bug Fixes**
  * Invalid, missing, or non-positive timeout values now safely use the default session timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->