### PR TITLE
Upgrade to mcp-sdk-php v2 with the remaining API adoptions (alternative to #109)

### DIFF
--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -31,6 +31,42 @@ class McpEndpoint
 {
     use CorsHeadersTrait;
     use RequestUrlTrait;
+
+    /**
+     * Header and query parameter names whose values must never reach a log file.
+     *
+     * Access tokens are handed out with a 30 day lifetime, so a single logged
+     * request is enough to leak a long lived credential to everyone who can read
+     * - or forward - the log.
+     */
+    private const CREDENTIAL_KEYS = [
+        'authorization',
+        'proxy-authorization',
+        'cookie',
+        'set-cookie',
+        'token',
+        'access_token',
+        'refresh_token',
+        'client_secret',
+    ];
+
+    /**
+     * Replace credential values with a marker while keeping the key itself, so the
+     * log still shows which headers and parameters a client actually sent.
+     *
+     * @param array<string, mixed> $values
+     * @return array<string, mixed>
+     */
+    private function redactCredentials(array $values): array
+    {
+        foreach ($values as $key => $value) {
+            if (in_array(strtolower((string)$key), self::CREDENTIAL_KEYS, true)) {
+                $values[$key] = '***redacted***';
+            }
+        }
+
+        return $values;
+    }
     /**
      * eID entry point via __invoke method
      */
@@ -42,15 +78,15 @@ class McpEndpoint
             $serverFactory = $container->get(McpServerFactory::class);
 
             // Debug: Log all request details
-            $headers = [];
+            $requestHeaders = [];
             foreach ($request->getHeaders() as $name => $values) {
-                $headers[$name] = implode(', ', $values);
+                $requestHeaders[$name] = implode(', ', $values);
             }
             $queryParams = $request->getQueryParams();
 
             error_log("MCP: Request method: " . $request->getMethod());
-            error_log("MCP: Request headers: " . json_encode($headers));
-            error_log("MCP: Query params: " . json_encode($queryParams));
+            error_log("MCP: Request headers: " . json_encode($this->redactCredentials($requestHeaders)));
+            error_log("MCP: Query params: " . json_encode($this->redactCredentials($queryParams)));
 
             // Check if this is an auth header test request
             if (isset($queryParams['test']) && $queryParams['test'] === 'auth') {

--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Hn\McpServer\Http;
 
 use Mcp\Server\HttpServerRunner;
-use Mcp\Server\Transport\Http\StandardPhpAdapter;
 use Mcp\Server\Transport\Http\FileSessionStore;
+use Mcp\Server\Transport\Http\HttpMessage;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -115,38 +115,33 @@ class McpEndpoint
                 $sessionStore
             );
 
-            // Handle the request and capture output
-            ob_start();
-
-            // Suppress warnings/notices from MCP SDK to prevent deprecation issues
-            $oldErrorReporting = error_reporting(E_ERROR | E_PARSE);
-
-            try {
-                $adapter = new StandardPhpAdapter($runner);
-                $adapter->handle();
-            } finally {
-                // Restore error reporting
-                error_reporting($oldErrorReporting);
+            // Convert the PSR-7 request into the SDK's HttpMessage and let the
+            // runner handle it directly. This keeps the whole request/response
+            // cycle inside PSR-7 (no superglobals, no output buffering), which
+            // also makes the endpoint testable in functional tests.
+            $mcpRequest = new HttpMessage((string)$request->getBody());
+            $mcpRequest->setMethod($request->getMethod());
+            $mcpRequest->setUri((string)$request->getUri());
+            $mcpRequest->setQueryParams($request->getQueryParams());
+            foreach ($request->getHeaders() as $name => $values) {
+                $mcpRequest->setHeader($name, implode(', ', $values));
             }
 
-            $output = ob_get_clean();
+            $mcpResponse = $runner->handleRequest($mcpRequest);
 
-            // Get the status code set by the adapter
-            $statusCode = http_response_code() ?: 200;
-
-            // Try to decode as JSON, fallback to plain text
-            $decodedOutput = json_decode($output, true);
-            $contentType = $decodedOutput !== null ? 'application/json' : 'text/plain';
-
-            // Create proper stream for response
             $stream = new Stream('php://temp', 'rw');
-            $stream->write($output);
+            $stream->write((string)($mcpResponse->getBody() ?? ''));
             $stream->rewind();
+
+            $headers = $mcpResponse->getHeaders();
+            if (!isset($headers['content-type'])) {
+                $headers['content-type'] = 'application/json';
+            }
 
             $response = new Response(
                 $stream,
-                $statusCode,
-                ['Content-Type' => $contentType]
+                $mcpResponse->getStatusCode(),
+                $headers
             );
 
             return $this->addCorsHeaders($response, $request);

--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -51,6 +51,31 @@ class McpEndpoint
     ];
 
     /**
+     * Whether the endpoint may write its diagnostic output to the log.
+     *
+     * The endpoint is polled by connector proxies in a retry loop, so logging
+     * every request unconditionally fills a production log with entries nobody
+     * asked for and nobody reads. Diagnostics are therefore limited to the
+     * Development context, which is also where they are actually needed.
+     */
+    private function isDebugLoggingEnabled(): bool
+    {
+        return Environment::getContext()->isDevelopment();
+    }
+
+    /**
+     * Write a diagnostic message, unless the context says otherwise.
+     */
+    private function logDebug(string $message): void
+    {
+        if (!$this->isDebugLoggingEnabled()) {
+            return;
+        }
+
+        error_log($message);
+    }
+
+    /**
      * Replace credential values with a marker while keeping the key itself, so the
      * log still shows which headers and parameters a client actually sent.
      *
@@ -77,16 +102,19 @@ class McpEndpoint
             $container = GeneralUtility::getContainer();
             $serverFactory = $container->get(McpServerFactory::class);
 
-            // Debug: Log all request details
-            $requestHeaders = [];
-            foreach ($request->getHeaders() as $name => $values) {
-                $requestHeaders[$name] = implode(', ', $values);
-            }
             $queryParams = $request->getQueryParams();
 
-            error_log("MCP: Request method: " . $request->getMethod());
-            error_log("MCP: Request headers: " . json_encode($this->redactCredentials($requestHeaders)));
-            error_log("MCP: Query params: " . json_encode($this->redactCredentials($queryParams)));
+            // Debug: Log all request details
+            if ($this->isDebugLoggingEnabled()) {
+                $requestHeaders = [];
+                foreach ($request->getHeaders() as $name => $values) {
+                    $requestHeaders[$name] = implode(', ', $values);
+                }
+
+                error_log("MCP: Request method: " . $request->getMethod());
+                error_log("MCP: Request headers: " . json_encode($this->redactCredentials($requestHeaders)));
+                error_log("MCP: Query params: " . json_encode($this->redactCredentials($queryParams)));
+            }
 
             // Check if this is an auth header test request
             if (isset($queryParams['test']) && $queryParams['test'] === 'auth') {
@@ -97,22 +125,22 @@ class McpEndpoint
             $token = $this->extractToken($request);
 
             if (!$token) {
-                error_log("MCP: No token found in Authorization header or query params");
+                $this->logDebug("MCP: No token found in Authorization header or query params");
                 return $this->createUnauthorizedResponse('Missing authentication token', $request);
             }
 
             // Log token for debugging (first 20 chars only for security)
-            error_log("MCP: Received token: " . substr($token, 0, 20) . "...");
+            $this->logDebug("MCP: Received token: " . substr($token, 0, 20) . "...");
 
             $oauthService = GeneralUtility::makeInstance(OAuthService::class);
             $tokenInfo = $oauthService->validateToken($token, $request);
 
             if (!$tokenInfo) {
-                error_log("MCP: Token validation failed for: " . substr($token, 0, 20) . "...");
+                $this->logDebug("MCP: Token validation failed for: " . substr($token, 0, 20) . "...");
                 return $this->createUnauthorizedResponse('Invalid or expired token', $request);
             }
 
-            error_log("MCP: Token validation successful for user: " . $tokenInfo['be_user_uid']);
+            $this->logDebug("MCP: Token validation successful for user: " . $tokenInfo['be_user_uid']);
 
             // Set up TYPO3 backend context for the authenticated user
             $this->setupBackendUserContext($tokenInfo['be_user_uid']);
@@ -332,7 +360,7 @@ class McpEndpoint
             $context->setAspect('workspace', new WorkspaceAspect($workspaceId));
 
             // Log workspace selection for debugging
-            error_log("MCP: User {$userId} switched to workspace {$workspaceId}");
+            $this->logDebug("MCP: User {$userId} switched to workspace {$workspaceId}");
         }
 
         // Ensure TCA is loaded using proper TYPO3 core method

--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -211,6 +211,20 @@ class McpEndpoint
             return $this->addCorsHeaders($response, $request);
 
         } catch (\Throwable $e) {
+            // Deliberately not behind the debug switch: this catch-all is the only
+            // place where an exception from the MCP layer becomes visible at all,
+            // and handing it to the client alone means it is gone the moment the
+            // client discards the 500.
+            error_log(sprintf(
+                'MCP: Unhandled %s at %s:%d - %s%s%s',
+                get_class($e),
+                $e->getFile(),
+                $e->getLine(),
+                $e->getMessage(),
+                PHP_EOL,
+                $e->getTraceAsString()
+            ));
+
             $stream = new Stream('php://temp', 'rw');
             $stream->write(json_encode([
                 'error' => 'Internal Server Error',

--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -129,14 +129,14 @@ class McpEndpoint
                 return $this->createUnauthorizedResponse('Missing authentication token', $request);
             }
 
-            // Log token for debugging (first 20 chars only for security)
-            $this->logDebug("MCP: Received token: " . substr($token, 0, 20) . "...");
+            // Log authentication status without exposing token material
+            $this->logDebug('MCP: Received authentication token');
 
             $oauthService = GeneralUtility::makeInstance(OAuthService::class);
             $tokenInfo = $oauthService->validateToken($token, $request);
 
             if (!$tokenInfo) {
-                $this->logDebug("MCP: Token validation failed for: " . substr($token, 0, 20) . "...");
+                $this->logDebug('MCP: Authentication token validation failed');
                 return $this->createUnauthorizedResponse('Invalid or expired token', $request);
             }
 

--- a/Classes/MCP/McpServerFactory.php
+++ b/Classes/MCP/McpServerFactory.php
@@ -8,7 +8,9 @@ use Mcp\Server\Server;
 use Mcp\Server\InitializationOptions;
 use Mcp\Server\NotificationOptions;
 use Mcp\Types\CallToolResult;
+use Mcp\Types\ListToolsResult;
 use Mcp\Types\TextContent;
+use Mcp\Types\Tool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Information\Typo3Version;
@@ -85,14 +87,20 @@ class McpServerFactory
             $tools = [];
 
             foreach ($toolRegistry->getTools() as $tool) {
-                $schema = $tool->getSchema();
-                $tools[] = [
+                // Normalize to plain arrays first: getSchema() may hand back a
+                // \stdClass for an empty "properties" object, which
+                // ToolInputSchema::fromArray() rejects. The round trip preserves
+                // every JSON Schema keyword - unknown keys are carried through by
+                // the extraFields handling in Tool, ToolInputSchema and
+                // ToolInputProperties.
+                $schema = json_decode((string)json_encode($tool->getSchema()), true) ?? [];
+                $tools[] = Tool::fromArray([
                     'name' => $tool->getName(),
                     ...$schema
-                ];
+                ]);
             }
 
-            return ['tools' => $tools];
+            return new ListToolsResult($tools);
         });
 
         // Register tool/call handler

--- a/Resources/Private/PHP/composer.json
+++ b/Resources/Private/PHP/composer.json
@@ -2,7 +2,7 @@
     "name": "hn/mcp-server-libraries",
     "description": "Bundled libraries for mcp_server extension in non-composer TYPO3 installations",
     "require": {
-        "logiscape/mcp-sdk-php": "^1.2"
+        "logiscape/mcp-sdk-php": "^2.0"
     },
     "replace": {
         "psr/log": "*"

--- a/Tests/Functional/Http/McpEndpointAuthTest.php
+++ b/Tests/Functional/Http/McpEndpointAuthTest.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hn\McpServer\Tests\Functional\Http;
+
+use Hn\McpServer\Http\McpEndpoint;
+use Hn\McpServer\Service\OAuthService;
+use Hn\McpServer\Tests\Functional\AbstractFunctionalTest;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Authorization and protocol-era tests for the /mcp HTTP endpoint.
+ *
+ * The endpoint authenticates every request with a static (pre-authorized)
+ * bearer token. Since the 2026-07-28 MCP spec revision ("stateless core"),
+ * a client can execute a tool call with a single HTTP request — no
+ * initialize handshake, no session. Legacy clients (2024-11-05 … 2025-11-25)
+ * still get the classic handshake with an Mcp-Session-Id. Both eras must
+ * work against the same endpoint, gated by the same token check.
+ */
+class McpEndpointAuthTest extends AbstractFunctionalTest
+{
+    private static function modernMeta(): array
+    {
+        return [
+            'io.modelcontextprotocol/protocolVersion' => '2026-07-28',
+            'io.modelcontextprotocol/client' => ['name' => 'stateless-test', 'version' => '1.0'],
+            'io.modelcontextprotocol/clientCapabilities' => new \stdClass(),
+        ];
+    }
+
+    /**
+     * SEP-2243 request-metadata headers of a 2026-07-28 client. The
+     * MCP-Protocol-Version header is what routes the request onto the
+     * stateless path; Mcp-Method/Mcp-Name mirror the body for gateways.
+     */
+    private static function modernHeaders(string $method, ?string $name = null): array
+    {
+        $headers = [
+            'MCP-Protocol-Version' => '2026-07-28',
+            'Mcp-Method' => $method,
+        ];
+        if ($name !== null) {
+            $headers['Mcp-Name'] = $name;
+        }
+        return $headers;
+    }
+
+    private mixed $previousRequest;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousRequest = $GLOBALS['TYPO3_REQUEST'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = $this->previousRequest;
+        parent::tearDown();
+    }
+
+    public function testStatelessToolCallWithStaticTokenNeedsNoHandshake(): void
+    {
+        $token = $this->createAccessToken();
+
+        // A single HTTP request: authenticate with the static token and call
+        // a tool — no initialize, no notifications/initialized, no session.
+        $response = $this->dispatch([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => 'GetPageTree',
+                'arguments' => new \stdClass(),
+                '_meta' => self::modernMeta(),
+            ],
+        ], $token, self::modernHeaders('tools/call', 'GetPageTree'));
+
+        $body = $this->decodeJsonRpc($response, 1);
+        $this->assertArrayHasKey('result', $body, json_encode($body));
+        $this->assertFalse($body['result']['isError'] ?? true, json_encode($body));
+        $this->assertNotEmpty($body['result']['content'] ?? []);
+
+        // The stateless lifecycle must not leak session machinery.
+        $this->assertFalse(
+            $response->hasHeader('mcp-session-id'),
+            'A 2026-07-28 stateless response must not carry an Mcp-Session-Id'
+        );
+    }
+
+    public function testStatelessToolsListExposesTools(): void
+    {
+        $token = $this->createAccessToken();
+
+        $response = $this->dispatch([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'tools/list',
+            'params' => ['_meta' => self::modernMeta()],
+        ], $token, self::modernHeaders('tools/list'));
+
+        $body = $this->decodeJsonRpc($response, 1);
+        $toolNames = array_column($body['result']['tools'] ?? [], 'name');
+        $this->assertContains('GetPageTree', $toolNames);
+        $this->assertContains('WriteTable', $toolNames);
+    }
+
+    public function testStatelessRequestWithoutMetaEnvelopeIsRejected(): void
+    {
+        $token = $this->createAccessToken();
+
+        // The stateless era is opt-in per request: the _meta envelope carries
+        // protocol version, client info and capabilities. A request that
+        // announces 2026-07-28 but omits the required clientCapabilities is
+        // rejected as invalid params — it does not fall back silently.
+        $response = $this->dispatch([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'tools/list',
+            'params' => [
+                '_meta' => [
+                    'io.modelcontextprotocol/protocolVersion' => '2026-07-28',
+                    'io.modelcontextprotocol/client' => ['name' => 'incomplete', 'version' => '1.0'],
+                ],
+            ],
+        ], $token, self::modernHeaders('tools/list'));
+
+        $body = json_decode((string)$response->getBody(), true);
+        $this->assertSame(-32602, $body['error']['code'] ?? null, json_encode($body));
+    }
+
+    public function testLegacyHandshakeAndSessionStillWork(): void
+    {
+        $token = $this->createAccessToken();
+
+        // 1. Classic initialize handshake of a pre-2026 client.
+        $response = $this->dispatch([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'initialize',
+            'params' => [
+                'protocolVersion' => '2025-06-18',
+                'capabilities' => new \stdClass(),
+                'clientInfo' => ['name' => 'legacy-test', 'version' => '1.0'],
+            ],
+        ], $token);
+
+        $body = $this->decodeJsonRpc($response, 1);
+        $this->assertSame('2025-06-18', $body['result']['protocolVersion'] ?? null, json_encode($body));
+        $this->assertTrue(
+            $response->hasHeader('mcp-session-id'),
+            'A legacy initialize response must carry an Mcp-Session-Id'
+        );
+        $sessionId = $response->getHeaderLine('mcp-session-id');
+
+        // 2. Complete the handshake.
+        $this->dispatch(
+            ['jsonrpc' => '2.0', 'method' => 'notifications/initialized'],
+            $token,
+            ['Mcp-Session-Id' => $sessionId]
+        );
+
+        // 3. Session-bound request works and sees the same tools.
+        $response = $this->dispatch(
+            ['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list'],
+            $token,
+            ['Mcp-Session-Id' => $sessionId]
+        );
+
+        $body = $this->decodeJsonRpc($response, 2);
+        $toolNames = array_column($body['result']['tools'] ?? [], 'name');
+        $this->assertContains('GetPageTree', $toolNames);
+    }
+
+    public function testMissingTokenIsRejectedWithOauthMetadata(): void
+    {
+        $response = $this->dispatch([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'tools/list',
+            'params' => ['_meta' => self::modernMeta()],
+        ], null);
+
+        $this->assertSame(401, $response->getStatusCode());
+        // RFC 9728: the 401 must point OAuth-capable clients to the
+        // protected-resource metadata so they can discover the auth server.
+        $this->assertStringContainsString(
+            'resource_metadata=',
+            $response->getHeaderLine('WWW-Authenticate')
+        );
+    }
+
+    public function testInvalidTokenIsRejected(): void
+    {
+        $response = $this->dispatch([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'tools/list',
+            'params' => ['_meta' => self::modernMeta()],
+        ], str_repeat('f', 64));
+
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    public function testExpiredTokenIsRejected(): void
+    {
+        $token = $this->createAccessToken();
+
+        $this->getConnectionForTable('tx_mcpserver_access_tokens')->update(
+            'tx_mcpserver_access_tokens',
+            ['expires' => time() - 10],
+            ['client_name' => 'endpoint-auth-test']
+        );
+
+        $response = $this->dispatch([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'tools/list',
+            'params' => ['_meta' => self::modernMeta()],
+        ], $token);
+
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    private function createAccessToken(): string
+    {
+        $oauthService = GeneralUtility::makeInstance(OAuthService::class);
+        $tokenData = $oauthService->createToken(1, 'endpoint-auth-test');
+        return $tokenData['access_token'];
+    }
+
+    /**
+     * Dispatch a JSON-RPC message to the endpoint the way the middleware
+     * would: as a PSR-7 request.
+     */
+    private function dispatch(array $jsonRpc, ?string $token, array $extraHeaders = []): ResponseInterface
+    {
+        $body = new Stream('php://temp', 'rw');
+        $body->write(json_encode($jsonRpc));
+        $body->rewind();
+
+        $headers = array_merge([
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ], $extraHeaders);
+        if ($token !== null) {
+            $headers['Authorization'] = 'Bearer ' . $token;
+        }
+
+        $request = new ServerRequest(new Uri('https://example.com/mcp'), 'POST', $body, $headers);
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        return (new McpEndpoint())($request);
+    }
+
+    private function decodeJsonRpc(ResponseInterface $response, int $expectedId): array
+    {
+        $raw = (string)$response->getBody();
+        $this->assertSame(200, $response->getStatusCode(), $raw);
+
+        $body = json_decode($raw, true);
+        $this->assertIsArray($body, $raw);
+        $this->assertArrayNotHasKey('error', $body, $raw);
+        $this->assertSame($expectedId, $body['id'] ?? null, $raw);
+
+        return $body;
+    }
+}

--- a/Tests/Functional/Http/McpEndpointUcPreservationTest.php
+++ b/Tests/Functional/Http/McpEndpointUcPreservationTest.php
@@ -79,8 +79,8 @@ class McpEndpointUcPreservationTest extends AbstractFunctionalTest
         $endpoint = new McpEndpoint();
         $response = $endpoint($request);
 
-        // A 401 would mean the token authentication - and with it the
-        // impersonation path under test - never ran.
+        // A 401 means authentication failed before the impersonation
+        // path under test could run.
         $this->assertNotSame(401, $response->getStatusCode());
 
         // The impersonated backend user must carry the stored configuration

--- a/Tests/Functional/Http/McpEndpointUcPreservationTest.php
+++ b/Tests/Functional/Http/McpEndpointUcPreservationTest.php
@@ -79,12 +79,8 @@ class McpEndpointUcPreservationTest extends AbstractFunctionalTest
         $endpoint = new McpEndpoint();
         $response = $endpoint($request);
 
-        // The JSON-RPC processing itself cannot succeed in this environment:
-        // the SDK's StandardPhpAdapter builds its request via
-        // HttpMessage::fromGlobals(), and PHPUnit's CLI process provides
-        // neither REQUEST_METHOD nor a fillable php://input. A 401 however
-        // would mean the token authentication - and with it the impersonation
-        // path under test - never ran.
+        // A 401 would mean the token authentication - and with it the
+        // impersonation path under test - never ran.
         $this->assertNotSame(401, $response->getStatusCode());
 
         // The impersonated backend user must carry the stored configuration

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "logiscape/mcp-sdk-php": "^1.2",
+        "logiscape/mcp-sdk-php": "^2.0",
         "typo3/cms-backend": "^13.4 || ^14.3",
         "typo3/cms-core": "^13.4 || ^14.3",
         "typo3/cms-workspaces": "^13.4 || ^14.3"


### PR DESCRIPTION
Refs #110.

This is an alternative to #109. It carries that PR's three commits unchanged and adds four
adoptions on top that the SDK v2 move turns out to need, plus the two logging fixes asked
about in #110.

I have a staging instance that reproduces #110 reliably, which is why I went looking for the
remainder.

## Relationship to #109

The first three commits are **cherry-picked verbatim from `claude/stateless-mcp-php-sdk-5as9cy`**,
original authorship preserved. Nothing in them is changed. If #109 is merged first, those three
drop out of this branch cleanly and the remaining five still apply.

| commit | origin | what |
|---|---|---|
| `29b1bfc` | #109 | `logiscape/mcp-sdk-php` `^1.2` → `^2.0` |
| `c8a53da` | #109 | functional coverage for both protocol eras |
| `2a88c8f` | #109 | comment fix in the uc-preservation test |
| `da1018a` | new | redact credentials from the request log |
| `2ae59e1` | new | gate the diagnostics behind the Development context |
| `01a5f4c` | new | log the throwable behind a 500 |
| `b9b6569` | new | raise the bundled SDK for non-Composer installs |
| `e1d37d2` | new | return a `ListToolsResult` from `tools/list` |

## The four additions

### `b9b6569` — the second manifest

This is the one I would most like a second pair of eyes on. #109 raises the constraint in the
root `composer.json`, but the extension carries a second one at
`Resources/Private/PHP/composer.json`, which is what `Build/build-ter.sh` installs and zips
for the TER artefact. Left at `^1.2`, every non-Composer installation would ship an SDK that
caps out at protocol revision `2025-11-25` with no `server/discover` handler — exactly the
failure #110 describes — while `Classes/` and the new tests assume the 2.x lifecycle. Both
manifests now agree on `^2.0`.

### `e1d37d2` — `tools/list` was not a `Result`

`McpServerFactory` returned a plain `['tools' => …]` array. In v2,
`ServerSession::adaptResultForModernClient()` guards on `instanceof Mcp\Types\Result`, so on a
`2026-07-28` session `tools/call` gets stamped and `tools/list` does not — it loses the
`resultType` discriminator, the SEP-2549 `ttlMs`/`cacheScope` hints and the serverInfo `_meta`.
The SDK asserts all three are required on the modern path in four places (`Result.php`,
`CacheableResult.php`, `docs/server-dev.md`, `tests/Server/ModernResultAdaptationTest.php`),
and `ListToolsResult` is one of the six result types SEP-2549 covers.

**Severity, stated honestly: this degrades, it does not break.** I could find no rejection path
anywhere in the SDK, and its own client treats a missing `resultType` as a legacy peer and
carries on. Whether Claude's connector is stricter I could not prove — neither the draft schema
nor the conformance suite is vendored. So this is conformance tidying, and it is the commit I
would drop first if you would rather keep the diff minimal.

The schema goes through a JSON round trip first because `ListTablesTool` declares its empty
parameter set as a `\stdClass`, which `ToolInputSchema::fromArray()` rejects.

### `da1018a`, `2ae59e1`, `01a5f4c` — the logging points from #110

`McpEndpoint` wrote the complete request header set to the PHP error log on every request,
including `Authorization` in clear text. Tokens are issued with a 30-day lifetime, so a single
logged request hands out a long-lived credential to anyone who can read the log — which is
what happened while I was diagnosing #110, and the tokens ended up pasted into our internal
ticket. The adjacent `MCP: Received token:` line already truncates to 20 characters, so the
intent was there; the header dump bypassed it. Credential-bearing header and query names are
now replaced with a marker, keys still visible.

The whole diagnostic block then moves behind `Environment::getContext()->isDevelopment()`.
Connector proxies poll this endpoint in a retry loop, so on a production site it was a steady
stream of entries nobody reads, in a log meant for errors. The header collection and encoding
is skipped along with it rather than assembled and thrown away.

The catch-all returned the exception message in the response body and dropped it otherwise.
That is precisely why the original 500 was undiagnosable for a week: the access log showed
`POST /mcp 500`, the error log showed a clean run up to the workspace switch, and the
exception in between existed nowhere. It is now logged with class, origin, message and trace —
deliberately outside the Development guard, since an unhandled exception is not a diagnostic.

Happy to split the three logging commits into their own PR if you would rather keep this one
to the SDK move; that was question 3 in #110.

## What I checked

`composer update` resolves `logiscape/mcp-sdk-php` to **v2.0.1**, `Build/runTests.sh -s lint`
is clean, and the functional suite passes under both `composer test` and
`Build/runTests.sh -s functional`:

```
Tests: 622, Assertions: 3329, Failures: 0, Errors: 0, Skipped: 6
```

Against the pre-bump baseline at `3a375ae` with SDK v1.7.5 (615 / 3299), the delta is exactly
the seven new `McpEndpointAuthTest` tests. The six skips are pre-existing and identical on both
trees. `WriteTableLanguageTest` fails when run in isolation, but it does so byte-for-byte
identically on the pre-bump baseline too, so it is existing test-isolation fragility rather
than anything from the SDK move.

For `e1d37d2` I captured the serialized `tools/list` body on both eras, before and after the
commit, and diffed them: all 8 tools present in the same order with `description`,
`inputSchema` and `annotations` deep-equal; `ListTables` still emits `"properties":{}` and not
`[]`; the modern session gains the four envelope fields; the legacy session has them correctly
stripped. The only difference anywhere is JSON key order.

**Not verified: a live Claude connector handshake.** Everything above is the test suite and
wire inspection. I have not yet been able to run the fork against the connector end to end —
when I do, I will report back in #110 either way.

## One thing I deliberately left out

CORS is broken for browser-based MCP clients, independently of this change:
`Access-Control-Allow-Headers` lists none of `MCP-Protocol-Version`, `Mcp-Session-Id`,
`Mcp-Method`, `Mcp-Name`, `Accept` or `Last-Event-ID`, there is no
`Access-Control-Expose-Headers`, `Allow-Methods` omits `DELETE`, and `McpEndpoint` — unlike
every OAuth endpoint — never short-circuits `OPTIONS`, so a browser preflight of `/mcp` gets a
401 and fails before the first POST. It is not the #110 blocker, since Claude's connector is a
server-side proxy that sends no `Origin`, and it pre-dates the modern era. Say the word and I
will open it separately rather than widening this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for stateless MCP requests, tool calls, and tool discovery.
  * Preserved response status codes and headers, with JSON used when no content type is provided.
  * Improved authentication handling, including OAuth metadata for missing credentials.
  * Continued support for legacy session-based MCP connections.

* **Bug Fixes**
  * Improved validation for invalid, expired, or incomplete authentication requests.
  * Enhanced diagnostic logging with sensitive credentials redacted.

* **Tests**
  * Added coverage for MCP authentication and protocol behavior across stateless and session-based requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->