### PR TITLE
Fix CORS handling for browser-based MCP clients

### DIFF
--- a/Classes/Http/CorsHeadersTrait.php
+++ b/Classes/Http/CorsHeadersTrait.php
@@ -24,11 +24,27 @@ trait CorsHeadersTrait
             return $response;
         }
 
+        // Authentication uses Bearer tokens, not cookies, so credentialed CORS
+        // is not needed. Reflecting an arbitrary Origin is only acceptable
+        // because of that: combining it with Allow-Credentials would be
+        // equivalent to the wildcard-with-credentials setup the CORS spec
+        // forbids for a reason.
         return $response
             ->withHeader('Access-Control-Allow-Origin', $allowedOrigin)
-            ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, OPTIONS')
-            ->withHeader('Access-Control-Allow-Headers', 'Content-Type, Content-Disposition, Authorization, X-Requested-With')
-            ->withHeader('Access-Control-Allow-Credentials', 'true')
+            ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
+            // The MCP Streamable HTTP transport requires several custom request
+            // headers (session id, protocol version, SSE resumption, routing
+            // headers) that are not CORS-safelisted and must be listed here or
+            // browsers reject the preflight.
+            ->withHeader(
+                'Access-Control-Allow-Headers',
+                'Content-Type, Content-Disposition, Authorization, X-Requested-With, Accept, '
+                . 'MCP-Protocol-Version, Mcp-Session-Id, Mcp-Method, Mcp-Name, Last-Event-ID'
+            )
+            // The server hands out the session id as a response header on
+            // initialize; without exposing it, browser clients can never read
+            // and echo it back on subsequent requests.
+            ->withHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id, MCP-Protocol-Version')
             ->withHeader('Access-Control-Max-Age', '86400');
     }
 

--- a/Classes/Http/CorsHeadersTrait.php
+++ b/Classes/Http/CorsHeadersTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hn\McpServer\Http;
 
+use Mcp\Shared\McpHeaders;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -13,15 +14,58 @@ use Psr\Http\Message\ServerRequestInterface;
 trait CorsHeadersTrait
 {
     /**
+     * Request headers a browser client may send when no preflight lists them
+     * explicitly. This is only a fallback: on a real preflight the requested
+     * headers are reflected instead, because the MCP Streamable HTTP transport
+     * also mirrors tool arguments as dynamic Mcp-Param-{name} headers
+     * (SEP-2243), which no static list can ever cover.
+     */
+    private function corsFallbackAllowHeaders(): string
+    {
+        return implode(', ', [
+            'Content-Type',
+            'Content-Disposition',
+            'Authorization',
+            'X-Requested-With',
+            'Accept',
+            McpHeaders::PROTOCOL_VERSION,
+            'Mcp-Session-Id',
+            McpHeaders::METHOD,
+            McpHeaders::NAME,
+            'Last-Event-ID',
+        ]);
+    }
+
+    /**
      * Add CORS headers to response for OAuth/API endpoints
      */
     private function addCorsHeaders(ResponseInterface $response, ServerRequestInterface $request): ResponseInterface
     {
-        $allowedOrigin = $request->hasHeader('Origin') ? $request->getHeaderLine('Origin') : '';
+        // The response content depends on these request headers, so shared
+        // caches must key on them - even when the current request carries no
+        // Origin at all, or a cached non-CORS response would later be served
+        // to a CORS request (and vice versa).
+        foreach (['Origin', 'Access-Control-Request-Headers'] as $varyOn) {
+            if (stripos($response->getHeaderLine('Vary'), $varyOn) === false) {
+                $response = $response->withAddedHeader('Vary', $varyOn);
+            }
+        }
+
+        $allowedOrigin = $request->getHeaderLine('Origin');
 
         // No CORS headers for non-CORS requests (no Origin header)
         if (empty($allowedOrigin)) {
             return $response;
+        }
+
+        // On a preflight the browser lists exactly the headers the client
+        // wants to send; reflecting that list keeps this trait free of
+        // transport knowledge and covers the dynamic Mcp-Param-* headers.
+        // Allow-Headers only gates the browser preflight - the server
+        // validates every actual request itself, so reflecting is safe.
+        $requestedHeaders = trim($request->getHeaderLine('Access-Control-Request-Headers'));
+        if ($requestedHeaders === '') {
+            $requestedHeaders = $this->corsFallbackAllowHeaders();
         }
 
         // Authentication uses Bearer tokens, not cookies, so credentialed CORS
@@ -32,19 +76,11 @@ trait CorsHeadersTrait
         return $response
             ->withHeader('Access-Control-Allow-Origin', $allowedOrigin)
             ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
-            // The MCP Streamable HTTP transport requires several custom request
-            // headers (session id, protocol version, SSE resumption, routing
-            // headers) that are not CORS-safelisted and must be listed here or
-            // browsers reject the preflight.
-            ->withHeader(
-                'Access-Control-Allow-Headers',
-                'Content-Type, Content-Disposition, Authorization, X-Requested-With, Accept, '
-                . 'MCP-Protocol-Version, Mcp-Session-Id, Mcp-Method, Mcp-Name, Last-Event-ID'
-            )
+            ->withHeader('Access-Control-Allow-Headers', $requestedHeaders)
             // The server hands out the session id as a response header on
             // initialize; without exposing it, browser clients can never read
             // and echo it back on subsequent requests.
-            ->withHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id, MCP-Protocol-Version')
+            ->withHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id, ' . McpHeaders::PROTOCOL_VERSION)
             ->withHeader('Access-Control-Max-Age', '86400');
     }
 

--- a/Classes/Http/McpEndpoint.php
+++ b/Classes/Http/McpEndpoint.php
@@ -96,6 +96,14 @@ class McpEndpoint
      */
     public function __invoke(ServerRequestInterface $request): ResponseInterface
     {
+        // Answer CORS preflights before authentication: browsers never send
+        // the Authorization header on an OPTIONS preflight, so requiring a
+        // token here would fail every browser-based client with a 401 before
+        // its first real request.
+        if ($request->getMethod() === 'OPTIONS') {
+            return $this->handlePreflightRequest($request);
+        }
+
         try {
             // Get services through DI container
             $container = GeneralUtility::getContainer();

--- a/Tests/Functional/Http/CorsHeadersTest.php
+++ b/Tests/Functional/Http/CorsHeadersTest.php
@@ -97,14 +97,51 @@ class CorsHeadersTest extends AbstractFunctionalTest
             'https://my-mcp-client.example.com',
             $response->getHeaderLine('Access-Control-Allow-Origin')
         );
+
+        // The preflight names exactly the headers the client wants to send;
+        // reflecting them covers dynamic headers (Mcp-Param-*) that no static
+        // allowlist could.
+        $this->assertEquals(
+            'authorization, content-type, mcp-protocol-version',
+            $response->getHeaderLine('Access-Control-Allow-Headers')
+        );
+    }
+
+    /**
+     * Reflecting the Origin makes the response origin-dependent, so shared
+     * caches must key on it - for CORS and non-CORS requests alike, or a
+     * cached response for one origin would be served to another.
+     */
+    public function testCorsResponsesVaryOnOrigin(): void
+    {
+        $endpoint = new OAuthTokenEndpoint();
+
+        foreach ([['Origin' => 'https://my-mcp-client.example.com'], []] as $headers) {
+            $request = new ServerRequest(
+                new Uri('https://example.com/mcp_oauth/token'),
+                'OPTIONS',
+                'php://input',
+                $headers
+            );
+            $GLOBALS['TYPO3_REQUEST'] = $request;
+
+            $response = $endpoint($request);
+
+            $this->assertStringContainsString(
+                'Origin',
+                $response->getHeaderLine('Vary'),
+                'Vary: Origin must be set regardless of whether the request is CORS'
+            );
+        }
     }
 
     /**
      * The MCP Streamable HTTP transport requires custom request headers that
      * are not CORS-safelisted, uses DELETE for session termination, and hands
      * the session id to the client as a response header. All three must be
-     * declared in the CORS headers or browser clients cannot connect.
-     * See issue #115.
+     * declared in the CORS headers or browser clients cannot connect. Without
+     * Access-Control-Request-Headers on the request, the fallback allowlist
+     * must cover the transport's static headers. See issue #115.
      */
     public function testCorsHeadersCoverMcpTransportRequirements(): void
     {

--- a/Tests/Functional/Http/CorsHeadersTest.php
+++ b/Tests/Functional/Http/CorsHeadersTest.php
@@ -69,6 +69,81 @@ class CorsHeadersTest extends AbstractFunctionalTest
     }
 
     /**
+     * A browser preflight never carries the Authorization header, so /mcp must
+     * answer OPTIONS before authentication. Requiring a token here would fail
+     * every browser-based MCP client with a 401 before its first real request.
+     * See issue #115.
+     */
+    public function testMcpPreflightSucceedsWithoutAuthentication(): void
+    {
+        $endpoint = new McpEndpoint();
+
+        $request = new ServerRequest(
+            new Uri('https://example.com/mcp'),
+            'OPTIONS',
+            'php://input',
+            [
+                'Origin' => 'https://my-mcp-client.example.com',
+                'Access-Control-Request-Method' => 'POST',
+                'Access-Control-Request-Headers' => 'authorization, content-type, mcp-protocol-version',
+            ]
+        );
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        $response = $endpoint($request);
+
+        $this->assertEquals(200, $response->getStatusCode(), 'Preflight must not require authentication');
+        $this->assertEquals(
+            'https://my-mcp-client.example.com',
+            $response->getHeaderLine('Access-Control-Allow-Origin')
+        );
+    }
+
+    /**
+     * The MCP Streamable HTTP transport requires custom request headers that
+     * are not CORS-safelisted, uses DELETE for session termination, and hands
+     * the session id to the client as a response header. All three must be
+     * declared in the CORS headers or browser clients cannot connect.
+     * See issue #115.
+     */
+    public function testCorsHeadersCoverMcpTransportRequirements(): void
+    {
+        $endpoint = new McpEndpoint();
+
+        $request = new ServerRequest(
+            new Uri('https://example.com/mcp'),
+            'OPTIONS',
+            'php://input',
+            ['Origin' => 'https://my-mcp-client.example.com']
+        );
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        $response = $endpoint($request);
+
+        $allowHeaders = strtolower($response->getHeaderLine('Access-Control-Allow-Headers'));
+        foreach (['authorization', 'content-type', 'mcp-protocol-version', 'mcp-session-id', 'mcp-method', 'mcp-name', 'last-event-id'] as $header) {
+            $this->assertStringContainsString($header, $allowHeaders, "Allow-Headers must include $header");
+        }
+
+        $this->assertStringContainsString(
+            'DELETE',
+            $response->getHeaderLine('Access-Control-Allow-Methods'),
+            'DELETE is used by MCP clients to terminate sessions'
+        );
+
+        $this->assertStringContainsString(
+            'mcp-session-id',
+            strtolower($response->getHeaderLine('Access-Control-Expose-Headers')),
+            'Browser clients must be able to read the session id from the initialize response'
+        );
+
+        $this->assertFalse(
+            $response->hasHeader('Access-Control-Allow-Credentials'),
+            'Reflecting arbitrary origins with credentials is a forbidden CORS combination; auth is Bearer-token based'
+        );
+    }
+
+    /**
      * The authenticated /mcp data response must carry CORS headers, just like
      * the error responses in the same class already do. Without this, browser-
      * and Electron-based MCP clients have the successful response blocked by


### PR DESCRIPTION
Fixes #115.

Browser-based MCP clients (e.g. the MCP Inspector in browser mode) could not connect to `/mcp` at all — four independent defects, each of which alone breaks the connection:

1. **`McpEndpoint` never short-circuited OPTIONS.** Browsers never send the `Authorization` header on a preflight, so every preflight got a 401 and the browser aborted before the first POST. All OAuth endpoints and the `FileUploadEndpoint` already handled OPTIONS before auth; `/mcp` now does the same.
2. **`Access-Control-Allow-Headers` was missing every custom MCP transport header.** The Streamable HTTP transport of the MCP SDK requires `MCP-Protocol-Version` (requests without it are rejected with 400), `Mcp-Session-Id`, `Mcp-Method`, `Mcp-Name` and `Last-Event-ID` — none of which are CORS-safelisted, so browsers rejected the preflight.
3. **No `Access-Control-Expose-Headers`.** The server hands out `Mcp-Session-Id` as a response header on initialize, but browser JavaScript could never read it, so the client could never echo it back on subsequent requests.
4. **`Allow-Methods` omitted `DELETE`,** which MCP clients use to terminate sessions.

Additionally, `Access-Control-Allow-Credentials: true` is dropped: combined with reflecting an arbitrary `Origin`, it is equivalent to the wildcard-with-credentials setup the CORS spec forbids — and since authentication is Bearer-token based (no cookies), credentialed CORS is not needed at all.

Since `CorsHeadersTrait` is shared, the OAuth and file-upload endpoints pick up the extended headers automatically; the additions are harmless there.

Server-side clients like Claude's connector were never affected (they send no `Origin`, so no CORS headers are emitted — unchanged).

## Tests

Two new functional tests in `Tests/Functional/Http/CorsHeadersTest.php`:
- an unauthenticated OPTIONS preflight on `/mcp` returns 200 with the reflected origin
- the CORS headers cover the MCP transport requirements (allow-headers, DELETE, expose-headers, no allow-credentials)

Full suite: 694 tests, 3577 assertions, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BJfBw7id5nD4Y3X53ydBF

---
_Generated by [Claude Code](https://claude.ai/code/session_015BJfBw7id5nD4Y3X53ydBF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved cross-origin support for MCP requests, including `PUT` and `DELETE` methods.
  - Added support for required MCP request headers and exposed session and protocol information.
  - MCP preflight requests now succeed without authentication.
  - Preflight responses now reflect requested headers and provide appropriate fallback headers.

- **Bug Fixes**
  - Updated CORS behavior to support Bearer-token authentication without enabling credentialed requests.
  - Improved cache safety by varying CORS responses based on request origin and requested headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->