### PR TITLE
fix: set foreign_table_field on embedded inline children

### DIFF
--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -1248,7 +1248,7 @@ class WriteTableTool extends AbstractRecordTool
 
             if ($isHiddenTable) {
                 // Process embedded inline relations (e.g., tx_news_domain_model_link)
-                $this->processEmbeddedInlineRelations($dataMap, $foreignTable, $foreignField, $parentUid, $pid, $value, $config, $liveUid);
+                $this->processEmbeddedInlineRelations($dataMap, $foreignTable, $foreignField, $parentUid, $pid, $value, $config, $liveUid, $parentTable);
             } else {
                 // Process independent inline relations (e.g., tt_content)
                 $this->processIndependentInlineRelations($foreignTable, $foreignField, $parentUid, $value, $liveUid);
@@ -1267,13 +1267,19 @@ class WriteTableTool extends AbstractRecordTool
         int $pid,
         array $records,
         array $config,
-        ?int $liveUid = null
+        ?int $liveUid = null,
+        string $parentTable = ''
     ): void {
         $foreignMatchFields = $config['foreign_match_fields'] ?? [];
+        // Content Blocks "Collection" fields with shareAcrossTables use this TCA key
+        // (not foreign_match_fields) to record which table a shared child table
+        // row belongs to — e.g. sys_file_reference uses foreign_match_fields for
+        // its tablenames column, this uses a dedicated key instead.
+        $foreignTableField = $config['foreign_table_field'] ?? null;
 
         // Existing children of this parent (live uids). Empty for the create path.
         $existingChildUids = $liveUid !== null
-            ? $this->fetchEmbeddedRelationChildUids($foreignTable, $foreignField, $liveUid, $foreignMatchFields)
+            ? $this->fetchEmbeddedRelationChildUids($foreignTable, $foreignField, $liveUid, $foreignMatchFields, $foreignTableField, $parentTable)
             : [];
 
         // Reject any uid that does not currently belong to this parent. Otherwise a caller
@@ -1336,6 +1342,14 @@ class WriteTableTool extends AbstractRecordTool
                     foreach ($config['foreign_match_fields'] as $matchField => $matchValue) {
                         $recordData[$matchField] = $matchValue;
                     }
+                }
+
+                // Set foreign_table_field (e.g., "tablenames" for a Content Blocks
+                // Collection with shareAcrossTables) to the parent's own table name.
+                // Without this the row is written but TYPO3 can never find it again —
+                // it renders as an empty relation in both the backend and frontend.
+                if (!empty($foreignTableField) && $parentTable !== '') {
+                    $recordData[$foreignTableField] = $parentTable;
                 }
 
                 $key = 'NEW' . uniqid() . '_' . $index;
@@ -1457,7 +1471,9 @@ class WriteTableTool extends AbstractRecordTool
         string $foreignTable,
         string $foreignField,
         int $parentUid,
-        array $foreignMatchFields = []
+        array $foreignMatchFields = [],
+        ?string $foreignTableField = null,
+        string $parentTable = ''
     ): array {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable($foreignTable);
@@ -1478,6 +1494,16 @@ class WriteTableTool extends AbstractRecordTool
         foreach ($foreignMatchFields as $matchField => $matchValue) {
             $queryBuilder->andWhere(
                 $queryBuilder->expr()->eq($matchField, $queryBuilder->createNamedParameter($matchValue))
+            );
+        }
+
+        // Scope to the owning parent table when the child table is shared across
+        // multiple parent tables (foreign_table_field, e.g. Content Blocks
+        // shareAcrossTables). Without this, two unrelated parents on different
+        // tables that happen to reuse the same uid could see each other's children.
+        if (!empty($foreignTableField) && $parentTable !== '') {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->eq($foreignTableField, $queryBuilder->createNamedParameter($parentTable))
             );
         }
 

--- a/Tests/Functional/Fixtures/Extensions/test_share_across_tables/Configuration/TCA/Overrides/tt_content.php
+++ b/Tests/Functional/Fixtures/Extensions/test_share_across_tables/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die;
+
+/*
+ * Same shape friendsoftypo3/content-blocks generates for a "Collection" field with
+ * shareAcrossTables (foreign_table_field) + shareAcrossFields (foreign_match_fields).
+ */
+$GLOBALS['TCA']['tt_content']['columns']['tx_testsat_items'] = [
+    'label' => 'Test shareAcrossTables items',
+    'config' => [
+        'type' => 'inline',
+        'foreign_table' => 'tx_testsat_item',
+        'foreign_field' => 'foreign_table_parent_uid',
+        'foreign_table_field' => 'tablenames',
+        'foreign_match_fields' => [
+            'fieldname' => 'tx_testsat_items',
+        ],
+        'foreign_sortby' => 'sorting',
+    ],
+];
+
+ExtensionManagementUtility::addToAllTCAtypes(
+    'tt_content',
+    'tx_testsat_items',
+    '',
+    'after:bodytext',
+);

--- a/Tests/Functional/Fixtures/Extensions/test_share_across_tables/Configuration/TCA/tx_testsat_item.php
+++ b/Tests/Functional/Fixtures/Extensions/test_share_across_tables/Configuration/TCA/tx_testsat_item.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Mirrors the TCA that friendsoftypo3/content-blocks generates for a "Collection"
+ * field with shareAcrossTables + shareAcrossFields: a hidden child table located
+ * purely through foreign_table_field ("tablenames") + foreign_match_fields
+ * ("fieldname") + foreign_field ("foreign_table_parent_uid"), never through its
+ * own list module entry.
+ */
+return [
+    'ctrl' => [
+        'title' => 'Test shareAcrossTables item',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'delete' => 'deleted',
+        'hideTable' => true,
+        'sortby' => 'sorting',
+        'versioningWS' => true,
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
+    ],
+    'columns' => [
+        'pid' => [
+            'label' => 'pid',
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'title' => [
+            'label' => 'Title',
+            'config' => [
+                'type' => 'input',
+            ],
+        ],
+        // Content Blocks declares these three as passthrough columns on the
+        // generated child table (confirmed via the real compiled TCA). Without
+        // them here, DataHandler::fillInFieldArray() silently drops any value
+        // for a field that has no TCA columns entry at all — masking the very
+        // bug this fixture exists to reproduce.
+        'foreign_table_parent_uid' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'tablenames' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'fieldname' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+    ],
+    'types' => [
+        0 => [
+            'showitem' => 'title',
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Extensions/test_share_across_tables/composer.json
+++ b/Tests/Functional/Fixtures/Extensions/test_share_across_tables/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "hn/test-share-across-tables",
+    "type": "typo3-cms-extension",
+    "description": "Test fixture: foreign_table_field inline child (Content Blocks shareAcrossTables shape)",
+    "license": "GPL-2.0-or-later",
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "test_share_across_tables"
+        }
+    }
+}

--- a/Tests/Functional/Fixtures/Extensions/test_share_across_tables/ext_emconf.php
+++ b/Tests/Functional/Fixtures/Extensions/test_share_across_tables/ext_emconf.php
@@ -1,0 +1,16 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'MCP Server Test Fixture: shareAcrossTables inline child',
+    'description' => 'Minimal child table using foreign_table_field (Content Blocks "shareAcrossTables" pattern), for functional tests only.',
+    'category' => 'example',
+    'author' => 'Konrad Michalik',
+    'author_email' => 'hej@konradmichalik.dev',
+    'state' => 'stable',
+    'version' => '1.0.0',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '13.4.0-14.4.99',
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Extensions/test_share_across_tables/ext_tables.sql
+++ b/Tests/Functional/Fixtures/Extensions/test_share_across_tables/ext_tables.sql
@@ -1,0 +1,13 @@
+CREATE TABLE tx_testsat_item (
+    fieldname varchar(255) DEFAULT '' NOT NULL,
+    foreign_table_parent_uid int(11) unsigned DEFAULT '0' NOT NULL,
+    tablenames varchar(255) DEFAULT '' NOT NULL,
+
+    title varchar(255) DEFAULT '' NOT NULL,
+
+    KEY parent (foreign_table_parent_uid, tablenames, fieldname)
+);
+
+CREATE TABLE tt_content (
+    tx_testsat_items int(11) unsigned DEFAULT '0' NOT NULL
+);

--- a/Tests/Functional/MCP/Tool/ShareAcrossTablesInlineRelationTest.php
+++ b/Tests/Functional/MCP/Tool/ShareAcrossTablesInlineRelationTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\MCP\Tool;
+
+use Hn\McpServer\MCP\Tool\Record\ReadTableTool;
+use Hn\McpServer\MCP\Tool\Record\WriteTableTool;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Covers embedded inline relations that use TCA's `foreign_table_field` to record
+ * the owning parent table (friendsoftypo3/content-blocks generates exactly this
+ * shape for a "Collection" field configured with `shareAcrossTables: true`).
+ *
+ * This is a distinct code path from `foreign_match_fields`, which is the only
+ * source WriteTableTool::processEmbeddedInlineRelations() reads today.
+ */
+class ShareAcrossTablesInlineRelationTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'workspaces',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        __DIR__ . '/../../Fixtures/Extensions/test_share_across_tables',
+        'mcp_server',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/be_users.csv');
+        $this->setUpBackendUser(1);
+    }
+
+    public function testCreatingChildRecordsSetsTheOwningParentTable(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+
+        $result = $writeTool->execute([
+            'table' => 'pages',
+            'action' => 'create',
+            'pid' => 0,
+            'data' => [
+                'title' => 'Test Page',
+                'doktype' => 1,
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $pageUid = json_decode($result->content[0]->text, true)['uid'];
+
+        $result = $writeTool->execute([
+            'table' => 'tt_content',
+            'action' => 'create',
+            'pid' => $pageUid,
+            'data' => [
+                'header' => 'Accordion-like element',
+                'CType' => 'text',
+                'tx_testsat_items' => [
+                    ['title' => 'First'],
+                    ['title' => 'Second'],
+                ],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $contentUid = json_decode($result->content[0]->text, true)['uid'];
+
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_testsat_item');
+        $queryBuilder->getRestrictions()->removeAll();
+        $children = $queryBuilder
+            ->select('uid', 'title', 'tablenames', 'fieldname', 'foreign_table_parent_uid')
+            ->from('tx_testsat_item')
+            ->orderBy('sorting')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $this->assertCount(2, $children, 'Both child records should have been written.');
+
+        foreach ($children as $child) {
+            $this->assertSame(
+                'tt_content',
+                $child['tablenames'],
+                sprintf(
+                    'Child "%s" (uid %d) is missing tablenames="tt_content" — TYPO3 cannot resolve '
+                    . 'the relation back to its parent without it, so the field renders empty in the '
+                    . 'backend even though the row exists in the database.',
+                    $child['title'],
+                    $child['uid']
+                )
+            );
+            $this->assertSame('tx_testsat_items', $child['fieldname']);
+            $this->assertSame($contentUid, $child['foreign_table_parent_uid']);
+        }
+
+        // With tablenames correctly set, TYPO3's own relation resolution (as used by
+        // ReadTableTool) must be able to find the children again.
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+        $result = $readTool->execute([
+            'table' => 'tt_content',
+            'uid' => $contentUid,
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $record = json_decode($result->content[0]->text, true)['records'][0];
+        $this->assertArrayHasKey('tx_testsat_items', $record);
+        $this->assertCount(2, $record['tx_testsat_items']);
+    }
+}


### PR DESCRIPTION
Fixes #111.

## Problem

`WriteTableTool::processEmbeddedInlineRelations()` only reads `foreign_match_fields` when populating a new embedded child record. It never reads TCA's `foreign_table_field`, so a child table that identifies its parent via that key is written with an empty `tablenames` column. The row exists in the database but TYPO3 can never resolve it back to its parent, it renders as an empty relation in both the backend form and the frontend, and the parent's own inline-count field stays `0` since it's derived from the same lookup.

This is the shape `friendsoftypo3/content-blocks` generates for a Collection field with `shareAcrossTables: true` (`tablenames` via `foreign_table_field`) combined with `shareAcrossFields: true` (`fieldname` via `foreign_match_fields`), the two TCA keys are handled asymmetrically today, only the second one is read.

## Fix

- `processEmbeddedInlineRelations()`: when creating a new child record and `config['foreign_table_field']` is set, write the parent's own table name into that field, mirroring the existing `foreign_match_fields` handling right above it.
- `fetchEmbeddedRelationChildUids()`: scope the existing-children lookup (used for the "does this uid belong to this parent" ownership check and for orphan deletion) by the same field when present, so a shared child table can't mix up children belonging to different parent tables.
- Both methods gained a `parentTable` parameter, threaded through from `processInlineRelations()`, which already has the parent table name in scope.

## Tests

Added `Tests/Functional/MCP/Tool/ShareAcrossTablesInlineRelationTest.php` with a minimal fixture extension (`Tests/Functional/Fixtures/Extensions/test_share_across_tables`) reproducing the exact `foreign_table_field` + `foreign_match_fields` TCA shape Content Blocks generates, no currently loaded test dependency (news, container) exercises this particular shape. The fixture's child table TCA also declares `foreign_table_parent_uid` / `tablenames` / `fieldname` as `passthrough` columns, matching what Content Blocks actually generates (confirmed against a real installation), without that, `DataHandler::fillInFieldArray()` silently drops any field that has no TCA columns entry at all, which would mask this exact bug in a test.

Verified locally:
- New test fails against `main` (RED) with `tablenames` empty, passes with the fix (GREEN)
- Full suite: `vendor/bin/phpunit`, same result as on `main` (616 tests, 2 pre-existing unrelated failures in `InvalidDataTest` reproduced identically on a clean checkout of `main`, not introduced by this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inline child record handling for relations shared across multiple parent tables.
  - Child records are now correctly associated with their owning table, preventing unrelated records from being shared or incorrectly discovered.

- **Tests**
  - Added functional coverage for creating and reading shared inline child records across tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->