### PR TITLE
fix: enforce array order for embedded inline children

### DIFF
--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -474,64 +474,25 @@ class WriteTableTool extends AbstractRecordTool
         // Now process inline relations with the resolved parent UID
         if (!empty($inlineRelations)) {
             $childDataMap = [];
-            $this->processInlineRelations($childDataMap, $table, $parentUid, $pid, $inlineRelations);
-            
-            
+            $embeddedRelations = $this->processInlineRelations($childDataMap, $table, $parentUid, $pid, $inlineRelations);
+
             if (!empty($childDataMap)) {
                 // Create a new DataHandler instance for child records
                 $childDataHandler = GeneralUtility::makeInstance(DataHandler::class);
                 $childDataHandler->BE_USER = $GLOBALS['BE_USER'];
                 $childDataHandler->start($childDataMap, []);
                 $childDataHandler->process_datamap();
-                
-                
+
                 // Check for errors in child creation
                 if (!empty($childDataHandler->errorLog)) {
                     // Parent was created but children failed
                     return $this->createErrorResult(
-                        'Parent record created but error creating child records: ' . 
+                        'Parent record created but error creating child records: ' .
                         implode(', ', $childDataHandler->errorLog)
                     );
                 }
-                
-                // Update foreign fields for embedded relations
-                foreach ($inlineRelations as $fieldName => $relationData) {
-                    $config = $relationData['config'];
-                    $foreignTable = $config['foreign_table'] ?? '';
-                    $foreignField = $config['foreign_field'] ?? '';
-                    
-                    if (empty($foreignTable) || empty($foreignField)) {
-                        continue;
-                    }
-                    
-                    // Check if this is an embedded table
-                    $isHiddenTable = $this->tableAccessService->isEmbeddedChildTable($foreignTable);
 
-                    if ($isHiddenTable) {
-                        // Collect the UIDs of created child records
-                        $childUids = [];
-                        foreach ($childDataHandler->substNEWwithIDs as $newId => $realId) {
-                            if (strpos($newId, 'NEW') === 0 && isset($childDataMap[$foreignTable][$newId])) {
-                                $childUids[] = $realId;
-                            }
-                        }
-                        
-                        if (!empty($childUids)) {
-                            // Update foreign field directly in database
-                            // RelationHandler's writeForeignField is for MM relations, not direct foreign fields
-                            $connection = GeneralUtility::makeInstance(ConnectionPool::class)
-                                ->getConnectionForTable($foreignTable);
-                            
-                            foreach ($childUids as $childUid) {
-                                $connection->update(
-                                    $foreignTable,
-                                    [$foreignField => $liveParentUid],
-                                    ['uid' => $childUid]
-                                );
-                            }
-                        }
-                    }
-                }
+                $this->finalizeEmbeddedInlineRelations($embeddedRelations, $childDataHandler, $liveParentUid);
             }
         }
 
@@ -605,59 +566,27 @@ class WriteTableTool extends AbstractRecordTool
             $pid = $record['pid'] ?? 0;
             
             $childDataMap = [];
-            $this->processInlineRelations($childDataMap, $table, $workspaceUid, $pid, $inlineRelations, $uid);
-            
+            $embeddedRelations = $this->processInlineRelations($childDataMap, $table, $workspaceUid, $pid, $inlineRelations, $uid);
+
+            // A new DataHandler instance is needed even when $childDataMap ends up empty
+            // (a pure reorder of already-existing children has nothing to patch), since
+            // finalizeEmbeddedInlineRelations() still needs one to issue the reorder.
+            $childDataHandler = GeneralUtility::makeInstance(DataHandler::class);
+            $childDataHandler->BE_USER = $GLOBALS['BE_USER'];
+
             if (!empty($childDataMap)) {
-                // Create a new DataHandler instance for child records
-                $childDataHandler = GeneralUtility::makeInstance(DataHandler::class);
-                $childDataHandler->BE_USER = $GLOBALS['BE_USER'];
                 $childDataHandler->start($childDataMap, []);
                 $childDataHandler->process_datamap();
-                
+
                 // Check for errors in child processing
                 if (!empty($childDataHandler->errorLog)) {
                     return $this->createErrorResult('Error processing inline relations: ' . implode(', ', $childDataHandler->errorLog));
                 }
-                
-                // Update foreign fields for embedded relations
-                foreach ($inlineRelations as $fieldName => $relationData) {
-                    $config = $relationData['config'];
-                    $foreignTable = $config['foreign_table'] ?? '';
-                    $foreignField = $config['foreign_field'] ?? '';
-                    
-                    if (empty($foreignTable) || empty($foreignField)) {
-                        continue;
-                    }
-                    
-                    // Check if this is an embedded table
-                    $isHiddenTable = $this->tableAccessService->isEmbeddedChildTable($foreignTable);
+            }
 
-                    if ($isHiddenTable) {
-                        // Collect the UIDs of created child records
-                        $childUids = [];
-                        foreach ($childDataHandler->substNEWwithIDs as $newId => $realId) {
-                            if (strpos($newId, 'NEW') === 0 && isset($childDataMap[$foreignTable][$newId])) {
-                                $childUids[] = $realId;
-                            }
-                        }
-                        
-                        if (!empty($childUids)) {
-                            // Update foreign field directly in database
-                            // RelationHandler's writeForeignField is for MM relations, not direct foreign fields
-                            $connection = GeneralUtility::makeInstance(ConnectionPool::class)
-                                ->getConnectionForTable($foreignTable);
-                            
-                            // In update context, $uid is already the live UID
-                            foreach ($childUids as $childUid) {
-                                $connection->update(
-                                    $foreignTable,
-                                    [$foreignField => $uid],
-                                    ['uid' => $childUid]
-                                );
-                            }
-                        }
-                    }
-                }
+            if (!empty($embeddedRelations)) {
+                // In update context, $uid is already the live UID
+                $this->finalizeEmbeddedInlineRelations($embeddedRelations, $childDataHandler, $uid);
             }
         }
         
@@ -1274,7 +1203,13 @@ class WriteTableTool extends AbstractRecordTool
     }
 
     /**
-     * Process inline relations for DataHandler
+     * Process inline relations for DataHandler.
+     *
+     * @return array<string, array{foreignTable: string, foreignField: string, order: array<int, int|string>}>
+     *         Per-field ordering info for embedded relations only, keyed by field name.
+     *         Each `order` entry is an existing child's live uid (int) or a new child's
+     *         "NEW..." datamap key (string). Passed to finalizeEmbeddedInlineRelations()
+     *         once the child DataHandler run has resolved real uids for new children.
      */
     protected function processInlineRelations(
         array &$dataMap,
@@ -1283,28 +1218,37 @@ class WriteTableTool extends AbstractRecordTool
         int $pid,
         array $inlineRelations,
         ?int $liveUid = null
-    ): void {
+    ): array {
+        $embeddedRelations = [];
+
         foreach ($inlineRelations as $fieldName => $relationData) {
             $config = $relationData['config'];
             $value = $relationData['value'];
             $foreignTable = $config['foreign_table'] ?? '';
             $foreignField = $config['foreign_field'] ?? '';
-            
+
             if (empty($foreignTable) || empty($foreignField)) {
                 continue;
             }
-            
+
             // Check if foreign table is treated as embedded inline child
             $isHiddenTable = $this->tableAccessService->isEmbeddedChildTable($foreignTable);
 
             if ($isHiddenTable) {
                 // Process embedded inline relations (e.g., tx_news_domain_model_link)
-                $this->processEmbeddedInlineRelations($dataMap, $foreignTable, $foreignField, $parentUid, $pid, $value, $config, $liveUid);
+                $order = $this->processEmbeddedInlineRelations($dataMap, $foreignTable, $foreignField, $parentUid, $pid, $value, $config, $liveUid);
+                $embeddedRelations[$fieldName] = [
+                    'foreignTable' => $foreignTable,
+                    'foreignField' => $foreignField,
+                    'order' => $order,
+                ];
             } else {
                 // Process independent inline relations (e.g., tt_content)
                 $this->processIndependentInlineRelations($foreignTable, $foreignField, $parentUid, $value, $liveUid);
             }
         }
+
+        return $embeddedRelations;
     }
     
     /**
@@ -1319,7 +1263,7 @@ class WriteTableTool extends AbstractRecordTool
         array $records,
         array $config,
         ?int $liveUid = null
-    ): void {
+    ): array {
         $foreignMatchFields = $config['foreign_match_fields'] ?? [];
 
         // Existing children of this parent (live uids). Empty for the create path.
@@ -1356,6 +1300,17 @@ class WriteTableTool extends AbstractRecordTool
             $this->deleteOrphanedEmbeddedRelations($foreignTable, $existingChildUids, $records);
         }
 
+        // Array order drives display order (see the tool description). DataHandler manages
+        // a child table's own sortby field automatically though: on create it overwrites
+        // whatever value is written below with its own "insert at top" number, and on
+        // update it silently drops a value for a field that (e.g. for Content Blocks
+        // generated tables) isn't exposed as an editable TCA column at all. $order is
+        // therefore handed back to the caller, which enforces array order afterwards via
+        // finalizeEmbeddedInlineRelations() once real uids for new children are known.
+        // Existing children are recorded by their (int) uid, new ones by their (string)
+        // "NEW..." datamap key — the two are always distinguishable by type.
+        $order = [];
+
         foreach ($records as $index => $recordData) {
             if (!is_array($recordData)) {
                 continue;
@@ -1390,15 +1345,18 @@ class WriteTableTool extends AbstractRecordTool
                 }
 
                 $key = 'NEW' . uniqid() . '_' . $index;
+                $order[] = $key;
             } else {
                 // Update path: target the workspace version so DataHandler patches the existing
                 // reference instead of touching the live record outside the workspace overlay.
                 $key = $this->resolveToWorkspaceUid($foreignTable, $existingUid);
+                $order[] = $existingUid;
             }
 
-            // Drive sort order from array position for both new and existing records.
-            // foreign_sortby is hidden from the schema (auto-managed), so reordering is
-            // only possible via the order in which the caller lists the children here.
+            // Best-effort sort hint: effective for tables like sys_file_reference, where
+            // sorting_foreign is a plain TCA column DataHandler leaves alone, but a no-op
+            // where the table auto-manages this field. finalizeEmbeddedInlineRelations()
+            // is what actually guarantees array order in the general case.
             if (isset($config['foreign_sortby'])) {
                 $recordData[$config['foreign_sortby']] = ($index + 1) * 256;
             }
@@ -1414,6 +1372,82 @@ class WriteTableTool extends AbstractRecordTool
                 $dataMap[$foreignTable] = [];
             }
             $dataMap[$foreignTable][$key] = $recordData;
+        }
+
+        return $order;
+    }
+
+    /**
+     * Enforce the caller's array order among embedded children after the child
+     * DataHandler run, and point newly created children back at their parent.
+     *
+     * DataHandler manages a child table's own sortby field automatically: on create it
+     * overwrites any value passed in with its own "insert at top" number (producing
+     * reverse order when several children are created in one call), and on update it
+     * silently drops a value for a field that isn't an editable TCA column. Array order
+     * is therefore enforced the same way the TYPO3 backend itself reorders records: a
+     * chain of DataHandler "move after" commands.
+     *
+     * @param array $embeddedRelations fieldName => ['foreignTable', 'foreignField', 'order'],
+     *              as returned by processInlineRelations()
+     */
+    protected function finalizeEmbeddedInlineRelations(
+        array $embeddedRelations,
+        DataHandler $childDataHandler,
+        int $parentLiveUid
+    ): void {
+        foreach ($embeddedRelations as $relation) {
+            $foreignTable = $relation['foreignTable'];
+            $foreignField = $relation['foreignField'];
+
+            // Resolve every item to its final, real uid, in the caller's array order.
+            // An existing child is already its (int) live uid; a new one is its (string)
+            // "NEW..." datamap key, resolved to a real uid via substNEWwithIDs.
+            $orderedUids = [];
+            $newUids = [];
+            foreach ($relation['order'] as $item) {
+                if (is_int($item)) {
+                    $orderedUids[] = $item;
+                    continue;
+                }
+                $realUid = $childDataHandler->substNEWwithIDs[$item] ?? null;
+                if ($realUid === null) {
+                    continue;
+                }
+                $realUid = (int)$realUid;
+                $orderedUids[] = $realUid;
+                $newUids[] = $realUid;
+            }
+
+            // Point newly created children back at their parent. RelationHandler's
+            // writeForeignField is for MM relations, not direct foreign fields.
+            if (!empty($newUids)) {
+                $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+                    ->getConnectionForTable($foreignTable);
+
+                foreach ($newUids as $childUid) {
+                    $connection->update(
+                        $foreignTable,
+                        [$foreignField => $parentLiveUid],
+                        ['uid' => $childUid]
+                    );
+                }
+            }
+
+            // Chain each child after its predecessor so the final order matches the
+            // array. Tables without a sortby field simply ignore the move (DataHandler
+            // logs it and no-ops), which is harmless since ordering isn't meaningful there.
+            if (count($orderedUids) > 1) {
+                $cmdMap = [];
+                for ($i = 1, $total = count($orderedUids); $i < $total; $i++) {
+                    $cmdMap[$foreignTable][$orderedUids[$i]]['move'] = -$orderedUids[$i - 1];
+                }
+
+                $reorderDataHandler = GeneralUtility::makeInstance(DataHandler::class);
+                $reorderDataHandler->BE_USER = $GLOBALS['BE_USER'];
+                $reorderDataHandler->start([], $cmdMap);
+                $reorderDataHandler->process_cmdmap();
+            }
         }
     }
     

--- a/Classes/MCP/Tool/Record/WriteTableTool.php
+++ b/Classes/MCP/Tool/Record/WriteTableTool.php
@@ -492,7 +492,10 @@ class WriteTableTool extends AbstractRecordTool
                     );
                 }
 
-                $this->finalizeEmbeddedInlineRelations($embeddedRelations, $childDataHandler, $liveParentUid);
+                $finalizeResult = $this->finalizeEmbeddedInlineRelations($embeddedRelations, $childDataHandler, $liveParentUid);
+                if ($finalizeResult !== null) {
+                    return $finalizeResult;
+                }
             }
         }
 
@@ -586,7 +589,10 @@ class WriteTableTool extends AbstractRecordTool
 
             if (!empty($embeddedRelations)) {
                 // In update context, $uid is already the live UID
-                $this->finalizeEmbeddedInlineRelations($embeddedRelations, $childDataHandler, $uid);
+                $finalizeResult = $this->finalizeEmbeddedInlineRelations($embeddedRelations, $childDataHandler, $uid);
+                if ($finalizeResult !== null) {
+                    return $finalizeResult;
+                }
             }
         }
         
@@ -1390,12 +1396,13 @@ class WriteTableTool extends AbstractRecordTool
      *
      * @param array $embeddedRelations fieldName => ['foreignTable', 'foreignField', 'order'],
      *              as returned by processInlineRelations()
+     * @return CallToolResult|null an error result if TYPO3 rejected a reorder, null on success
      */
     protected function finalizeEmbeddedInlineRelations(
         array $embeddedRelations,
         DataHandler $childDataHandler,
         int $parentLiveUid
-    ): void {
+    ): ?CallToolResult {
         foreach ($embeddedRelations as $relation) {
             $foreignTable = $relation['foreignTable'];
             $foreignField = $relation['foreignField'];
@@ -1434,9 +1441,15 @@ class WriteTableTool extends AbstractRecordTool
                 }
             }
 
-            // Chain each child after its predecessor so the final order matches the
-            // array. Tables without a sortby field simply ignore the move (DataHandler
-            // logs it and no-ops), which is harmless since ordering isn't meaningful there.
+            // A table without its own sortby field has no order for DataHandler to
+            // move — issuing the command anyway would only produce the "table does
+            // not support sorting" log entry DataHandler always emits for that case
+            // (see DataHandler::moveRecord()), which is not a real failure.
+            if ($this->tableAccessService->getSortingFieldName($foreignTable) === null) {
+                continue;
+            }
+
+            // Chain each child after its predecessor so the final order matches the array.
             if (count($orderedUids) > 1) {
                 $cmdMap = [];
                 for ($i = 1, $total = count($orderedUids); $i < $total; $i++) {
@@ -1447,8 +1460,17 @@ class WriteTableTool extends AbstractRecordTool
                 $reorderDataHandler->BE_USER = $GLOBALS['BE_USER'];
                 $reorderDataHandler->start([], $cmdMap);
                 $reorderDataHandler->process_cmdmap();
+
+                if (!empty($reorderDataHandler->errorLog)) {
+                    return $this->createErrorResult(
+                        'Error reordering embedded relation ' . $foreignTable . ': ' .
+                        implode(', ', $reorderDataHandler->errorLog)
+                    );
+                }
             }
         }
+
+        return null;
     }
     
     /**

--- a/Tests/Functional/NewsExtension/NewsLinkInlineTest.php
+++ b/Tests/Functional/NewsExtension/NewsLinkInlineTest.php
@@ -325,10 +325,9 @@ class NewsLinkInlineTest extends FunctionalTestCase
         $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
         $newsUid = json_decode($result->content[0]->text, true)['uid'];
 
-        $news = json_decode(
-            $readTool->execute(['table' => 'tx_news_domain_model_news', 'uid' => $newsUid])->content[0]->text,
-            true
-        )['records'][0];
+        $result = $readTool->execute(['table' => 'tx_news_domain_model_news', 'uid' => $newsUid]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $news = json_decode($result->content[0]->text, true)['records'][0];
         $byTitle = [];
         foreach ($news['related_links'] as $link) {
             $byTitle[$link['title']] = (int)$link['uid'];
@@ -350,11 +349,20 @@ class NewsLinkInlineTest extends FunctionalTestCase
         ]);
         $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
 
-        $news = json_decode(
-            $readTool->execute(['table' => 'tx_news_domain_model_news', 'uid' => $newsUid])->content[0]->text,
-            true
-        )['records'][0];
+        $result = $readTool->execute(['table' => 'tx_news_domain_model_news', 'uid' => $newsUid]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $news = json_decode($result->content[0]->text, true)['records'][0];
         $this->assertCount(3, $news['related_links'], 'No links should be lost during reorder');
+
+        // Assert the uids themselves, not just the titles — a delete-and-recreate
+        // implementation could pass a title-only check while discarding the
+        // original child records.
+        $this->assertSame(
+            [$byTitle['Third link'], $byTitle['First link'], $byTitle['Second link']],
+            array_map('intval', array_column($news['related_links'], 'uid')),
+            'Reordering must retain the existing child records, not delete and recreate them.'
+        );
+
         $titles = array_column($news['related_links'], 'title');
         $this->assertSame(
             ['Third link', 'First link', 'Second link'],

--- a/Tests/Functional/NewsExtension/NewsLinkInlineTest.php
+++ b/Tests/Functional/NewsExtension/NewsLinkInlineTest.php
@@ -230,12 +230,19 @@ class NewsLinkInlineTest extends FunctionalTestCase
     }
 
     /**
-     * Test embedded links respect sorting
+     * Embedded children must come out in the order they were passed in, not reversed.
+     *
+     * tx_news_domain_model_link declares `ctrl.sortby = 'sorting'` and isn't a
+     * `foreign_match_fields` relation (no tablenames/fieldname), making it the
+     * real-world case for the "embedded inline children created in reverse order" bug:
+     * DataHandler auto-manages that table's own sortby field, overwriting whatever
+     * WriteTableTool writes to it with its own "insert at top" number, so array order
+     * has to be enforced separately.
      */
     public function testEmbeddedLinksSorting(): void
     {
         $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
-        
+
         // Create news with links in specific order
         $result = $writeTool->execute([
             'table' => 'tx_news_domain_model_news',
@@ -250,23 +257,110 @@ class NewsLinkInlineTest extends FunctionalTestCase
                 ]
             ],
         ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
         $newsUid = json_decode($result->content[0]->text, true)['uid'];
-        
+
         // Read and verify order
         $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
         $result = $readTool->execute([
             'table' => 'tx_news_domain_model_news',
             'uid' => $newsUid,
         ]);
-        
+
         $news = json_decode($result->content[0]->text, true)['records'][0];
         $this->assertCount(3, $news['related_links']);
-        
-        // Verify all links are present (order may vary)
+
         $titles = array_column($news['related_links'], 'title');
-        $this->assertContains('First link', $titles);
-        $this->assertContains('Second link', $titles);
-        $this->assertContains('Third link', $titles);
+        $this->assertSame(
+            ['First link', 'Second link', 'Third link'],
+            $titles,
+            'Embedded links must be returned in the order they were passed in. Actual order: ' . json_encode($titles)
+        );
+
+        // The underlying "sorting" column (tx_news_domain_model_link.ctrl.sortby) must
+        // itself be ascending in array order, not just however ReadTableTool happens to
+        // return rows.
+        $queryBuilder = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Database\ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_news_domain_model_link');
+        $queryBuilder->getRestrictions()->removeAll();
+        $rows = $queryBuilder->select('title', 'sorting')
+            ->from('tx_news_domain_model_link')
+            ->orderBy('sorting', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $this->assertSame(
+            ['First link', 'Second link', 'Third link'],
+            array_column($rows, 'title'),
+            'Sorting values must ascend in array order. Rows: ' . json_encode($rows)
+        );
+    }
+
+    /**
+     * Reordering existing embedded children by uid must actually take effect.
+     *
+     * Before the fix this had no effect for a table like tx_news_domain_model_link
+     * that manages its own sortby field: DataHandler::fillInFieldArray() silently
+     * drops a manually written value for a field that isn't a real TCA column, so
+     * the only way to reorder was to delete and recreate the children.
+     */
+    public function testReorderExistingLinksByArrayOrder(): void
+    {
+        $writeTool = GeneralUtility::makeInstance(WriteTableTool::class);
+        $readTool = GeneralUtility::makeInstance(ReadTableTool::class);
+
+        $result = $writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'create',
+            'pid' => 1,
+            'data' => [
+                'title' => 'News for reorder',
+                'related_links' => [
+                    ['title' => 'First link', 'uri' => 'https://first.com'],
+                    ['title' => 'Second link', 'uri' => 'https://second.com'],
+                    ['title' => 'Third link', 'uri' => 'https://third.com'],
+                ],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+        $newsUid = json_decode($result->content[0]->text, true)['uid'];
+
+        $news = json_decode(
+            $readTool->execute(['table' => 'tx_news_domain_model_news', 'uid' => $newsUid])->content[0]->text,
+            true
+        )['records'][0];
+        $byTitle = [];
+        foreach ($news['related_links'] as $link) {
+            $byTitle[$link['title']] = (int)$link['uid'];
+        }
+
+        // Reorder to Third, First, Second by passing back only the existing uids —
+        // no field changes, so this exercises the escape hatch that used to be a no-op.
+        $result = $writeTool->execute([
+            'table' => 'tx_news_domain_model_news',
+            'action' => 'update',
+            'uid' => $newsUid,
+            'data' => [
+                'related_links' => [
+                    ['uid' => $byTitle['Third link']],
+                    ['uid' => $byTitle['First link']],
+                    ['uid' => $byTitle['Second link']],
+                ],
+            ],
+        ]);
+        $this->assertFalse($result->isError, json_encode($result->jsonSerialize()));
+
+        $news = json_decode(
+            $readTool->execute(['table' => 'tx_news_domain_model_news', 'uid' => $newsUid])->content[0]->text,
+            true
+        )['records'][0];
+        $this->assertCount(3, $news['related_links'], 'No links should be lost during reorder');
+        $titles = array_column($news['related_links'], 'title');
+        $this->assertSame(
+            ['Third link', 'First link', 'Second link'],
+            $titles,
+            'Embedded children must follow the order supplied in the update payload. Actual order: ' . json_encode($titles)
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes #118.

## Problem

`WriteTableTool::processEmbeddedInlineRelations()` writes a sort hint into `config['foreign_sortby']`, but DataHandler auto-manages that field on any child table that declares it as its own `ctrl.sortby` — the shape both Content Blocks collections and `tx_news_domain_model_link` (shipped with `georgringer/news`) use:

- **On create**, `DataHandler::resolveSortingAndPidForNewRecord()` overwrites the value with its own "insert at top" number regardless of what was written. Since every new child in a batch is created with the same positive `pid`, each successive insert lands above the previous one — children end up in the exact reverse of the array order they were passed in.
- **On update**, the value is dropped even earlier: `DataHandler::fillInFieldArray()` only applies an incoming field when it's a real TCA column, and a `ctrl.sortby` field typically isn't one — the same reason writing `sorting` directly is rejected by validation. This made reordering existing children by uid a no-op.

## Fix

After the child `DataHandler` run, resolve every embedded child (both newly created and pre-existing) to its real uid in the caller's array order, then chain them into position with a follow-up `DataHandler::process_cmdmap()` "move" call — the same mechanism `WriteTableTool` already uses for top-level record positioning (`moveRecord()` / the `position` parameter). This also fixes reordering existing children by uid, since `move` bypasses the same `hasField()` gate that silently dropped direct field writes.

`processInlineRelations()` / `processEmbeddedInlineRelations()` now return per-field ordering info instead of `void`, consumed by the new `finalizeEmbeddedInlineRelations()`, which also absorbs the two near-identical "point new children at their parent" blocks that were previously duplicated between `create()` and `updateRecord()`.

## Tests

Extended `Tests/Functional/NewsExtension/NewsLinkInlineTest.php` using `tx_news_domain_model_link` — no Content Blocks fixture needed, this table reproduces the exact TCA shape (`ctrl.sortby`, no `foreign_match_fields`) that triggers the bug:

- `testEmbeddedLinksSorting` now asserts exact array order (previously only membership) and that the underlying `sorting` column itself ascends.
- Added `testReorderExistingLinksByArrayOrder` covering the previously-broken "reorder existing children by uid" path.

Verified locally:
- Both new/strengthened tests fail against `main` (RED) — the sorting test fails with the exact reversed order reported in #118, the reorder test shows the update having no effect
- Both pass with the fix (GREEN)
- Full relevant suite (`InlineRelationWriteTest`, `FileReferenceTest`, `NewsLinkInlineTest`, `WriteTableToolErrorTest` — 61 tests) green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Embedded related records now consistently retain the order provided when creating or updating a parent record.
  * Reordering existing embedded records is now honored, including when only their identifiers are submitted.
  * Related records are returned in the same sequence as the submitted array, with their sorting values updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->